### PR TITLE
Treat replacement of a deleted doc as doc creation when authorizing

### DIFF
--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -68,7 +68,7 @@ function(doc, oldDoc) {
     var requiredChannels;
     if (doc._deleted) {
       requiredChannels = docChannelMap.remove;
-    } else if (oldDoc) {
+    } else if (oldDoc && !oldDoc._deleted) {
       requiredChannels = docChannelMap.replace;
     } else {
       requiredChannels = docChannelMap.add;

--- a/test/sample-sync-doc-definitions-spec.js
+++ b/test/sample-sync-doc-definitions-spec.js
@@ -584,8 +584,12 @@ describe('The sample-sync-doc-definitions sync function', function() {
         'createdAt': '2016-02-29T17:13:43.666Z',
         'actions': [ { 'url': 'http://foobar.baz', 'label': 'pay up here'} ]
       };
+      var oldDoc = {
+        '_id': 'biz.63.notification.5',
+        '_deleted': true
+      };
 
-      syncFunction(doc, null);
+      syncFunction(doc, oldDoc);
 
       verifyDocumentCreated(notificationsPrivilege, 63);
     });
@@ -618,7 +622,12 @@ describe('The sample-sync-doc-definitions sync function', function() {
       };
       var oldDoc = {
         '_id': 'biz.7.notification.3',
-        '_deleted': true
+        'type': 'invoice-payments',
+        'sender': 'test-service',
+        'subject': 'a different subject',
+        'message': 'last warning!',
+        'createdAt': '2016-02-29T17:13:43.666Z',
+        'actions': [ { 'url': 'http://foobar.baz/lastwarning', 'label': 'pay up here'} ]
       };
 
       syncFunction(doc, oldDoc);


### PR DESCRIPTION
Previously, if the old instance of a document was deleted, when creating a new document to replace it, the authorization method required that the user had the replacement channel(s). However, it is more logical to expect the creation channel(s), so that's what it does now.