### PR TITLE
Restrict versions of npm dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.13",
   "dependencies": {},
   "devDependencies": {
-    "expect.js": "*",
-    "mocha": "*",
-    "simple-mock": "*"
+    "expect.js": "^0.3.1",
+    "mocha": "^2.5.3",
+    "simple-mock": "^0.7.0"
   },
   "scripts": {
     "test": "etc/prepare-tests.sh && node_modules/.bin/mocha",


### PR DESCRIPTION
Specify caret ranges for each of the npm dev dependencies to protect against automatic upgrades with breaking changes.