### PR TITLE
Issue #32: Option to exclude min/max values in range validation constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#29](https://github.com/Kashoo/synctos/issues/29): Parameter to indicate that an item cannot be modified if it has a value
 - [#30](https://github.com/Kashoo/synctos/issues/30): Parameter to prevent documents from being replaced
 - [#31](https://github.com/Kashoo/synctos/issues/31): Parameter to prevent documents from being deleted
+- [#32](https://github.com/Kashoo/synctos/issues/32): Range validation parameters that exclude the minimum/maximum values
 
 ## [1.1.0] - 2016-07-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -233,18 +233,26 @@ Validation for simple data types:
   * `minimumLength`: The minimum number of characters (inclusive) allowed in the string. Undefined by default.
   * `maximumLength`: The maximum number of characters (inclusive) allowed in the string. Undefined by default.
 * `integer`: The value is a number with no fractional component. Additional parameters:
-  * `minimumValue`: The smallest (inclusive) value that is allowed. Undefined by default.
-  * `maximumValue`: The largest (inclusive) value that is allowed. Undefined by default.
+  * `minimumValue`: Reject values that are less than this. No restriction by default.
+  * `minimumValueExclusive`: Reject values that are less than or equal to this. No restriction by default.
+  * `maximumValue`: Reject values that are greater than this. No restriction by default.
+  * `maximumValueExclusive`: Reject values that are greater than or equal to this. No restriction by default.
 * `float`: The value is a number with an optional fractional component (i.e. it is either an integer or a floating point number). Additional parameters:
-  * `minimumValue`: The smallest (inclusive) value that is allowed. Undefined by default.
-  * `maximumValue`: The largest (inclusive) value that is allowed. Undefined by default.
+  * `minimumValue`: Reject values that are less than this. No restriction by default.
+  * `minimumValueExclusive`: Reject values that are less than or equal to this. No restriction by default.
+  * `maximumValue`: Reject values that are greater than this. No restriction by default.
+  * `maximumValueExclusive`: Reject values that are greater than or equal to this. No restriction by default.
 * `boolean`: The value is either `true` or `false`. No additional parameters.
 * `datetime`: The value is an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date string with optional time and time zone components (e.g. "2016-06-18T18:57:35.328-08:00"). Additional parameters:
-  * `minimumValue`: The earliest (inclusive) date/time that is allowed. If the value of this parameter or the property value to which it is to be applied are missing their time and time zone components, they will default to midnight UTC of the date in question. No restriction by default.
-  * `maximumValue`: The latest (inclusive) date/time that is allowed. If the value of this parameter or the property value to which it is to be applied are missing their time and time zone components, they will default to midnight UTC of the date in question. No restriction by default.
+  * `minimumValue`: Reject date/times that are less than this. If the value of this parameter or the property value to which it is to be applied are missing their time and time zone components, they will default to midnight UTC of the date in question. No restriction by default.
+  * `minimumValueExclusive`: Reject date/times that are less than or equal to this. If the value of this parameter or the property value to which it is to be applied are missing their time and time zone components, they will default to midnight UTC of the date in question. No restriction by default.
+  * `maximumValue`: Reject date/times that are greater than this. If the value of this parameter or the property value to which it is to be applied are missing their time and time zone components, they will default to midnight UTC of the date in question. No restriction by default.
+  * `maximumValueExclusive`: Reject date/times that are greater than or equal to this. If the value of this parameter or the property value to which it is to be applied are missing their time and time zone components, they will default to midnight UTC of the date in question. No restriction by default.
 * `date`: The value is an ISO 8601 date string _without_ time and time zone components (e.g. "2016-06-18"). Additional parameters:
-  * `minimumValue`: The earliest (inclusive) date that is allowed. No restriction by default.
-  * `maximumValue`: The latest (inclusive) date that is allowed. No restriction by default.
+  * `minimumValue`: Reject dates that are less than this. No restriction by default.
+  * `minimumValueExclusive`: Reject dates that are less than or equal to this. No restriction by default.
+  * `maximumValue`: Reject dates that are greater than this. No restriction by default.
+  * `maximumValueExclusive`: Reject dates that are greater than or equal to this. No restriction by default.
 * `attachmentReference`: The value is the name of one of the document's file attachments. Note that, because the addition of an attachment is often a separate Sync Gateway API operation from the creation/replacement of the associated document, this validation type is only applied if the attachment is actually present in the document. However, since the sync function is run twice in such situations (i.e. once when the document is created/replaced and once when the attachment is created/replaced), the validation will be performed eventually. Additional parameters:
   * `supportedExtensions`: An array of case-insensitive file extensions that are allowed for the attachment's filename (e.g. "txt", "jpg", "pdf"). No restriction by default.
   * `supportedContentTypes`: An array of content/MIME types that are allowed for the attachment's contents (e.g. "image/png", "text/html", "application/xml"). No restriction by default.

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -235,14 +235,40 @@ function synctos(doc, oldDoc) {
         var minComparator = function(left, right) {
           return left < right;
         };
-        validateRangeConstraint(validator.minimumValue, validator.type, itemStack, minComparator, 'less', validationErrors);
+        validateRangeConstraint(validator.minimumValue, validator.type, itemStack, minComparator, 'less than', validationErrors);
+      }
+
+      if (!isValueNullOrUndefined(validator.minimumValueExclusive)) {
+        var minExclusiveComparator = function(left, right) {
+          return left <= right;
+        };
+        validateRangeConstraint(
+          validator.minimumValueExclusive,
+          validator.type,
+          itemStack,
+          minExclusiveComparator,
+          'less than or equal to',
+          validationErrors);
       }
 
       if (!isValueNullOrUndefined(validator.maximumValue)) {
         var maxComparator = function(left, right) {
           return left > right;
         };
-        validateRangeConstraint(validator.maximumValue, validator.type, itemStack, maxComparator, 'greater', validationErrors);
+        validateRangeConstraint(validator.maximumValue, validator.type, itemStack, maxComparator, 'greater than', validationErrors);
+      }
+
+      if (!isValueNullOrUndefined(validator.maximumValueExclusive)) {
+        var maxExclusiveComparator = function(left, right) {
+          return left >= right;
+        };
+        validateRangeConstraint(
+          validator.maximumValueExclusive,
+          validator.type,
+          itemStack,
+          maxExclusiveComparator,
+          'greater than or equal to',
+          validationErrors);
       }
 
       if (!isValueNullOrUndefined(validator.minimumLength) && itemValue.length < validator.minimumLength) {
@@ -415,7 +441,7 @@ function synctos(doc, oldDoc) {
     return true;
   }
 
-  function validateRangeConstraint(rangeLimit, validationType, itemStack, comparator, violationType, validationErrors) {
+  function validateRangeConstraint(rangeLimit, validationType, itemStack, comparator, violationDescription, validationErrors) {
     var itemValue = itemStack[itemStack.length - 1].itemValue;
     var outOfRange;
     if (validationType === 'datetime') {
@@ -431,7 +457,7 @@ function synctos(doc, oldDoc) {
     }
 
     if (outOfRange) {
-      validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be ' + violationType + ' than ' + rangeLimit);
+      validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be ' + violationDescription + ' ' + rangeLimit);
     }
   }
 

--- a/etc/validation-error-message-formatter.js
+++ b/etc/validation-error-message-formatter.js
@@ -44,12 +44,32 @@ exports.maximumValueViolation = function(itemPath, maxValue) {
   return 'item "' + itemPath + '" must not be greater than ' + maxValue;
 };
 
+/**
+ * Formats a message for the error that occurs when a value is greater than or equal to the maximum allowed.
+ *
+ * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "objectProp.dateProp")
+ * @param {(float|integer|string)} maxValue The maximum value that is allowed
+ */
+exports.maximumValueExclusiveViolation = function(itemPath, maxValue) {
+  return 'item "' + itemPath + '" must not be greater than or equal to ' + maxValue;
+};
+
 exports.minimumLengthViolation = function(itemPath, minLength) {
   return 'length of item "' + itemPath + '" must not be less than ' + minLength;
 };
 
+/**
+ * Formats a message for the error that occurs when a value is less than or equal to the minimum allowed.
+ *
+ * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "arrayProp[0].datetimeProp")
+ * @param {(float|integer|string)} minValue The minimum value that is allowed
+ */
 exports.minimumValueViolation = function(itemPath, minValue) {
   return 'item "' + itemPath + '" must not be less than ' + minValue;
+};
+
+exports.minimumValueExclusiveViolation = function(itemPath, minValue) {
+  return 'item "' + itemPath + '" must not be less than or equal to ' + minValue;
 };
 
 exports.mustNotBeEmptyViolation = function(itemPath) {

--- a/test/date-spec.js
+++ b/test/date-spec.js
@@ -43,33 +43,4 @@ describe('Date validation type', function() {
       testHelper.verifyDocumentNotCreated(doc, 'dateDoc', errorFormatter.dateFormatInvalid('formatValidationProp'));
     });
   });
-
-  describe('range validation', function() {
-    it('can create a doc with a date that is within the minimum and maximum values', function() {
-      var doc = {
-        _id: 'dateDoc',
-        rangeValidationProp: '2016-06-23'
-      };
-
-      testHelper.verifyDocumentCreated(doc);
-    });
-
-    it('cannot create a doc with a date that is before the minimum value', function() {
-      var doc = {
-        _id: 'dateDoc',
-        rangeValidationProp: '2016-06-22'
-      };
-
-      testHelper.verifyDocumentNotCreated(doc, 'dateDoc', errorFormatter.minimumValueViolation('rangeValidationProp', '2016-06-23'));
-    });
-
-    it('cannot create a doc with a date that is after than the maximum value', function() {
-      var doc = {
-        _id: 'dateDoc',
-        rangeValidationProp: '2016-06-24'
-      };
-
-      testHelper.verifyDocumentNotCreated(doc, 'dateDoc', errorFormatter.maximumValueViolation('rangeValidationProp', '2016-06-23'));
-    });
-  });
 });

--- a/test/range-constraint-spec.js
+++ b/test/range-constraint-spec.js
@@ -1,4 +1,5 @@
 var testHelper = require('../etc/test-helper.js');
+var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('Range constraints:', function() {
   beforeEach(function() {
@@ -48,7 +49,7 @@ describe('Range constraints:', function() {
         integerProp: -6
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "integerProp" must not be less than -5');
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', errorFormatter.minimumValueViolation('integerProp', -5));
     });
 
     it('reject an integer that is above the maximum constraint', function() {
@@ -57,7 +58,7 @@ describe('Range constraints:', function() {
         integerProp: -4
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "integerProp" must not be greater than -5');
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', errorFormatter.maximumValueViolation('integerProp', -5));
     });
 
     it('reject a floating point number that is below the minimum constraint', function() {
@@ -66,7 +67,7 @@ describe('Range constraints:', function() {
         floatProp: 7.499
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "floatProp" must not be less than 7.5');
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', errorFormatter.minimumValueViolation('floatProp', 7.5));
     });
 
     it('reject a floating point number that is above the maximum constraint', function() {
@@ -75,7 +76,7 @@ describe('Range constraints:', function() {
         floatProp: 7.501
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "floatProp" must not be greater than 7.5');
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', errorFormatter.maximumValueViolation('floatProp', 7.5));
     });
 
     it('reject a datetime that is below the minimum constraint', function() {
@@ -84,7 +85,7 @@ describe('Range constraints:', function() {
         datetimeProp: '2016-07-19T19:24:38.919-0700'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "datetimeProp" must not be less than 2016-07-19T19:24:38.920-0700');
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', errorFormatter.minimumValueViolation('datetimeProp', '2016-07-19T19:24:38.920-0700'));
     });
 
     it('reject a datetime that is above the maximum constraint', function() {
@@ -93,7 +94,7 @@ describe('Range constraints:', function() {
         datetimeProp: '2016-07-19T19:24:38.921-0700'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "datetimeProp" must not be greater than 2016-07-19T19:24:38.920-0700');
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', errorFormatter.maximumValueViolation('datetimeProp', '2016-07-19T19:24:38.920-0700'));
     });
 
     it('reject a date that is below the minimum constraint', function() {
@@ -102,7 +103,7 @@ describe('Range constraints:', function() {
         dateProp: '2016-07-18'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "dateProp" must not be less than 2016-07-19');
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', errorFormatter.minimumValueViolation('dateProp', '2016-07-19'));
     });
 
     it('reject a date that is above the maximum constraint', function() {
@@ -111,7 +112,7 @@ describe('Range constraints:', function() {
         dateProp: '2016-07-20'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "dateProp" must not be greater than 2016-07-19');
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', errorFormatter.maximumValueViolation('dateProp', '2016-07-19'));
     });
   });
 
@@ -158,7 +159,7 @@ describe('Range constraints:', function() {
         integerProp: 51
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "integerProp" must not be less than or equal to 51');
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', errorFormatter.minimumValueExclusiveViolation('integerProp', 51));
     });
 
     it('reject an integer that is less than the minimum constraint', function() {
@@ -167,7 +168,7 @@ describe('Range constraints:', function() {
         integerProp: 50
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "integerProp" must not be less than or equal to 51');
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', errorFormatter.minimumValueExclusiveViolation('integerProp', 51));
     });
 
     it('reject an integer that is equal to the maximum constraint', function() {
@@ -176,7 +177,7 @@ describe('Range constraints:', function() {
         integerProp: 53
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "integerProp" must not be greater than or equal to 53');
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', errorFormatter.maximumValueExclusiveViolation('integerProp', 53));
     });
 
     it('reject an integer that is greater than the maximum constraint', function() {
@@ -185,7 +186,7 @@ describe('Range constraints:', function() {
         integerProp: 54
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "integerProp" must not be greater than or equal to 53');
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', errorFormatter.maximumValueExclusiveViolation('integerProp', 53));
     });
 
     it('reject a floating point number that is equal to the minimum constraint', function() {
@@ -194,7 +195,7 @@ describe('Range constraints:', function() {
         floatProp: -14.001
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "floatProp" must not be less than or equal to -14.001');
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', errorFormatter.minimumValueExclusiveViolation('floatProp', -14.001));
     });
 
     it('reject a floating point number that is less than the minimum constraint', function() {
@@ -203,7 +204,7 @@ describe('Range constraints:', function() {
         floatProp: -15
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "floatProp" must not be less than or equal to -14.001');
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', errorFormatter.minimumValueExclusiveViolation('floatProp', -14.001));
     });
 
     it('reject a floating point number that is equal to the maximum constraint', function() {
@@ -212,7 +213,7 @@ describe('Range constraints:', function() {
         floatProp: -13.999
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "floatProp" must not be greater than or equal to -13.999');
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', errorFormatter.maximumValueExclusiveViolation('floatProp', -13.999));
     });
 
     it('reject a floating point number that is greater than the maximum constraint', function() {
@@ -221,7 +222,7 @@ describe('Range constraints:', function() {
         floatProp: -13
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "floatProp" must not be greater than or equal to -13.999');
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', errorFormatter.maximumValueExclusiveViolation('floatProp', -13.999));
     });
 
     it('reject a datetime that is equal to the minimum constraint', function() {
@@ -230,7 +231,10 @@ describe('Range constraints:', function() {
         datetimeProp: '2016-07-19T19:24:38.919-0700'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "datetimeProp" must not be less than or equal to 2016-07-19T19:24:38.919-0700');
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'exclusiveRangeDocType',
+        errorFormatter.minimumValueExclusiveViolation('datetimeProp', '2016-07-19T19:24:38.919-0700'));
     });
 
     it('reject a datetime that is less than the minimum constraint', function() {
@@ -239,7 +243,10 @@ describe('Range constraints:', function() {
         datetimeProp: '2016-07-19T19:24:38.918-0700'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "datetimeProp" must not be less than or equal to 2016-07-19T19:24:38.919-0700');
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'exclusiveRangeDocType',
+        errorFormatter.minimumValueExclusiveViolation('datetimeProp', '2016-07-19T19:24:38.919-0700'));
     });
 
     it('reject a datetime that is equal to the maximum constraint', function() {
@@ -248,7 +255,10 @@ describe('Range constraints:', function() {
         datetimeProp: '2016-07-19T19:24:38.921-0700'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "datetimeProp" must not be greater than or equal to 2016-07-19T19:24:38.921-0700');
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'exclusiveRangeDocType',
+        errorFormatter.maximumValueExclusiveViolation('datetimeProp', '2016-07-19T19:24:38.921-0700'));
     });
 
     it('reject a datetime that is greater than the maximum constraint', function() {
@@ -257,7 +267,10 @@ describe('Range constraints:', function() {
         datetimeProp: '2016-07-19T19:24:38.922-0700'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "datetimeProp" must not be greater than or equal to 2016-07-19T19:24:38.921-0700');
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'exclusiveRangeDocType',
+        errorFormatter.maximumValueExclusiveViolation('datetimeProp', '2016-07-19T19:24:38.921-0700'));
     });
 
     it('reject a date that is equal to the minimum constraint', function() {
@@ -266,7 +279,10 @@ describe('Range constraints:', function() {
         dateProp: '2016-07-18'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "dateProp" must not be less than or equal to 2016-07-18');
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'exclusiveRangeDocType',
+        errorFormatter.minimumValueExclusiveViolation('dateProp', '2016-07-18'));
     });
 
     it('reject a date that is less than the minimum constraint', function() {
@@ -275,7 +291,10 @@ describe('Range constraints:', function() {
         dateProp: '2016-07-17'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "dateProp" must not be less than or equal to 2016-07-18');
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'exclusiveRangeDocType',
+        errorFormatter.minimumValueExclusiveViolation('dateProp', '2016-07-18'));
     });
 
     it('reject a date that is equal to the maximum constraint', function() {
@@ -284,7 +303,10 @@ describe('Range constraints:', function() {
         dateProp: '2016-07-20'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "dateProp" must not be greater than or equal to 2016-07-20');
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'exclusiveRangeDocType',
+        errorFormatter.maximumValueExclusiveViolation('dateProp', '2016-07-20'));
     });
 
     it('reject a date that is greater than the maximum constraint', function() {
@@ -293,7 +315,10 @@ describe('Range constraints:', function() {
         dateProp: '2016-07-21'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "dateProp" must not be greater than or equal to 2016-07-20');
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'exclusiveRangeDocType',
+        errorFormatter.maximumValueExclusiveViolation('dateProp', '2016-07-20'));
     });
   });
 });

--- a/test/range-constraint-specs.js
+++ b/test/range-constraint-specs.js
@@ -1,0 +1,299 @@
+var testHelper = require('../etc/test-helper.js');
+
+describe('Range constraints:', function() {
+  beforeEach(function() {
+    testHelper.init('build/sync-functions/test-range-constraint-sync-function.js');
+  });
+
+  describe('inclusive ranges', function() {
+    it('allow an integer that matches the minimum and maximum constraints', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        integerProp: -5
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('allow a floating point number that matches the minimum and maximum constraints', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        floatProp: 7.5
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('allow a datetime that matches the minimum and maximum constraints', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        datetimeProp: '2016-07-19T19:24:38.920-0700'
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('allow a date that matches the minimum and maximum constraints', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        dateProp: '2016-07-19'
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('reject an integer that is below the minimum constraint', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        integerProp: -6
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "integerProp" must not be less than -5');
+    });
+
+    it('reject an integer that is above the maximum constraint', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        integerProp: -4
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "integerProp" must not be greater than -5');
+    });
+
+    it('reject a floating point number that is below the minimum constraint', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        floatProp: 7.499
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "floatProp" must not be less than 7.5');
+    });
+
+    it('reject a floating point number that is above the maximum constraint', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        floatProp: 7.501
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "floatProp" must not be greater than 7.5');
+    });
+
+    it('reject a datetime that is below the minimum constraint', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        datetimeProp: '2016-07-19T19:24:38.919-0700'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "datetimeProp" must not be less than 2016-07-19T19:24:38.920-0700');
+    });
+
+    it('reject a datetime that is above the maximum constraint', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        datetimeProp: '2016-07-19T19:24:38.921-0700'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "datetimeProp" must not be greater than 2016-07-19T19:24:38.920-0700');
+    });
+
+    it('reject a date that is below the minimum constraint', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        dateProp: '2016-07-18'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "dateProp" must not be less than 2016-07-19');
+    });
+
+    it('reject a date that is above the maximum constraint', function() {
+      var doc = {
+        _id: 'inclusiveRangeDocType',
+        dateProp: '2016-07-20'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'inclusiveRangeDocType', 'item "dateProp" must not be greater than 2016-07-19');
+    });
+  });
+
+  describe('exclusive ranges', function() {
+    it('allow an integer that is within the minimum and maximum constraints', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        integerProp: 52
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('allow a floating point number that is within the minimum and maximum constraints', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        floatProp: -14
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('allow a datetime that is within the minimum and maximum constraints', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        datetimeProp: '2016-07-19T19:24:38.920-0700'
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('allow a date that is within the minimum and maximum constraints', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        dateProp: '2016-07-19'
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('reject an integer that is equal to the minimum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        integerProp: 51
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "integerProp" must not be less than or equal to 51');
+    });
+
+    it('reject an integer that is less than the minimum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        integerProp: 50
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "integerProp" must not be less than or equal to 51');
+    });
+
+    it('reject an integer that is equal to the maximum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        integerProp: 53
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "integerProp" must not be greater than or equal to 53');
+    });
+
+    it('reject an integer that is greater than the maximum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        integerProp: 54
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "integerProp" must not be greater than or equal to 53');
+    });
+
+    it('reject a floating point number that is equal to the minimum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        floatProp: -14.001
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "floatProp" must not be less than or equal to -14.001');
+    });
+
+    it('reject a floating point number that is less than the minimum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        floatProp: -15
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "floatProp" must not be less than or equal to -14.001');
+    });
+
+    it('reject a floating point number that is equal to the maximum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        floatProp: -13.999
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "floatProp" must not be greater than or equal to -13.999');
+    });
+
+    it('reject a floating point number that is greater than the maximum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        floatProp: -13
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "floatProp" must not be greater than or equal to -13.999');
+    });
+
+    it('reject a datetime that is equal to the minimum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        datetimeProp: '2016-07-19T19:24:38.919-0700'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "datetimeProp" must not be less than or equal to 2016-07-19T19:24:38.919-0700');
+    });
+
+    it('reject a datetime that is less than the minimum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        datetimeProp: '2016-07-19T19:24:38.918-0700'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "datetimeProp" must not be less than or equal to 2016-07-19T19:24:38.919-0700');
+    });
+
+    it('reject a datetime that is equal to the maximum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        datetimeProp: '2016-07-19T19:24:38.921-0700'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "datetimeProp" must not be greater than or equal to 2016-07-19T19:24:38.921-0700');
+    });
+
+    it('reject a datetime that is greater than the maximum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        datetimeProp: '2016-07-19T19:24:38.922-0700'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "datetimeProp" must not be greater than or equal to 2016-07-19T19:24:38.921-0700');
+    });
+
+    it('reject a date that is equal to the minimum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        dateProp: '2016-07-18'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "dateProp" must not be less than or equal to 2016-07-18');
+    });
+
+    it('reject a date that is less than the minimum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        dateProp: '2016-07-17'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "dateProp" must not be less than or equal to 2016-07-18');
+    });
+
+    it('reject a date that is equal to the maximum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        dateProp: '2016-07-20'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "dateProp" must not be greater than or equal to 2016-07-20');
+    });
+
+    it('reject a date that is greater than the maximum constraint', function() {
+      var doc = {
+        _id: 'exclusiveRangeDocType',
+        dateProp: '2016-07-21'
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'exclusiveRangeDocType', 'item "dateProp" must not be greater than or equal to 2016-07-20');
+    });
+  });
+});

--- a/test/resources/range-constraint-doc-definitions.js
+++ b/test/resources/range-constraint-doc-definitions.js
@@ -1,0 +1,58 @@
+{
+  inclusiveRangeDocType: {
+    channels: { write: 'write' },
+    typeFilter: function(doc) {
+      return doc._id === 'inclusiveRangeDocType';
+    },
+    propertyValidators: {
+      integerProp: {
+        type: 'integer',
+        minimumValue: -5,
+        maximumValue: -5
+      },
+      floatProp: {
+        type: 'float',
+        minimumValue: 7.5,
+        maximumValue: 7.5
+      },
+      datetimeProp: {
+        type: 'datetime',
+        minimumValue: '2016-07-19T19:24:38.920-0700',
+        maximumValue: '2016-07-19T19:24:38.920-0700'
+      },
+      dateProp: {
+        type: 'date',
+        minimumValue: '2016-07-19',
+        maximumValue: '2016-07-19'
+      }
+    }
+  },
+  exclusiveRangeDocType: {
+    channels: { write: 'write' },
+    typeFilter: function(doc) {
+      return doc._id === 'exclusiveRangeDocType';
+    },
+    propertyValidators: {
+      integerProp: {
+        type: 'integer',
+        minimumValueExclusive: 51,
+        maximumValueExclusive: 53
+      },
+      floatProp: {
+        type: 'float',
+        minimumValueExclusive: -14.001,
+        maximumValueExclusive: -13.999
+      },
+      datetimeProp: {
+        type: 'datetime',
+        minimumValueExclusive: '2016-07-19T19:24:38.919-0700',
+        maximumValueExclusive: '2016-07-19T19:24:38.921-0700'
+      },
+      dateProp: {
+        type: 'date',
+        minimumValueExclusive: '2016-07-18',
+        maximumValueExclusive: '2016-07-20'
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added new range validation constraints `minimumValueExclusive` and `maximumValueExclusive` for use with `integer`, `float`, `date` and `datetime` validation types. They are similar to `minimumValue` and `maximumValue`, respectively, except that they do not allow values that are equal to the specified range limit value.

Addresses issue #32.