### PR TITLE
Minimum and maximum value validation for date and datetime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,12 @@ Validation for simple data types:
   * `minimumValue`: The smallest (inclusive) value that is allowed. Undefined by default.
   * `maximumValue`: The largest (inclusive) value that is allowed. Undefined by default.
 * `boolean`: The value is either `true` or `false`. No additional parameters.
-* `datetime`: The value is an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date string with optional time and time zone components (e.g. "2016-06-18T18:57:35.328-08:00"). No additional parameters.
+* `datetime`: The value is an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date string with optional time and time zone components (e.g. "2016-06-18T18:57:35.328-08:00"). Additional parameters:
+  * `minimumValue`: The earliest (inclusive) date/time that is allowed. If the value of this parameter or the property value to which it is to be applied are missing their time and time zone components, they will default to midnight UTC of the date in question. No restriction by default.
+  * `maximumValue`: The latest (inclusive) date/time that is allowed. If the value of this parameter or the property value to which it is to be applied are missing their time and time zone components, they will default to midnight UTC of the date in question. No restriction by default.
 * `date`: The value is an ISO 8601 date string _without_ time and time zone components (e.g. "2016-06-18"). Additional parameters:
-  * `minimumValue`: The earliest (inclusive) date that is allowed. Undefined by default.
-  * `maximumValue`: The latest (inclusive) date that is allowed. Undefined by default.
+  * `minimumValue`: The earliest (inclusive) date that is allowed. No restriction by default.
+  * `maximumValue`: The latest (inclusive) date that is allowed. No restriction by default.
 * `attachmentReference`: The value is the name of one of the document's file attachments. Note that, because the addition of an attachment is often a separate Sync Gateway API operation from the creation/replacement of the associated document, this validation type is only applied if the attachment is actually present in the document. However, since the sync function is run twice in such situations (i.e. once when the document is created/replaced and once when the attachment is created/replaced), the validation will be performed eventually. Additional parameters:
   * `supportedExtensions`: An array of case-insensitive file extensions that are allowed for the attachment's filename (e.g. "txt", "jpg", "pdf"). No restriction by default.
   * `supportedContentTypes`: An array of content/MIME types that are allowed for the attachment's contents (e.g. "image/png", "text/html", "application/xml"). No restriction by default.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ Validation for simple data types:
   * `maximumValue`: The largest (inclusive) value that is allowed. Undefined by default.
 * `boolean`: The value is either `true` or `false`. No additional parameters.
 * `datetime`: The value is an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date string with optional time and time zone components (e.g. "2016-06-18T18:57:35.328-08:00"). No additional parameters.
-* `date`: The value is an ISO 8601 date string _without_ time and time zone components (e.g. "2016-06-18"). No additional parameters.
+* `date`: The value is an ISO 8601 date string _without_ time and time zone components (e.g. "2016-06-18"). Additional parameters:
+  * `minimumValue`: The earliest (inclusive) date that is allowed. Undefined by default.
+  * `maximumValue`: The latest (inclusive) date that is allowed. Undefined by default.
 * `attachmentReference`: The value is the name of one of the document's file attachments. Note that, because the addition of an attachment is often a separate Sync Gateway API operation from the creation/replacement of the associated document, this validation type is only applied if the attachment is actually present in the document. However, since the sync function is run twice in such situations (i.e. once when the document is created/replaced and once when the attachment is created/replaced), the validation will be performed eventually. Additional parameters:
   * `supportedExtensions`: An array of case-insensitive file extensions that are allowed for the attachment's filename (e.g. "txt", "jpg", "pdf"). No restriction by default.
   * `supportedContentTypes`: An array of content/MIME types that are allowed for the attachment's contents (e.g. "image/png", "text/html", "application/xml"). No restriction by default.

--- a/etc/prepare-tests.sh
+++ b/etc/prepare-tests.sh
@@ -9,3 +9,4 @@ mkdir -p build/test-reports/
 ./make-sync-function samples/sample-sync-doc-definitions.js build/resources/test-sample-sync-function.js
 ./make-sync-function test/resources/array-doc-definitions.js build/resources/test-array-sync-function.js
 ./make-sync-function test/resources/string-doc-definitions.js build/resources/test-string-sync-function.js
+./make-sync-function test/resources/date-doc-definitions.js build/resources/test-date-sync-function.js

--- a/etc/prepare-tests.sh
+++ b/etc/prepare-tests.sh
@@ -10,3 +10,4 @@ mkdir -p build/test-reports/
 ./make-sync-function test/resources/array-doc-definitions.js build/resources/test-array-sync-function.js
 ./make-sync-function test/resources/string-doc-definitions.js build/resources/test-string-sync-function.js
 ./make-sync-function test/resources/date-doc-definitions.js build/resources/test-date-sync-function.js
+./make-sync-function test/resources/datetime-doc-definitions.js build/resources/test-datetime-sync-function.js

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -8,7 +8,7 @@ function(doc, oldDoc) {
 
   // Check that a given value is a valid ISO 8601 format date string with optional time and time zone components
   function isIso8601DateTimeString(value) {
-    var regex = new RegExp('^(([\\+-]?[0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))([T ]([01][0-9]|2[0-4])(:[0-5][0-9])?(:[0-5][0-9])?([\\.,][0-9]{1,3})?)?([zZ]|([\\+-])([01][0-9]|2[0-3]):?([0-5][0-9])?)$');
+    var regex = new RegExp('^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))([T ]([01][0-9]|2[0-4])(:[0-5][0-9])?(:[0-5][0-9])?([\\.,][0-9]{1,3})?)?([zZ]|([\\+-])([01][0-9]|2[0-3]):?([0-5][0-9])?)?$');
 
     return regex.test(value);
   }
@@ -186,12 +186,18 @@ function(doc, oldDoc) {
         validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be empty');
       }
 
-      if (!isValueNullOrUndefined(validator.minimumValue) && itemValue < validator.minimumValue) {
-        validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be less than ' + validator.minimumValue);
+      if (!isValueNullOrUndefined(validator.minimumValue)) {
+        var comparator = function(left, right) {
+          return left < right;
+        };
+        validateRangeConstraint(validator.minimumValue, validator.type, itemStack, comparator, 'less', validationErrors);
       }
 
-      if (!isValueNullOrUndefined(validator.maximumValue) && itemValue > validator.maximumValue) {
-        validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be greater than ' + validator.maximumValue);
+      if (!isValueNullOrUndefined(validator.maximumValue)) {
+        var comparator = function(left, right) {
+          return left > right;
+        };
+        validateRangeConstraint(validator.maximumValue, validator.type, itemStack, comparator, 'greater', validationErrors);
       }
 
       if (!isValueNullOrUndefined(validator.minimumLength) && itemValue.length < validator.minimumLength) {
@@ -283,6 +289,26 @@ function(doc, oldDoc) {
           validationErrors.push('value of item "' + buildItemPath(itemStack) + '" may not be modified')
         }
       }
+    }
+  }
+
+  function validateRangeConstraint(rangeLimit, validationType, itemStack, comparator, violationType, validationErrors) {
+    var itemValue = itemStack[itemStack.length - 1].itemValue;
+    var outOfRange;
+    if (validationType === 'datetime') {
+      // Date/times require special handling because their time and time zone components are optional and time zones may differ
+      try {
+        outOfRange = comparator(new Date(itemValue).getTime(), new Date(rangeLimit).getTime());
+      } catch (ex) {
+        // The date/time's format may be invalid but it isn't technically in violation of the range constraint
+        outOfRange = false;
+      }
+    } else if (comparator(itemValue, rangeLimit)) {
+      outOfRange = true;
+    }
+
+    if (outOfRange) {
+      validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be ' + violationType + ' than ' + rangeLimit);
     }
   }
 

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -15,7 +15,7 @@ function(doc, oldDoc) {
 
   // Check that a given value is a valid ISO 8601 date string without time and time zone components
   function isIso8601DateString(value) {
-    var regex = new RegExp('^(([\\+-]?[0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$');
+    var regex = new RegExp('^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$');
 
     return regex.test(value);
   }

--- a/test/array-spec.js
+++ b/test/array-spec.js
@@ -37,6 +37,7 @@ describe('Array validation type', function() {
       expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
         expect(ex.forbidden).to.contain('Invalid arrayDoc document');
         expect(ex.forbidden).to.contain('length of item "lengthValidationProp" must not be less than 2');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
       });
 
       verifyDocumentWriteDenied();
@@ -51,6 +52,7 @@ describe('Array validation type', function() {
       expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
         expect(ex.forbidden).to.contain('Invalid arrayDoc document');
         expect(ex.forbidden).to.contain('length of item "lengthValidationProp" must not be greater than 2');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
       });
 
       verifyDocumentWriteDenied();
@@ -77,4 +79,8 @@ function verifyDocumentReplaced() {
 function verifyDocumentWriteDenied() {
   expect(requireAccess.callCount).to.equal(1);
   expect(channel.callCount).to.equal(0);
+}
+
+function numberOfValidationErrors(message) {
+  return message.split(';').length;
 }

--- a/test/date-spec.js
+++ b/test/date-spec.js
@@ -37,6 +37,7 @@ describe('Date validation type', function() {
       expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
         expect(ex.forbidden).to.contain('Invalid dateDoc document');
         expect(ex.forbidden).to.contain('item "rangeValidationProp" must not be less than 2016-06-23');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
       });
 
       verifyDocumentWriteDenied();
@@ -51,6 +52,7 @@ describe('Date validation type', function() {
       expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
         expect(ex.forbidden).to.contain('Invalid dateDoc document');
         expect(ex.forbidden).to.contain('item "rangeValidationProp" must not be greater than 2016-06-23');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
       });
 
       verifyDocumentWriteDenied();
@@ -77,4 +79,8 @@ function verifyDocumentReplaced() {
 function verifyDocumentWriteDenied() {
   expect(requireAccess.callCount).to.equal(1);
   expect(channel.callCount).to.equal(0);
+}
+
+function numberOfValidationErrors(message) {
+  return message.split(';').length;
 }

--- a/test/date-spec.js
+++ b/test/date-spec.js
@@ -1,0 +1,80 @@
+var expect = require('expect.js');
+var simple = require('simple-mock');
+var fs = require('fs');
+
+// Load the contents of the sync function file into a global variable called syncFunction
+eval('var syncFunction = ' + fs.readFileSync('build/resources/test-date-sync-function.js').toString());
+
+// Placeholders for stubbing built-in Sync Gateway support functions.
+// More info: http://developer.couchbase.com/mobile/develop/guides/sync-gateway/sync-function-api-guide/index.html
+var requireAccess;
+var channel;
+
+describe('Date validation type', function() {
+  beforeEach(function() {
+    requireAccess = simple.stub();
+    channel = simple.stub();
+  });
+
+  describe('range validation', function() {
+    it('can create a doc with a date that is within the minimum and maximum values', function() {
+      var doc = {
+        _id: 'dateDoc',
+        rangeValidationProp: '2016-06-23'
+      };
+
+      syncFunction(doc);
+
+      verifyDocumentCreated();
+    });
+
+    it('cannot create a doc with a date that is before the minimum value', function() {
+      var doc = {
+        _id: 'dateDoc',
+        rangeValidationProp: '2016-06-22'
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid dateDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationProp" must not be less than 2016-06-23');
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot create a doc with a date that is after than the maximum value', function() {
+      var doc = {
+        _id: 'dateDoc',
+        rangeValidationProp: '2016-06-24'
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid dateDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationProp" must not be greater than 2016-06-23');
+      });
+
+      verifyDocumentWriteDenied();
+    });
+  });
+});
+
+function verifyDocumentWriteAccepted(expectedChannel) {
+  expect(requireAccess.callCount).to.equal(1);
+  expect(requireAccess.calls[0].arg).to.contain(expectedChannel);
+
+  expect(channel.callCount).to.equal(1);
+  expect(channel.calls[0].arg).to.contain(expectedChannel);
+}
+
+function verifyDocumentCreated() {
+  verifyDocumentWriteAccepted('add');
+}
+
+function verifyDocumentReplaced() {
+  verifyDocumentWriteAccepted('replace');
+}
+
+function verifyDocumentWriteDenied() {
+  expect(requireAccess.callCount).to.equal(1);
+  expect(channel.callCount).to.equal(0);
+}

--- a/test/datetime-spec.js
+++ b/test/datetime-spec.js
@@ -1,0 +1,200 @@
+var expect = require('expect.js');
+var simple = require('simple-mock');
+var fs = require('fs');
+
+// Load the contents of the sync function file into a global variable called syncFunction
+eval('var syncFunction = ' + fs.readFileSync('build/resources/test-datetime-sync-function.js').toString());
+
+// Placeholders for stubbing built-in Sync Gateway support functions.
+// More info: http://developer.couchbase.com/mobile/develop/guides/sync-gateway/sync-function-api-guide/index.html
+var requireAccess;
+var channel;
+
+describe('Date/time validation type', function() {
+  beforeEach(function() {
+    requireAccess = simple.stub();
+    channel = simple.stub();
+  });
+
+  describe('range validation for min and max dates with time and time zone components', function() {
+    it('can create a doc with a date/time that is within the minimum and maximum values', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatetimesProp: '2016-06-24T08:22:17.123+02:30'  // Same date/time as the min and max values, different time zone
+      };
+
+      syncFunction(doc);
+
+      verifyDocumentCreated();
+    });
+
+    it('cannot create a doc with a date/time that is less than the minimum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatetimesProp: '2016-06-24T05:52:17.122Z'
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid datetimeDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationAsDatetimesProp" must not be less than 2016-06-23T21:52:17.123-08:00');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot create a doc with a date without time and time zone components that is less than the minimum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatetimesProp: '2016-06-24'  // Treated as UTC when time zone is undefined, making it less than the min value
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid datetimeDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationAsDatetimesProp" must not be less than 2016-06-23T21:52:17.123-08:00');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot create a doc with a date/time that is greater than the maximum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatetimesProp: '2016-06-23T21:52:17.124-08:00'
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid datetimeDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationAsDatetimesProp" must not be greater than 2016-06-24T05:52:17.123Z');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot create a doc with a date without time and time zone components that is greater than the maximum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatetimesProp: '2016-06-25'
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid datetimeDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationAsDatetimesProp" must not be greater than 2016-06-24T05:52:17.123Z');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+  });
+
+  describe('range validation for min and max dates without time and time zone components', function() {
+    it('can create a doc with a date/time that is within the minimum and maximum values', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatesOnlyProp: '2016-06-23T16:30:00.000-07:30'  // When adjusted to UTC, this matches the min and max dates
+      };
+
+      syncFunction(doc);
+
+      verifyDocumentCreated();
+    });
+
+    it('can create a doc with a date without time and time zone components that is within the minimum and maximum values', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatesOnlyProp: '2016-06-24'
+      };
+
+      syncFunction(doc);
+
+      verifyDocumentCreated();
+    });
+
+    it('cannot create a doc with a date/time that is less than the minimum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatesOnlyProp: '2016-06-23T23:59:59.999Z'
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid datetimeDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationAsDatesOnlyProp" must not be less than 2016-06-24');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot create a doc with a date without time and time zone components that is less than the minimum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatesOnlyProp: '2016-06-23'
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid datetimeDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationAsDatesOnlyProp" must not be less than 2016-06-24');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot create a doc with a date/time that is greater than the maximum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatesOnlyProp: '2016-06-24T00:00:00.001Z'
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid datetimeDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationAsDatesOnlyProp" must not be greater than 2016-06-24');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot create a doc with a date without time and time zone components that is greater than the maximum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        rangeValidationAsDatesOnlyProp: '2016-06-25'
+      };
+
+      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid datetimeDoc document');
+        expect(ex.forbidden).to.contain('item "rangeValidationAsDatesOnlyProp" must not be greater than 2016-06-24');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+  });
+});
+
+function verifyDocumentWriteAccepted(expectedChannel) {
+  expect(requireAccess.callCount).to.equal(1);
+  expect(requireAccess.calls[0].arg).to.contain(expectedChannel);
+
+  expect(channel.callCount).to.equal(1);
+  expect(channel.calls[0].arg).to.contain(expectedChannel);
+}
+
+function verifyDocumentCreated() {
+  verifyDocumentWriteAccepted('add');
+}
+
+function verifyDocumentReplaced() {
+  verifyDocumentWriteAccepted('replace');
+}
+
+function verifyDocumentWriteDenied() {
+  expect(requireAccess.callCount).to.equal(1);
+  expect(channel.callCount).to.equal(0);
+}
+
+function numberOfValidationErrors(message) {
+  return message.split(';').length;
+}

--- a/test/resources/date-doc-definitions.js
+++ b/test/resources/date-doc-definitions.js
@@ -1,0 +1,21 @@
+{
+  dateDoc: {
+    channels: {
+      view: 'view',
+      add: 'add',
+      replace: 'replace',
+      remove: 'remove'
+    },
+    typeFilter: function(doc) {
+      return doc._id === 'dateDoc';
+    },
+    propertyValidators: [
+      {
+        propertyName: 'rangeValidationProp',
+        type: 'date',
+        minimumValue: '2016-06-23',
+        maximumValue: '2016-06-23'
+      }
+    ]
+  }
+}

--- a/test/resources/datetime-doc-definitions.js
+++ b/test/resources/datetime-doc-definitions.js
@@ -1,0 +1,27 @@
+{
+  datetimeDoc: {
+    channels: {
+      view: 'view',
+      add: 'add',
+      replace: 'replace',
+      remove: 'remove'
+    },
+    typeFilter: function(doc) {
+      return doc._id === 'datetimeDoc';
+    },
+    propertyValidators: [
+      {
+        propertyName: 'rangeValidationAsDatetimesProp',
+        type: 'datetime',
+        minimumValue: '2016-06-23T21:52:17.123-08:00',
+        maximumValue: '2016-06-24T05:52:17.123Z'  // This is the same date and time, just in UTC
+      },
+      {
+        propertyName: 'rangeValidationAsDatesOnlyProp',
+        type: 'datetime',
+        minimumValue: '2016-06-24',
+        maximumValue: '2016-06-24'
+      }
+    ]
+  }
+}

--- a/test/string-spec.js
+++ b/test/string-spec.js
@@ -37,6 +37,7 @@ describe('String validation type', function() {
       expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
         expect(ex.forbidden).to.contain('Invalid stringDoc document');
         expect(ex.forbidden).to.contain('length of item "lengthValidationProp" must not be less than 3');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
       });
 
       verifyDocumentWriteDenied();
@@ -51,6 +52,7 @@ describe('String validation type', function() {
       expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
         expect(ex.forbidden).to.contain('Invalid stringDoc document');
         expect(ex.forbidden).to.contain('length of item "lengthValidationProp" must not be greater than 3');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
       });
 
       verifyDocumentWriteDenied();
@@ -77,4 +79,8 @@ function verifyDocumentReplaced() {
 function verifyDocumentWriteDenied() {
   expect(requireAccess.callCount).to.equal(1);
   expect(channel.callCount).to.equal(0);
+}
+
+function numberOfValidationErrors(message) {
+  return message.split(';').length;
 }


### PR DESCRIPTION
For pure `date`s, the validation logic is quite simple: since the type requires that values are of a fixed length and format, they can be compared alphanumerically as strings. However, for `datetimes`, it gets more complicated because time and time zone components are optional and a value's time zone may not match the time zone defined in the validator. The solution I chose was to construct `Date` objects from the input value and the validator range value and then compare their Unix timestamp values.

Note that I have not yet verified these validation parameters in a live Sync Gateway instance. As such, there may be some inconsistencies in date handling that are not yet apparent.