### PR TITLE
Use JSHint to check for lint in generated sync functions

### DIFF
--- a/etc/prepare-tests.sh
+++ b/etc/prepare-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 cd "$(dirname "$0")"/.. || exit 1
 
@@ -22,3 +22,6 @@ for docDefinitionPath in "$definitionsDir"/*-doc-definitions.js; do
 
   ./make-sync-function "$docDefinitionPath" "$outputFile"
 done
+
+echo "\nLinting generated sync functions with JSHint"
+node_modules/jshint/bin/jshint "$outputDir"/*.js

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {},
   "devDependencies": {
     "expect.js": "^0.3.1",
+    "jshint": "^2.9.2",
     "mocha": "^2.5.3",
     "simple-mock": "^0.7.0"
   },


### PR DESCRIPTION
When running the project's specs (e.g. `npm test`), also execute JSHint on the generated sync functions to identify lint and fail the operation if any is found.