### PR TITLE
Support the immutable constraint for complex data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,6 @@ Validation for simple data types:
   * `supportedContentTypes`: An array of content/MIME types that are allowed for the attachment's contents (e.g. "image/png", "text/html", "application/xml"). No restriction by default.
   * `maximumSize`: The maximum file size, in bytes, of the attachment. May not be greater than 20MB (20,971,520 bytes), as Couchbase Server/Sync Gateway sets that as the hard limit per document or attachment. Undefined by default.
 
-**NOTE**: Validation for all _simple data types_ support the following additional parameter:
-
-* `immutable`: The item cannot be changed from its existing value if the document is being replaced. Does not apply when creating a new document or deleting an existing document. Defaults to `false`.
-
 Validation for complex data types, which allow for nesting of child properties and elements:
 
 * `array`: An array/list of elements. Additional parameters:
@@ -308,6 +304,7 @@ Validation for complex data types, which allow for nesting of child properties a
 **NOTE**: Validation for all simple and complex data types support the following additional parameters:
 
 * `required`: The value cannot be null or undefined. Defaults to `false`.
+* `immutable`: The item cannot be changed from its existing value if the document is being replaced. Applied recursively so that, if a value that is nested an arbitrary number of levels deep within an immutable complex type is modified, the document change will be rejected. Does not apply when creating a new document or deleting an existing document. Defaults to `false`.
 * `customValidation`: A function that accepts as parameters (1) the new document, (2) the old document that is being replaced/deleted (if any), (3) an object that contains metadata about the current item to validate and (4) a stack of the items (e.g. object properties, array elements, hashtable element values) that have gone through validation, where the last/top element contains metadata for the direct parent of the item currently being validated and the first/bottom element is metadata for the root (i.e. the document). Generally, custom validation should not throw exceptions; it's recommended to return an array/list of error descriptions so the sync function can compile a list of all validation errors that were encountered once full validation is complete. A return value of `null`, `undefined` or an empty array indicate there were no validation errors. An example:
 
 ```

--- a/etc/prepare-tests.sh
+++ b/etc/prepare-tests.sh
@@ -6,6 +6,7 @@ mkdir -p build/resources/
 mkdir -p build/test-reports/
 
 # Create a temporary sync function from test resource document definitions to use in test cases
-./make-sync-function samples/sample-sync-doc-definitions.js build/resources/test-sample-sync-function.js
 ./make-sync-function test/resources/array-doc-definitions.js build/resources/test-array-sync-function.js
+./make-sync-function test/resources/immutable-doc-definitions.js build/resources/test-immutable-sync-function.js
+./make-sync-function samples/sample-sync-doc-definitions.js build/resources/test-sample-sync-function.js
 ./make-sync-function test/resources/string-doc-definitions.js build/resources/test-string-sync-function.js

--- a/etc/prepare-tests.sh
+++ b/etc/prepare-tests.sh
@@ -6,9 +6,9 @@ mkdir -p build/resources/
 mkdir -p build/test-reports/
 
 # Create a temporary sync function from test resource document definitions to use in test cases
+./make-sync-function samples/sample-sync-doc-definitions.js build/resources/test-sample-sync-function.js
 ./make-sync-function test/resources/array-doc-definitions.js build/resources/test-array-sync-function.js
 ./make-sync-function test/resources/immutable-doc-definitions.js build/resources/test-immutable-sync-function.js
-./make-sync-function samples/sample-sync-doc-definitions.js build/resources/test-sample-sync-function.js
 ./make-sync-function test/resources/string-doc-definitions.js build/resources/test-string-sync-function.js
 ./make-sync-function test/resources/date-doc-definitions.js build/resources/test-date-sync-function.js
 ./make-sync-function test/resources/datetime-doc-definitions.js build/resources/test-datetime-sync-function.js

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -339,12 +339,12 @@ function(doc, oldDoc) {
       itemProperties.push(itemProp);
     }
 
-    var oldItemProperties = [ ];
+    var oldItemPropertiesCount = 0;
     for (var oldItemProp in oldItemValue) {
-      oldItemProperties.push(oldItemProp);
+      oldItemPropertiesCount++;
     }
 
-    if (itemProperties.length !== oldItemProperties.length) {
+    if (itemProperties.length !== oldItemPropertiesCount) {
       return false;
     }
 
@@ -358,7 +358,7 @@ function(doc, oldDoc) {
       }
     }
 
-    // If we got here, all elements match
+    // If we got here, all properties match
     return true;
   }
 

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -278,12 +278,48 @@ function(doc, oldDoc) {
       // question is the value of a property in an object that is itself in an array, but the object did not exist in the array in the old
       // document, then there is nothing to validate.
       var oldParentItemValue = (itemStack.length >= 2) ? itemStack[itemStack.length - 2].oldItemValue : null;
+      var constraintSatisfied = true;
       if (!isValueNullOrUndefined(oldParentItemValue)) {
-        if (oldItemValue !== itemValue && !(isValueNullOrUndefined(oldItemValue) && isValueNullOrUndefined(itemValue))) {
-          validationErrors.push('value of item "' + buildItemPath(itemStack) + '" may not be modified')
-        }
+        constraintSatisfied = validateImmutableItem(itemValue, oldItemValue);
+      }
+
+      if (!constraintSatisfied) {
+        validationErrors.push('value of item "' + buildItemPath(itemStack) + '" may not be modified');
       }
     }
+  }
+
+  function validateImmutableItem(itemValue, oldItemValue) {
+    if (oldItemValue === itemValue || (isValueNullOrUndefined(oldItemValue) && isValueNullOrUndefined(itemValue))) {
+      return true;
+    } else {
+      if (itemValue instanceof Array && oldItemValue instanceof Array) {
+        return validateImmutableArray(itemValue, oldItemValue);
+      } else if (typeof(itemValue) === 'object' && typeof(oldItemValue) === 'object') {
+        // TODO
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
+
+  function validateImmutableArray(itemValue, oldItemValue) {
+    if (itemValue.length !== oldItemValue.length) {
+      return false;
+    }
+
+    for (var elementIndex = 0; elementIndex < itemValue.length; elementIndex++) {
+      var elementValue = itemValue[elementIndex];
+      var oldElementValue = oldItemValue[elementIndex];
+
+      if (!validateImmutableItem(elementValue, oldElementValue)) {
+        return false;
+      }
+    }
+
+    // If we got here, all elements match
+    return true;
   }
 
   function validateArray(doc, oldDoc, elementValidator, itemStack, validationErrors) {

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -293,11 +293,10 @@ function(doc, oldDoc) {
     if (oldItemValue === itemValue || (isValueNullOrUndefined(oldItemValue) && isValueNullOrUndefined(itemValue))) {
       return true;
     } else {
-      if (itemValue instanceof Array && oldItemValue instanceof Array) {
+      if (itemValue instanceof Array || oldItemValue instanceof Array) {
         return validateImmutableArray(itemValue, oldItemValue);
-      } else if (typeof(itemValue) === 'object' && typeof(oldItemValue) === 'object') {
-        // TODO
-        return true;
+      } else if (typeof(itemValue) === 'object' || typeof(oldItemValue) === 'object') {
+        return validateImmutableObject(itemValue, oldItemValue);
       } else {
         return false;
       }
@@ -305,7 +304,9 @@ function(doc, oldDoc) {
   }
 
   function validateImmutableArray(itemValue, oldItemValue) {
-    if (itemValue.length !== oldItemValue.length) {
+    if (!(itemValue instanceof Array && oldItemValue instanceof Array)) {
+      return false;
+    } else if (itemValue.length !== oldItemValue.length) {
       return false;
     }
 
@@ -314,6 +315,39 @@ function(doc, oldDoc) {
       var oldElementValue = oldItemValue[elementIndex];
 
       if (!validateImmutableItem(elementValue, oldElementValue)) {
+        return false;
+      }
+    }
+
+    // If we got here, all elements match
+    return true;
+  }
+
+  function validateImmutableObject(itemValue, oldItemValue) {
+    if (typeof(itemValue) !== 'object' || typeof(oldItemValue) !== 'object') {
+      return false;
+    }
+
+    var itemProperties = [ ];
+    for (var itemProp in itemValue) {
+      itemProperties.push(itemProp);
+    }
+
+    var oldItemProperties = [ ];
+    for (var oldItemProp in oldItemValue) {
+      oldItemProperties.push(oldItemProp);
+    }
+
+    if (itemProperties.length !== oldItemProperties.length) {
+      return false;
+    }
+
+    for (var propIndex = 0; propIndex < itemProperties.length; propIndex++) {
+      var propertyName = itemProperties[propIndex];
+      var propertyValue = itemValue[propertyName];
+      var oldPropertyValue = oldItemValue[propertyName];
+
+      if (!validateImmutableItem(propertyValue, oldPropertyValue)) {
         return false;
       }
     }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
     "test": "etc/prepare-tests.sh && node_modules/.bin/mocha",
     "test-report": "etc/prepare-tests.sh && node_modules/.bin/mocha -R xunit test/ > build/test-reports/synctos.xml"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/Kashoo/synctos"
+  }
 }

--- a/samples/sample-sync-doc-definitions.js
+++ b/samples/sample-sync-doc-definitions.js
@@ -167,6 +167,7 @@ function() {
         {
           propertyName: 'actions',
           type: 'array',
+          immutable: true,
           arrayElementsValidator: {
             type: 'object',
             required: true,
@@ -175,15 +176,13 @@ function() {
                 propertyName: 'url',
                 type: 'string',
                 required: true,
-                mustNotBeEmpty: true,
-                immutable: true
+                mustNotBeEmpty: true
               },
               {
                 propertyName: 'label',
                 type: 'string',
                 required: true,
-                mustNotBeEmpty: true,
-                immutable: true
+                mustNotBeEmpty: true
               }
             ]
           }

--- a/test/immutable-spec.js
+++ b/test/immutable-spec.js
@@ -1,0 +1,171 @@
+var expect = require('expect.js');
+var simple = require('simple-mock');
+var fs = require('fs');
+
+// Load the contents of the sync function file into a global variable called syncFunction
+eval('var syncFunction = ' + fs.readFileSync('build/resources/test-immutable-sync-function.js').toString());
+
+// Placeholders for stubbing built-in Sync Gateway support functions.
+// More info: http://developer.couchbase.com/mobile/develop/guides/sync-gateway/sync-function-api-guide/index.html
+var requireAccess;
+var channel;
+
+describe('Immutable validation parameter', function() {
+  beforeEach(function() {
+    requireAccess = simple.stub();
+    channel = simple.stub();
+  });
+
+  describe('array type validation', function() {
+    it('can replace a document with an immutable array where the simple type elements have not changed', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ 'foobar', 3, false, 45.9 ]
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ 'foobar', 3, false, 45.9 ]
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentReplaced();
+    });
+
+    it('can replace a document with an immutable array where the nested array type elements have not changed', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [], null ]
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [], undefined ]
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentReplaced();
+    });
+
+    it('can create a document with an immutable array where the old document does not exist', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [] ]
+      };
+
+      syncFunction(doc);
+
+      verifyDocumentCreated();
+    });
+
+    it('can create a document with an immutable array where the old document was deleted', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [] ]
+      };
+      var oldDoc = { _id: 'immutableDoc', _deleted: true };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentCreated();
+    });
+
+    it('can delete a document with an immutable array', function() {
+      var doc = { _id: 'immutableDoc', _deleted: true };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ 'foobar', 3, false, 45.9 ]
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentDeleted();
+    });
+
+    it('cannot replace a document with an immutable array where the elements are not equal', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ]
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ 'foobar', 3, false, 45.9, [] ]
+      };
+
+      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid immutableDoc document');
+        expect(ex.forbidden).to.contain('value of item "immutableArrayProp" may not be modified');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot replace a document with an immutable array where the one is a subset of the other', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ 'foobar', 3, false, 45.9 ]
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ 'foobar', 3, false, 45.9, [] ]
+      };
+
+      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid immutableDoc document');
+        expect(ex.forbidden).to.contain('value of item "immutableArrayProp" may not be modified');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot replace a document with an immutable array where the element order has changed', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ [], 'foobar', 3, false, 45.9 ]
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: [ 'foobar', 3, false, 45.9, [] ]
+      };
+
+      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid immutableDoc document');
+        expect(ex.forbidden).to.contain('value of item "immutableArrayProp" may not be modified');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+  });
+});
+
+function verifyDocumentWriteAccepted(expectedChannel) {
+  expect(requireAccess.callCount).to.equal(1);
+  expect(requireAccess.calls[0].arg).to.contain(expectedChannel);
+
+  expect(channel.callCount).to.equal(1);
+  expect(channel.calls[0].arg).to.contain(expectedChannel);
+}
+
+function verifyDocumentCreated() {
+  verifyDocumentWriteAccepted('add');
+}
+
+function verifyDocumentReplaced() {
+  verifyDocumentWriteAccepted('replace');
+}
+
+function verifyDocumentDeleted() {
+  verifyDocumentWriteAccepted('remove');
+}
+
+function verifyDocumentWriteDenied() {
+  expect(requireAccess.callCount).to.equal(1);
+  expect(channel.callCount).to.equal(0);
+}
+
+function numberOfValidationErrors(message) {
+  return message.split(';').length;
+}

--- a/test/immutable-spec.js
+++ b/test/immutable-spec.js
@@ -17,14 +17,14 @@ describe('Immutable validation parameter', function() {
   });
 
   describe('array type validation', function() {
-    it('can replace a document with an immutable array where the simple type elements have not changed', function() {
+    it('can replace a document with an immutable array when the simple type elements have not changed', function() {
       var doc = {
         _id: 'immutableDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9 ]
+        immutableArrayProp: [ 'foobar', 3, false, 46.0 ]
       };
       var oldDoc = {
         _id: 'immutableDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9 ]
+        immutableArrayProp: [ 'foobar', 3, false, 46 ]
       };
 
       syncFunction(doc, oldDoc);
@@ -32,7 +32,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentReplaced();
     });
 
-    it('can replace a document with an immutable array where the nested complex type elements have not changed', function() {
+    it('can replace a document with an immutable array when the nested complex type elements have not changed', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], null, { foo: 'bar' } ]
@@ -47,7 +47,19 @@ describe('Immutable validation parameter', function() {
       verifyDocumentReplaced();
     });
 
-    it('can create a document with an immutable array where the old document does not exist', function() {
+    it('can replace a document with an immutable array when it is null or undefined', function() {
+      var doc = { _id: 'immutableDoc' };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableArrayProp: null
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentReplaced();
+    });
+
+    it('can create a document with an immutable array when the old document does not exist', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], { foo: 'bar' } ]
@@ -58,7 +70,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentCreated();
     });
 
-    it('can create a document with an immutable array where the old document was deleted', function() {
+    it('can create a document with an immutable array when the old document was deleted', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], { foo: 'bar' } ]
@@ -82,14 +94,14 @@ describe('Immutable validation parameter', function() {
       verifyDocumentDeleted();
     });
 
-    it('cannot replace a document with an immutable array where the elements are not equal', function() {
+    it('cannot replace a document with an immutable array when the elements are not equal', function() {
       var doc = {
         _id: 'immutableDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ]
+        immutableArrayProp: [ 'foobar', 3, false, 15.0 ]
       };
       var oldDoc = {
         _id: 'immutableDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ] ]
+        immutableArrayProp: [ 'foobar', 3, false, 45.9 ]
       };
 
       expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
@@ -101,14 +113,14 @@ describe('Immutable validation parameter', function() {
       verifyDocumentWriteDenied();
     });
 
-    it('cannot replace a document with an immutable array where a nested object is not equal', function() {
+    it('cannot replace a document with an immutable array when a nested element is not equal', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ], { foo: 'bar' } ]
       };
       var oldDoc = {
         _id: 'immutableDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ], { bar: 'baz' } ]
+        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ], { bar: null } ]
       };
 
       expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
@@ -120,7 +132,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentWriteDenied();
     });
 
-    it('cannot replace a document with an immutable array where one is a subset of the other', function() {
+    it('cannot replace a document with an immutable array when one is a subset of the other', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableArrayProp: [ 'foobar', 3, false, 45.9, { } ]
@@ -139,7 +151,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentWriteDenied();
     });
 
-    it('cannot replace a document with an immutable array where nested complex type elements are not the same type', function() {
+    it('cannot replace a document with an immutable array when nested complex type elements are not the same type', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableArrayProp: [ 'foobar', 3, false, 45.9, { } ]
@@ -158,7 +170,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentWriteDenied();
     });
 
-    it('cannot replace a document with an immutable array where the element order has changed', function() {
+    it('cannot replace a document with an immutable array when the element order has changed', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableArrayProp: [ [ ], 'foobar', 3, false, 45.9 ]
@@ -214,7 +226,7 @@ describe('Immutable validation parameter', function() {
   });
 
   describe('object type validation', function() {
-    it('can replace a document with an immutable object where the simple type properties have not changed', function() {
+    it('can replace a document with an immutable object when the simple type properties have not changed', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableObjectProp: {
@@ -239,7 +251,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentReplaced();
     });
 
-    it('can replace a document with an immutable object where the nested complex type elements have not changed', function() {
+    it('can replace a document with an immutable object when the nested complex type elements have not changed', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableObjectProp: {
@@ -260,7 +272,21 @@ describe('Immutable validation parameter', function() {
       verifyDocumentReplaced();
     });
 
-    it('can replace a document with an immutable object where the property order has changed', function() {
+    it('can replace a document with an immutable object when the property is null or undefined', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableObjectProp: null
+      };
+      var oldDoc = {
+        _id: 'immutableDoc'
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentReplaced();
+    });
+
+    it('can replace a document with an immutable object when the property order has changed', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableObjectProp: {
@@ -281,7 +307,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentReplaced();
     });
 
-    it('can create a document with an immutable object where the old document does not exist', function() {
+    it('can create a document with an immutable object when the old document does not exist', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableObjectProp: {
@@ -295,7 +321,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentCreated();
     });
 
-    it('can create a document with an immutable object where the old document was deleted', function() {
+    it('can create a document with an immutable object when the old document was deleted', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableObjectProp: {
@@ -325,7 +351,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentDeleted();
     });
 
-    it('cannot replace a document with an immutable object when the properties are not equal', function() {
+    it('cannot replace a document with an immutable object when the nested properties are not equal', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableObjectProp: {
@@ -350,7 +376,7 @@ describe('Immutable validation parameter', function() {
       verifyDocumentWriteDenied();
     });
 
-    it('cannot replace a document with an immutable object when a property is missing', function() {
+    it('cannot replace a document with an immutable object when a nested property is missing', function() {
       var doc = {
         _id: 'immutableDoc',
         immutableObjectProp: {
@@ -411,6 +437,225 @@ describe('Immutable validation parameter', function() {
       expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
         expect(ex.forbidden).to.contain('Invalid immutableDoc document');
         expect(ex.forbidden).to.contain('value of item "immutableObjectProp" may not be modified');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+  });
+
+  describe('hashtable type validation', function() {
+    it('can replace a document with an immutable hashtable when the simple type properties have not changed', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myStringProp: 'foobar',
+          myIntegerProp: 8,
+          myBooleanProp: true,
+          myFloatProp: 88.92
+        }
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myStringProp: 'foobar',
+          myIntegerProp: 8,
+          myBooleanProp: true,
+          myFloatProp: 88.92
+        }
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentReplaced();
+    });
+
+    it('can replace a document with an immutable hashtable when the nested complex type elements have not changed', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myArrayProp: [ 'foobar', 3, false, 45.9, [ undefined ], { foobar: 18.0 } ],
+          myObjectProp: { foo: 'bar', baz: 73, qux: [ ] }
+        }
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myArrayProp: [ 'foobar', 3, false, 45.9, [ null ], { foobar: 18 } ],
+          myObjectProp: { foo: 'bar', baz: 73, qux: [ ] }
+        }
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentReplaced();
+    });
+
+    it('can replace a document with an immutable hashtable when the property is null or undefined', function() {
+      var doc = {
+        _id: 'immutableDoc'
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: null
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentReplaced();
+    });
+
+    it('can replace a document with an immutable hashtable when the property order has changed', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myIntegerProp: 8,
+          myStringProp: 'foobar'
+        }
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myStringProp: 'foobar',
+          myIntegerProp: 8
+        }
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentReplaced();
+    });
+
+    it('can create a document with an immutable hashtable when the old document does not exist', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ],
+          myObjectProp: { foo: 'bar', baz: 73 }
+        }
+      };
+
+      syncFunction(doc);
+
+      verifyDocumentCreated();
+    });
+
+    it('can create a document with an immutable hashtable when the old document was deleted', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ],
+          myObjectProp: { foo: 'bar', baz: 73 }
+        }
+      };
+      var oldDoc = { _id: 'immutableDoc', _deleted: true };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentCreated();
+    });
+
+    it('can delete a document with an immutable hashtable', function() {
+      var doc = { _id: 'immutableDoc', _deleted: true };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ],
+          myObjectProp: { foo: 'bar', baz: 73 }
+        }
+      };
+
+      syncFunction(doc, oldDoc);
+
+      verifyDocumentDeleted();
+    });
+
+    it('cannot replace a document with an immutable hashtable when the properties are not equal', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myArrayProp: [ 'foobar', 3, false, 45.9, [ { foo: 'bar' } ] ],
+          myObjectProp: { foo: 'bar', baz: 73 }
+        }
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myArrayProp: [ 'foobar', 3, false, 45.9, [ { } ] ],
+          myObjectProp: { foo: 'bar', baz: 73 }
+        }
+      };
+
+      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid immutableDoc document');
+        expect(ex.forbidden).to.contain('value of item "immutableHashtableProp" may not be modified');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot replace a document with an immutable hashtable when a property is missing', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myStringProp: 'foobar',
+          myBooleanProp: true,
+          myFloatProp: 88.92
+        }
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myStringProp: 'foobar',
+          myIntegerProp: 8,
+          myBooleanProp: true,
+          myFloatProp: 88.92
+        }
+      };
+
+      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid immutableDoc document');
+        expect(ex.forbidden).to.contain('value of item "immutableHashtableProp" may not be modified');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot replace a document with an immutable hashtable when it is missing in the new document', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: null
+      };
+      var oldDoc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: {
+          myStringProp: 'foobar',
+          myBooleanProp: true,
+          myFloatProp: 88.92
+        }
+      };
+
+      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid immutableDoc document');
+        expect(ex.forbidden).to.contain('value of item "immutableHashtableProp" may not be modified');
+        expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
+      });
+
+      verifyDocumentWriteDenied();
+    });
+
+    it('cannot replace a document with an immutable hashtable when it is missing in the old document', function() {
+      var doc = {
+        _id: 'immutableDoc',
+        immutableHashtableProp: { }
+      };
+      var oldDoc = { _id: 'immutableDoc' };
+
+      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        expect(ex.forbidden).to.contain('Invalid immutableDoc document');
+        expect(ex.forbidden).to.contain('value of item "immutableHashtableProp" may not be modified');
         expect(numberOfValidationErrors(ex.forbidden)).to.be(1);
       });
 

--- a/test/resources/immutable-doc-definitions.js
+++ b/test/resources/immutable-doc-definitions.js
@@ -14,6 +14,16 @@
         propertyName: 'immutableArrayProp',
         type: 'array',
         immutable: true
+      },
+      {
+        propertyName: 'immutableObjectProp',
+        type: 'object',
+        immutable: true
+      },
+      {
+        propertyName: 'immutableHashtableProp',
+        type: 'hashtable',
+        immutable: true
       }
     ]
   }

--- a/test/resources/immutable-doc-definitions.js
+++ b/test/resources/immutable-doc-definitions.js
@@ -1,0 +1,20 @@
+{
+  immutableDoc: {
+    channels: {
+      view: 'view',
+      add: 'add',
+      replace: 'replace',
+      remove: 'remove'
+    },
+    typeFilter: function(doc) {
+      return doc._id === 'immutableDoc';
+    },
+    propertyValidators: [
+      {
+        propertyName: 'immutableArrayProp',
+        type: 'array',
+        immutable: true
+      }
+    ]
+  }
+}

--- a/test/sample-sync-doc-definitions-spec.js
+++ b/test/sample-sync-doc-definitions-spec.js
@@ -654,7 +654,7 @@ describe('The sample-sync-doc-definitions sync function', function() {
       };
 
       expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
-        expect(ex).to.eql({ forbidden: 'Invalid notification document: value of item "sender" may not be modified; item "sender" must not be empty; value of item "type" may not be modified; required item "type" is missing; value of item "subject" may not be modified; required item "subject" is missing; value of item "message" may not be modified; item "message" must not be empty; value of item "createdAt" may not be modified; value of item "actions[0].url" may not be modified; required item "actions[0].url" is missing; value of item "actions[0].label" may not be modified; item "actions[0].label" must not be empty' });
+        expect(ex).to.eql({ forbidden: 'Invalid notification document: value of item "sender" may not be modified; item "sender" must not be empty; value of item "type" may not be modified; required item "type" is missing; value of item "subject" may not be modified; required item "subject" is missing; value of item "message" may not be modified; item "message" must not be empty; value of item "createdAt" may not be modified; value of item "actions" may not be modified; required item "actions[0].url" is missing; item "actions[0].label" must not be empty' });
       });
       verifyDocumentNotReplaced(notificationsPrivilege, 10);
     });


### PR DESCRIPTION
Array, object and hashtable type items may now be marked as `immutable` to ensure they are not changed when a document is replaced. The constraint is applied recursively so that it can be applied to complex types with an arbitrary number of nested layers and to items that have themselves been nested an arbitrary number of layers deep.

Tests were successfully executed with `npm test`.