### PR TITLE
Update change log for release of v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+Nothing yet
+
+## [1.2.0]
 ### Added
 - [#29](https://github.com/Kashoo/synctos/issues/29): Parameter to indicate that an item cannot be modified if it has a value
 - [#30](https://github.com/Kashoo/synctos/issues/30): Parameter to prevent documents from being replaced
@@ -20,5 +23,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [#36](https://github.com/Kashoo/synctos/issues/36): Does not return a non-zero exit status when sync function generation fails
 
-[Unreleased]: https://github.com/Kashoo/synctos/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/Kashoo/synctos/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/Kashoo/synctos/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Kashoo/synctos/compare/v1.0.0...v1.1.0


### PR DESCRIPTION
Switched the "Unreleased" section to "v1.2.0" in preparation for publishing to npm.