### PR TITLE
Ensure test helper handles channel access with only one channel

### DIFF
--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -18,14 +18,20 @@ function init(syncFunctionPath) {
 
 function verifyChannelAccess(expectedChannels) {
   expect(requireAccess.callCount).to.equal(1);
+
+  if (!(expectedChannels instanceof Array)) {
+    expectedChannels = [ expectedChannels ];
+  }
+
   var actualChannels = requireAccess.calls[0].arg;
-  if (expectedChannels instanceof Array && actualChannels instanceof Array) {
-    expect(actualChannels.length).to.equal(expectedChannels.length);
-    for (var channelIndex = 0; channelIndex < expectedChannels.length; channelIndex++) {
-      expect(actualChannels).to.contain(expectedChannels[channelIndex]);
-    }
-  } else {
-    expect(actualChannels).to.equal(expectedChannels);
+  if (!(actualChannels instanceof Array)) {
+    actualChannels = [ actualChannels ];
+  }
+
+  expect(actualChannels.length).to.equal(expectedChannels.length);
+
+  for (var channelIndex = 0; channelIndex < expectedChannels.length; channelIndex++) {
+    expect(actualChannels).to.contain(expectedChannels[channelIndex]);
   }
 }
 

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -1,6 +1,6 @@
-const expect = require('expect.js');
-const simple = require('simple-mock');
-const fs = require('fs');
+var expect = require('expect.js');
+var simple = require('simple-mock');
+var fs = require('fs');
 
 // Placeholders for stubbing built-in Sync Gateway support functions.
 // More info: http://developer.couchbase.com/mobile/develop/guides/sync-gateway/sync-function-api-guide/index.html


### PR DESCRIPTION
Because each of a document definition's expected channels can be defined as either an array of strings or a string, the test helper now performs some normalization to ensure that tests don't need to care whether the access mode's channel was declared as an array with one element or as a string.