### PR TITLE
Issue #36: Non-zero exit status on sync function generator failure

### DIFF
--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -555,7 +555,6 @@ function synctos(doc, oldDoc) {
     docDefinitions = rawDocDefinitions;
   }
 
-
   function getDocumentType(doc, oldDoc) {
     var actualOldDoc = (oldDoc && !(oldDoc._deleted)) ? oldDoc : null;
 

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -139,7 +139,6 @@ function verifyUnknownDocumentType(doc, oldDoc) {
     expect(ex.forbidden).to.equal('Unknown document type');
   });
 
-
   expect(requireAccess.callCount).to.be(0);
   expect(channel.callCount).to.be(0);
 }

--- a/make-sync-function
+++ b/make-sync-function
@@ -41,8 +41,11 @@ try {
   // which it will be injected
   syncDocDefn = syncDocDefn.trim().replace(/(?:\r\n)|(?:\r)|(?:\n)/g, function() { return '\n  '; });
 } catch (ex) {
-  console.log('Unable to read the sync document definitions file: ' + ex);
-
+  if (ex.code === 'ENOENT') {
+    console.log('ERROR: Sync document definitions file does not exist');
+  } else {
+    console.log('ERROR: Unable to read the sync document definitions file: ' + ex);
+  }
   process.exit(errorStatus);
 }
 
@@ -50,7 +53,7 @@ var syncFuncTemplate;
 try {
   syncFuncTemplate = fs.readFileSync(scriptDir + '/etc/sync-function-template.js', 'utf8');
 } catch (ex) {
-  console.log('Unable to read the sync function template file: ' + ex);
+  console.log('ERROR: Unable to read the sync function template file: ' + ex);
 
   process.exit(errorStatus);
 }
@@ -60,7 +63,7 @@ var syncFunc = syncFuncTemplate.replace('%SYNC_DOCUMENT_DEFINITIONS%', function(
 try {
   fs.writeFileSync(outputFilename, syncFunc, 'utf8');
 } catch (ex) {
-  console.log('Unable to write the sync function to the output file: ' + ex);
+  console.log('ERROR: Unable to write the sync function to the output file: ' + ex);
 
   process.exit(errorStatus);
 }

--- a/make-sync-function
+++ b/make-sync-function
@@ -4,7 +4,6 @@ var fs = require('fs');
 var path = require('path');
 
 var errorStatus = 1;
-var successStatus = 0;
 
 var scriptDir = path.dirname(process.argv[1]);
 
@@ -28,7 +27,7 @@ if (process.argv.length !== 4) {
 
   console.log('See the README for more information.');
 
-  return errorStatus;
+  process.exit(errorStatus);
 }
 
 syncDocDefnFilename = process.argv[2];
@@ -44,7 +43,7 @@ try {
 } catch (ex) {
   console.log('Unable to read the sync document definitions file: ' + ex);
 
-  return errorStatus;
+  process.exit(errorStatus);
 }
 
 var syncFuncTemplate;
@@ -53,7 +52,7 @@ try {
 } catch (ex) {
   console.log('Unable to read the sync function template file: ' + ex);
 
-  return errorStatus;
+  process.exit(errorStatus);
 }
 
 var syncFunc = syncFuncTemplate.replace('%SYNC_DOCUMENT_DEFINITIONS%', function() { return syncDocDefn; });
@@ -63,9 +62,7 @@ try {
 } catch (ex) {
   console.log('Unable to write the sync function to the output file: ' + ex);
 
-  return errorStatus;
+  process.exit(errorStatus);
 }
 
 console.log('Sync function written to ' + outputFilename);
-
-return successStatus;


### PR DESCRIPTION
The make-sync-function script now returns an exit status of 1 if an error was encountered when generating a sync function.

Resolves issue #36.