### PR TITLE
Define doc and object property validators in an object/hash instead of an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ With this utility, you define all your JSON document types in a declarative Java
 
 To learn more about Sync Gateway, check out [Couchbase](http://www.couchbase.com/)'s comprehensive [developer documentation](http://developer.couchbase.com/documentation/mobile/current/get-started/sync-gateway-overview/index.html).
 
+[![Build Status](https://travis-ci.org/Kashoo/synctos.svg?branch=master)](https://travis-ci.org/Kashoo/synctos)
+
 # Installation
 
 Synctos is distributed as an [npm](https://www.npmjs.com/) package and has several npm dependencies. As such, it requires that [Node.js](https://nodejs.org/) is installed in order to run.

--- a/README.md
+++ b/README.md
@@ -49,17 +49,15 @@ For example, a document definition file implemented as an object:
             return doc.type === 'myDocType1';
           }
         },
-        propertyValidators: [
-          {
-            propertyName: 'type',
+        propertyValidators: {
+          type: {
             type: 'string',
             required: true
           },
-          {
-            propertyName: 'myProp1',
+          myProp1: {
             type: 'integer'
           }
-        ]
+        }
       },
       myDocType2: {
         channels: {
@@ -75,17 +73,15 @@ For example, a document definition file implemented as an object:
             return doc.type === 'myDocType2';
           }
         },
-        propertyValidators: [
-          {
-            propertyName: 'type',
+        propertyValidators: {
+          type: {
             type: 'string',
             required: true
           },
-          {
-            propertyName: 'myProp2',
+          myProp2: {
             type: 'datetime'
           }
-        ]
+        }
       }
     }
 
@@ -99,7 +95,6 @@ Or a functionally equivalent document definition file implemented as a function:
         remove: 'delete'
       };
       var typePropertyValidator = {
-        propertyName: 'type',
         type: 'string',
         required: true
       };
@@ -118,24 +113,22 @@ Or a functionally equivalent document definition file implemented as a function:
         myDocType1: {
           channels: sharedChannels,
           typeFilter: makeDocTypeFilter(doc, oldDoc, 'myDocType1'),
-          propertyValidators: [
-            typePropertyValidator,
-            {
-              propertyName: 'myProp1',
+          propertyValidators: {
+            type: typePropertyValidator,
+            myProp1: {
               type: 'integer'
             }
-          ]
+          }
         },
         myDocType2: {
           channels: sharedChannels,
           typeFilter: makeDocTypeFilter(doc, oldDoc, 'myDocType2'),
-          propertyValidators: [
-            typePropertyValidator,
-            {
-              propertyName: 'myProp2',
+          propertyValidators: {
+            type: typePropertyValidator,
+            myProp2: {
               type: 'datetime'
             }
-          ]
+          }
         }
       };
     }
@@ -188,21 +181,19 @@ Each document type is specified as an object with the following properties:
     }
 ```
 
-* `propertyValidators`: (required) An array of validators that specify the format of each of the document type's supported properties. Each property must declare a name and a type and, optionally, some number of parameters. For example:
+* `propertyValidators`: (required) An object/hash of validators that specify the format of each of the document type's supported properties. Each entry consists of a key that specifies the property name and a value that specifies the validation to perform on that property. Each element must declare a type and, optionally, some number of additional parameters. Any property that is not declared will be rejected by the sync function. An example:
 
 ```
-    propertyValidators: [
-      {
-        propertyName: 'myProp1',
+    propertyValidators: {
+      myProp1: {
         type: 'boolean',
         required: true
       },
-      {
-        propertyName: 'myProp2',
+      myProp2: {
         type: 'array',
         mustNotBeEmpty: true
       }
-    ]
+    }
 ```
 
 * `allowAttachments`: (optional) Whether to allow the addition of [file attachments](http://developer.couchbase.com/documentation/mobile/current/develop/references/sync-gateway/rest-api/document-public/put-db-doc-attachment/index.html) for the document type. Defaults to `false` to prevent malicious/misbehaving clients from polluting the bucket/database with unwanted files.
@@ -247,8 +238,7 @@ Validation for complex data types, which allow for nesting of child properties a
   * `arrayElementsValidator`: The validation that is applied to each element of the array. Any validation type, including those for complex data types, may be used. Undefined by default. An example:
 
 ```
-    {
-      propertyName: 'myArray1',
+    myArray1: {
       type: 'array',
       mustNotBeEmpty: true,
       arrayElementsValidator: {
@@ -259,24 +249,21 @@ Validation for complex data types, which allow for nesting of child properties a
 ```
 
 * `object`: An object that is able to declare which properties it supports so that unrecognized properties are rejected. Additional parameters:
-  * `propertyValidators`: An array of validators to be applied to the properties that are supported by the object. Any validation type, including those for complex data types, may be used for each property validator. Undefined by default. If defined, then any property that is not declared will be rejected by the sync function. An example:
+  * `propertyValidators`: An object/hash of validators to be applied to the properties that are supported by the object. Any validation type, including those for complex data types, may be used for each property validator. Undefined by default. If defined, then any property that is not declared will be rejected by the sync function. An example:
 
 ```
-    {
-      propertyName: 'myObj1',
+    myObj1: {
       type: 'object',
-      propertyValidators: [
-        {
-          propertyName: 'myProp1',
+      propertyValidators: {
+        myProp1: {
           type: 'date',
           immutable: true
         },
-        {
-          propertyName: 'myProp2',
+        myProp2: {
           type: 'integer',
           minimumValue: 1
         }
-      ]
+      }
     }
 ```
 
@@ -287,8 +274,7 @@ Validation for complex data types, which allow for nesting of child properties a
   * `hashtableValuesValidator`: The validation that is applied to each of the values in the object/hash. Undefined by default. Any validation type, including those for complex data types, may be used. An example:
 
 ```
-    {
-      propertyName: 'myHash1',
+    myHash1: {
       type: 'hashtable',
       hashtableKeysValidator: {
         mustNotBeEmpty: false,
@@ -297,12 +283,11 @@ Validation for complex data types, which allow for nesting of child properties a
       hashtableValuesValidator: {
         type: 'object',
         required: true,
-        propertyValidators: [
-          {
-            propertyName: 'mySubObjProp1',
+        propertyValidators: {
+          mySubObjProp1: {
             type: 'string'
           }
-        ]
+        }
       }
     }
 ```
@@ -314,13 +299,11 @@ Validation for complex data types, which allow for nesting of child properties a
 * `customValidation`: A function that accepts as parameters (1) the new document, (2) the old document that is being replaced/deleted (if any), (3) an object that contains metadata about the current item to validate and (4) a stack of the items (e.g. object properties, array elements, hashtable element values) that have gone through validation, where the last/top element contains metadata for the direct parent of the item currently being validated and the first/bottom element is metadata for the root (i.e. the document). Generally, custom validation should not throw exceptions; it's recommended to return an array/list of error descriptions so the sync function can compile a list of all validation errors that were encountered once full validation is complete. A return value of `null`, `undefined` or an empty array indicate there were no validation errors. An example:
 
 ```
-    propertyValidators: [
-      {
-        propertyName: 'myStringProp',
+    propertyValidators: {
+      myStringProp: {
         type: 'string'
       },
-      {
-        propertyName: 'myCustomProp',
+      myCustomProp: {
         type: 'integer',
         minimumValue: 1,
         maximumValue: 100,
@@ -350,5 +333,5 @@ Validation for complex data types, which allow for nesting of child properties a
           return validationErrors;
         }
       }
-    ]
+    }
 ```

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -137,9 +137,13 @@ function(doc, oldDoc) {
     var oldObjectValue = currentItemEntry.oldItemValue;
 
     var supportedProperties = [ ];
-    for (var validatorIndex = 0; validatorIndex < propertyValidators.length; validatorIndex++) {
-      var validator = propertyValidators[validatorIndex];
-      var propertyName = validator.propertyName;
+    for (var propertyName in propertyValidators) {
+      var validator = propertyValidators[propertyName];
+      if (isValueNullOrUndefined(validator) || isValueNullOrUndefined(validator.type)) {
+        // Skip over non-validator fields/properties
+        continue;
+      }
+
       var propertyValue = objectValue[propertyName];
 
       var oldPropertyValue;

--- a/samples/sample-sync-doc-definitions.js
+++ b/samples/sample-sync-doc-definitions.js
@@ -80,30 +80,26 @@ function() {
         return new RegExp('^biz\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
       allowAttachments: true,
-      propertyValidators: [
-        {
-          propertyName: 'businessLogoAttachment',
+      propertyValidators: {
+        businessLogoAttachment: {
           type: 'attachmentReference',
           required: false,
           maximumSize: 2097152,
           supportedExtensions: [ 'png', 'gif', 'jpg', 'jpeg' ],
           supportedContentTypes: [ 'image/png', 'image/gif', 'image/jpeg' ]
         },
-        {
-          propertyName: 'defaultInvoiceTemplate',
+        defaultInvoiceTemplate: {
           type: 'object',
           required: false,
-          propertyValidators: [
-            {
-              propertyName: 'templateId',
+          propertyValidators: {
+            templateId: {
               type: 'string',
               required: false,
               mustNotBeEmpty: true
             }
-          ],
+          },
         },
-        {
-          propertyName: 'paymentProcessors',
+        paymentProcessors: {
           type: 'array',
           required: false,
           arrayElementsValidator: {
@@ -111,7 +107,7 @@ function() {
             mustNotBeEmpty: true
           }
         }
-      ]
+      }
     },
 
     notification: {
@@ -119,75 +115,65 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notification\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
-      propertyValidators: [
-        {
-          propertyName: 'sender',
+      propertyValidators: {
+        sender: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true,
           immutable: true
         },
-        {
-          propertyName: 'type',
+        type: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true,
           immutable: true
         },
-        {
-          propertyName: 'subject',
+        subject: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true,
           immutable: true
         },
-        {
-          propertyName: 'message',
+        message: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true,
           immutable: true
         },
-        {
-          propertyName: 'createdAt',
+        createdAt: {
           type: 'datetime',
           required: true,
           immutable: true
         },
-        {
-          propertyName: 'firstReadAt',
+        firstReadAt: {
           type: 'datetime'
         },
-        {
-          propertyName: 'siteName',
+        siteName: {
           type: 'string',
           mustNotBeEmpty: true,
           immutable: true
         },
-        {
-          propertyName: 'actions',
+        actions: {
           type: 'array',
           immutable: true,
           arrayElementsValidator: {
             type: 'object',
             required: true,
-            propertyValidators: [
-              {
-                propertyName: 'url',
+            propertyValidators: {
+              url: {
                 type: 'string',
                 required: true,
                 mustNotBeEmpty: true
               },
-              {
-                propertyName: 'label',
+              label: {
                 type: 'string',
                 required: true,
                 mustNotBeEmpty: true
               }
-            ]
+            }
           }
         }
-      ]
+      }
     },
 
     notificationsConfig: {
@@ -195,9 +181,8 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notificationsConfig$').test(doc._id);
       },
-      propertyValidators: [
-        {
-          propertyName: 'notificationTypes',
+      propertyValidators: {
+        notificationTypes: {
           type: 'hashtable',
           hashtableKeysValidator: {
             type: 'string',
@@ -207,27 +192,25 @@ function() {
           hashtableValuesValidator: {
             type: 'object',
             required: true,
-            propertyValidators: [
-              {
-                propertyName: 'enabledTransports',
+            propertyValidators: {
+              enabledTransports: {
                 type: 'array',
                 arrayElementsValidator: {
                   type: 'object',
                   required: true,
-                  propertyValidators: [
-                    {
-                      propertyName: 'transportId',
+                  propertyValidators: {
+                    transportId: {
                       type: 'string',
                       required: true,
                       mustNotBeEmpty: true
                     }
-                  ]
+                  }
                 }
               }
-            ]
+            }
           }
         }
-      ]
+      }
     },
 
     notificationsReference: {
@@ -235,9 +218,8 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notifications$').test(doc._id);
       },
-      propertyValidators: [
-        {
-          propertyName: 'allNotificationIds',
+      propertyValidators: {
+        allNotificationIds: {
           type: 'array',
           required: false,
           arrayElementsValidator: {
@@ -245,8 +227,7 @@ function() {
             mustNotBeEmpty: true
           }
         },
-        {
-          propertyName: 'unreadNotificationIds',
+        unreadNotificationIds: {
           type: 'array',
           required: false,
           arrayElementsValidator: {
@@ -254,7 +235,7 @@ function() {
             mustNotBeEmpty: true
           }
         }
-      ]
+      }
     },
 
     notificationTransport: {
@@ -262,20 +243,18 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notificationTransport\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
-      propertyValidators: [
-        {
-          propertyName: 'type',
+      propertyValidators: {
+        type: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true
         },
-        {
-          propertyName: 'recipient',
+        recipient: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true
         }
-      ]
+      }
     },
 
     notificationTransportProcessingSummary: {
@@ -288,23 +267,20 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notification\\.[A-Za-z0-9_-]+\\.processedTransport\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
-      propertyValidators: [
-        {
-          propertyName: 'processedBy',
+      propertyValidators: {
+        processedBy: {
           type: 'string',
           immutable: true
         },
-        {
-          propertyName: 'processedAt',
+        processedAt: {
           type: 'datetime',
           required: true,
           immutable: true
         },
-        {
-          propertyName: 'sentAt',
+        sentAt: {
           type: 'datetime'
         }
-      ]
+      }
     },
 
     paymentAttempt: {
@@ -312,61 +288,51 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return new RegExp('^paymentAttempt\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
-      propertyValidators: [
-        {
-          propertyName: 'businessId',
+      propertyValidators: {
+        businessId: {
           type: 'integer',
           minimumValue: 1,
           customValidation: validateBusinessIdProperty
         },
-        {
-          propertyName: 'invoiceRecordId',
+        invoiceRecordId: {
           type: 'integer',
           required: true,
           minimumValue: 1
         },
-        {
-          propertyName: 'paymentRequisitionId',
+        paymentRequisitionId: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true
         },
-        {
-          propertyName: 'paymentAttemptSpreedlyToken',
+        paymentAttemptSpreedlyToken: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true,
         },
-        {
-          propertyName: 'date',
+        date: {
           type: 'date',
           required: true
         },
-        {
-          propertyName: 'internalPaymentRecordId',
+        internalPaymentRecordId: {
           type: 'integer',
           minimumValue: 1
         },
-        {
-          propertyName: 'gatewayTransactionId',
+        gatewayTransactionId: {
           type: 'string',
           mustNotBeEmpty: true
         },
-        {
-          propertyName: 'gatewayMessage',
+        gatewayMessage: {
           type: 'string'
         },
-        {
-          propertyName: 'totalAmountPaid',
+        totalAmountPaid: {
           type: 'integer',
           minimumValue: 1
         },
-        {
-          propertyName: 'totalAmountPaidFormatted',
+        totalAmountPaidFormatted: {
           type: 'string',
           mustNotBeEmpty: true
         }
-      ]
+      }
     },
 
     paymentProcessorDefinition: {
@@ -374,38 +340,33 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('paymentProcessor\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
-      propertyValidators: [
-        {
-          propertyName: 'provider',
+      propertyValidators: {
+        provider: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true
         },
-        {
-          propertyName: 'spreedlyGatewayToken',
+        spreedlyGatewayToken: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true
         },
-        {
-          propertyName: 'accountId',
+        accountId: {
           type: 'integer',
           required: true,
           minimumValue: 1
         },
-        {
-          propertyName: 'displayName',
+        displayName: {
           type: 'string'
         },
-        {
-          propertyName: 'supportedCurrencyCodes',
+        supportedCurrencyCodes: {
           type: 'array',
           arrayElementsValidator: {
             type: 'string',
             regexPattern: iso4217CurrencyCodeRegex
           }
         }
-      ]
+      }
     },
 
     paymentRequisition: {
@@ -413,33 +374,28 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return new RegExp('^paymentRequisition\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
-      propertyValidators: [
-        {
-          propertyName: 'invoiceRecordId',
+      propertyValidators: {
+        invoiceRecordId: {
           type: 'integer',
           required: true,
           minimumValue: 1
         },
-        {
-          propertyName: 'businessId',
+        businessId: {
           type: 'integer',
           minimumValue: 1,
           customValidation: validateBusinessIdProperty
         },
-        {
-          propertyName: 'issuedAt',
+        issuedAt: {
           type: 'datetime'
         },
-        {
-          propertyName: 'issuedByUserId',
+        issuedByUserId: {
           type: 'integer',
           minimumValue: 1
         },
-        {
-          propertyName: 'invoiceRecipients',
+        invoiceRecipients: {
           type: 'string'
         }
-      ]
+      }
     },
 
     paymentRequisitionsReference: {
@@ -447,15 +403,13 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('invoice\\.[A-Za-z0-9_-]+.paymentRequisitions$').test(doc._id);
       },
-      propertyValidators: [
-        {
-          propertyName: 'paymentProcessorId',
+      propertyValidators: {
+        paymentProcessorId: {
           type: 'string',
           required: true,
           mustNotBeEmpty: true
         },
-        {
-          propertyName: 'paymentRequisitionIds',
+        paymentRequisitionIds: {
           type: 'array',
           required: true,
           mustNotBeEmpty: true,
@@ -464,15 +418,14 @@ function() {
             mustNotBeEmpty: true
           }
         },
-        {
-          propertyName: 'paymentAttemptIds',
+        paymentAttemptIds: {
           type: 'array',
           arrayElementsValidator: {
             type: 'string',
             mustNotBeEmpty: true
           }
         }
-      ]
+      }
     }
   };
 }

--- a/test/resources/array-doc-definitions.js
+++ b/test/resources/array-doc-definitions.js
@@ -9,9 +9,8 @@
     typeFilter: function(doc) {
       return doc._id === 'arrayDoc';
     },
-    propertyValidators: [
-      {
-        propertyName: 'lengthValidationProp',
+    propertyValidators: {
+      lengthValidationProp: {
         type: 'array',
         minimumLength: 2,
         maximumLength: 2,
@@ -19,6 +18,6 @@
           type: 'string'
         }
       }
-    ]
+    }
   }
 }

--- a/test/resources/date-doc-definitions.js
+++ b/test/resources/date-doc-definitions.js
@@ -9,13 +9,12 @@
     typeFilter: function(doc) {
       return doc._id === 'dateDoc';
     },
-    propertyValidators: [
-      {
-        propertyName: 'rangeValidationProp',
+    propertyValidators: {
+      rangeValidationProp: {
         type: 'date',
         minimumValue: '2016-06-23',
         maximumValue: '2016-06-23'
       }
-    ]
+    }
   }
 }

--- a/test/resources/datetime-doc-definitions.js
+++ b/test/resources/datetime-doc-definitions.js
@@ -9,19 +9,17 @@
     typeFilter: function(doc) {
       return doc._id === 'datetimeDoc';
     },
-    propertyValidators: [
-      {
-        propertyName: 'rangeValidationAsDatetimesProp',
+    propertyValidators: {
+      rangeValidationAsDatetimesProp: {
         type: 'datetime',
         minimumValue: '2016-06-23T21:52:17.123-08:00',
         maximumValue: '2016-06-24T05:52:17.123Z'  // This is the same date and time, just in UTC
       },
-      {
-        propertyName: 'rangeValidationAsDatesOnlyProp',
+      rangeValidationAsDatesOnlyProp: {
         type: 'datetime',
         minimumValue: '2016-06-24',
         maximumValue: '2016-06-24'
       }
-    ]
+    }
   }
 }

--- a/test/resources/immutable-docs-doc-definitions.js
+++ b/test/resources/immutable-docs-doc-definitions.js
@@ -9,12 +9,11 @@
     typeFilter: function(doc) {
       return doc._id === 'immutableDoc';
     },
-    propertyValidators: [
-      {
-        propertyName: 'stringProp',
+    propertyValidators: {
+      stringProp: {
         type: 'string'
       }
-    ],
+    },
     immutable: true,
     allowAttachments: true
   }

--- a/test/resources/immutable-items-doc-definitions.js
+++ b/test/resources/immutable-items-doc-definitions.js
@@ -9,22 +9,19 @@
     typeFilter: function(doc) {
       return doc._id === 'immutableItemsDoc';
     },
-    propertyValidators: [
-      {
-        propertyName: 'immutableArrayProp',
+    propertyValidators: {
+      immutableArrayProp: {
         type: 'array',
         immutable: true
       },
-      {
-        propertyName: 'immutableObjectProp',
+      immutableObjectProp: {
         type: 'object',
         immutable: true
       },
-      {
-        propertyName: 'immutableHashtableProp',
+      immutableHashtableProp: {
         type: 'hashtable',
         immutable: true
       }
-    ]
+    }
   }
 }

--- a/test/resources/string-doc-definitions.js
+++ b/test/resources/string-doc-definitions.js
@@ -9,13 +9,12 @@
     typeFilter: function(doc) {
       return doc._id === 'stringDoc';
     },
-    propertyValidators: [
-      {
-        propertyName: 'lengthValidationProp',
+    propertyValidators: {
+      lengthValidationProp: {
         type: 'string',
         minimumLength: 3,
         maximumLength: 3
       }
-    ]
+    }
   }
 }


### PR DESCRIPTION
This is a more natural and concise way to define property validators since each can be thought of as an entry that is uniquely identified by its property name (just like properties in an object/hashtable). Since it is a breaking change, the package version will be bumped up from 0.1.x to 0.2.x.