### PR TITLE
Issue #24: Allow assignment of channels to users and roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#28](https://github.com/Kashoo/synctos/issues/28): Parameter to allow unknown properties in a document or object
 - [#49](https://github.com/Kashoo/synctos/issues/49): Explicitly declare JSHint rules
+- [#24](https://github.com/Kashoo/synctos/issues/24): Support dynamic assignment of channels to roles and users
 
 ## [1.2.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -216,14 +216,17 @@ And an example of a more complex custom type filter:
     }
 ```
 
-* `accessAssignments`: (optional) Defines the channels to dynamically assign to users and/or roles when a document of the corresponding type is successfully created, replaced or deleted. It is specified as a list, where each entry is an object that defines `users`, `roles` and `channels` properties. The value of each property can be either a list of strings that specify the raw user/role/channel names or a function that returns the corresponding values as a list and accepts the following parameters: (1) the new document, (2) the old document that is being replaced/deleted (if any). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be true, so be sure to account for such cases. An example:
+* `accessAssignments`: (optional) Defines the channels to dynamically assign to users and/or roles when a document of the corresponding type is successfully created, replaced or deleted. It is specified as a list, where each entry is an object that defines `users`, `roles` and/or `channels` properties. The value of each property can be either a list of strings that specify the raw user/role/channel names or a function that returns the corresponding values as a list and accepts the following parameters: (1) the new document, (2) the old document that is being replaced/deleted (if any). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be true, so be sure to account for such cases. An example:
 
 ```
     accessAssignments: [
       {
         users: [ 'user1', 'user2' ],
+        channels: [ 'channel1' ]
+      },
+      {
         roles: [ 'role1', 'role2' ],
-        channels: [ 'channel1', 'channel2' ]
+        channels: [ 'channel2' ]
       },
       {
         users: function(doc, oldDoc) {

--- a/README.md
+++ b/README.md
@@ -216,6 +216,29 @@ And an example of a more complex custom type filter:
     }
 ```
 
+* `accessAssignments`: (optional) Defines the channels to dynamically assign to users and/or roles when a document of the corresponding type is successfully created, replaced or deleted. Specified as a list, where each entry is an object that defines `users`, `roles` and `channels` properties. The value of each property can be either a list of strings that specify the raw user/role/channel names or a function that returns the corresponding values as a list and accepts the following parameters: (1) the new document, (2) the old document that is being replaced/deleted (if any). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be true, so be sure to account for such cases. An example:
+
+```
+    accessAssignments: [
+      {
+        users: [ 'user1', 'user2' ],
+        roles: [ 'role1', 'role2' ],
+        channels: [ 'channel1', 'channel2' ]
+      },
+      {
+        users: function(doc, oldDoc) {
+          return doc.users;
+        },
+        roles: function(doc, oldDoc) {
+          return doc.roles;
+        },
+        channels: function(doc, oldDoc) {
+          return [ doc._id + '-channel1', doc._id + '-channel2' ];
+        }
+      },
+    ]
+```
+
 * `allowAttachments`: (optional) Whether to allow the addition of [file attachments](http://developer.couchbase.com/documentation/mobile/current/develop/references/sync-gateway/rest-api/document-public/put-db-doc-attachment/index.html) for the document type. Defaults to `false` to prevent malicious/misbehaving clients from polluting the bucket/database with unwanted files.
 * `allowUnknownProperties`: (optional) Whether to allow the existence of properties that are not explicitly declared in the document type definition. Not applied recursively to objects that are nested within documents of this type. Defaults to `false`.
 * `immutable`: (optional) The document cannot be replaced or deleted after it is created. Note that, even if attachments are allowed for this document type (see the `allowAttachments` parameter for more info), it will not be possible to create, modify or delete attachments in a document that already exists, which means that they must be created inline in the document's `_attachments` property when the document is first created. Defaults to `false`.
@@ -406,10 +429,23 @@ it('can create a myDocType document', function() {
     _id: 'myDocId',
     type: 'myDocType',
     foo: 'bar',
-    bar: -32
+    bar: -32,
+    members: [ 'joe', 'nancy' ]
   }
 
-  testHelper.verifyDocumentCreated(doc, [ 'my-add-channel1', 'my-add-channel2' ]);
+  testHelper.verifyDocumentCreated(
+    doc,
+    [ 'my-add-channel1', 'my-add-channel2' ],
+    [
+      {
+        expectedUsers: function(doc) {
+          return doc.members;
+        },
+        expectedChannels: function(doc) {
+          return 'view-' + doc._id;
+        }
+      }
+    ]);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ And an example of a more complex custom type filter:
     }
 ```
 
-* `accessAssignments`: (optional) Defines the channels to dynamically assign to users and/or roles when a document of the corresponding type is successfully created, replaced or deleted. Specified as a list, where each entry is an object that defines `users`, `roles` and `channels` properties. The value of each property can be either a list of strings that specify the raw user/role/channel names or a function that returns the corresponding values as a list and accepts the following parameters: (1) the new document, (2) the old document that is being replaced/deleted (if any). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be true, so be sure to account for such cases. An example:
+* `accessAssignments`: (optional) Defines the channels to dynamically assign to users and/or roles when a document of the corresponding type is successfully created, replaced or deleted. It is specified as a list, where each entry is an object that defines `users`, `roles` and `channels` properties. The value of each property can be either a list of strings that specify the raw user/role/channel names or a function that returns the corresponding values as a list and accepts the following parameters: (1) the new document, (2) the old document that is being replaced/deleted (if any). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be true, so be sure to account for such cases. An example:
 
 ```
     accessAssignments: [
@@ -233,7 +233,7 @@ And an example of a more complex custom type filter:
           return doc.roles;
         },
         channels: function(doc, oldDoc) {
-          return [ doc._id + '-channel1', doc._id + '-channel2' ];
+          return [ doc._id + '-channel3', doc._id + '-channel4' ];
         }
       },
     ]

--- a/README.md
+++ b/README.md
@@ -438,10 +438,10 @@ it('can create a myDocType document', function() {
     [ 'my-add-channel1', 'my-add-channel2' ],
     [
       {
-        expectedUsers: function(doc) {
+        expectedUsers: function(doc, oldDoc) {
           return doc.members;
         },
-        expectedChannels: function(doc) {
+        expectedChannels: function(doc, oldDoc) {
           return 'view-' + doc._id;
         }
       }

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -607,7 +607,7 @@ function synctos(doc, oldDoc) {
 
   function resolveCollectionItems(originalItems, itemPrefix) {
     if (isValueNullOrUndefined(originalItems)) {
-      return null;
+      return [ ];
     } else if (originalItems instanceof Array) {
       var resultItems = [ ];
       for (var i = 0; i < originalItems.length; i++) {
@@ -630,7 +630,7 @@ function synctos(doc, oldDoc) {
 
   function resolveCollectionDefinition(doc, oldDoc, collectionDefinition, itemPrefix) {
     if (isValueNullOrUndefined(collectionDefinition)) {
-      return null;
+      return [ ];
     } else {
       if (typeof(collectionDefinition) === 'function') {
         var fnResults = collectionDefinition(doc, oldDoc);
@@ -643,24 +643,24 @@ function synctos(doc, oldDoc) {
   }
 
   function assignUserAccess(doc, oldDoc, accessAssignmentDefinitions) {
-    for (var i = 0; i < accessAssignmentDefinitions.length; i++) {
-      var definition = accessAssignmentDefinitions[i];
+    for (var assignmentIndex = 0; assignmentIndex < accessAssignmentDefinitions.length; assignmentIndex++) {
+      var definition = accessAssignmentDefinitions[assignmentIndex];
+      var usersAndRoles = [ ];
 
-      var users = resolveCollectionDefinition(doc, oldDoc, definition);
+      var users = resolveCollectionDefinition(doc, oldDoc, definition.users);
+      for (var userIndex = 0; userIndex < users.length; userIndex++) {
+        usersAndRoles.push(users[userIndex]);
+      }
 
       // Role names must begin with the special token "role:" to distinguish them from users
-      var roles = resolveCollectionDefinition(doc, oldDoc, definition, 'role:');
-
-      var channels = resolveCollectionDefinition(doc, oldDoc, definition);
-      if (channels) {
-        if (users) {
-          access(users, channels);
-        }
-
-        if (roles) {
-          access(roles, channels);
-        }
+      var roles = resolveCollectionDefinition(doc, oldDoc, definition.roles, 'role:');
+      for (var roleIndex = 0; roleIndex < roles.length; roleIndex++) {
+        usersAndRoles.push(roles[roleIndex]);
       }
+
+      var channels = resolveCollectionDefinition(doc, oldDoc, definition.channels);
+
+      access(usersAndRoles, channels);
     }
   }
 

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -605,6 +605,10 @@ function synctos(doc, oldDoc) {
     }
   }
 
+  function prefixItem(item, prefix) {
+    return (prefix ? prefix + item : item.toString());
+  }
+
   function resolveCollectionItems(originalItems, itemPrefix) {
     if (isValueNullOrUndefined(originalItems)) {
       return [ ];
@@ -617,14 +621,13 @@ function synctos(doc, oldDoc) {
           continue;
         }
 
-        var qualifiedItem = itemPrefix ? itemPrefix.toString() + item : item.toString();
-        resultItems.push(qualifiedItem);
+        resultItems.push(prefixItem(item, itemPrefix));
       }
 
       return resultItems;
     } else {
       // Represents a single item
-      return [ originalItems.toString() ];
+      return [ prefixItem(originalItems, itemPrefix) ];
     }
   }
 

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -59,6 +59,35 @@ function checkChannels(expectedChannels, actualChannels) {
   }
 }
 
+function areSetsEqual(set1, set2) {
+  if (set1.length !== set2.length) {
+    return false;
+  }
+
+  for (var setIndex = 0; setIndex < set1.length; setIndex++) {
+    if (set2.indexOf(set1[setIndex]) < 0) {
+      return false;
+    } else if (set1.indexOf(set2[setIndex]) < 0) {
+      return false;
+    }
+  }
+
+  // If we got here, the two sets are equal
+  return true;
+}
+
+function accessAssignmentCallExists(expectedUsersAndRoles, expectedChannels) {
+  // Try to find an actual access assignment call that matches the expected call
+  for (var accessCallIndex = 0; accessCallIndex < access.callCount; accessCallIndex++) {
+    var accessCall = access.calls[accessCallIndex];
+    if (areSetsEqual(accessCall.args[0], expectedUsersAndRoles) && areSetsEqual(accessCall.args[1], expectedChannels)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function verifyAccessAssignments(expectedAccessAssignments) {
   var assignmentIndex;
   for (assignmentIndex = 0; assignmentIndex < expectedAccessAssignments.length; assignmentIndex++) {
@@ -103,16 +132,13 @@ function verifyAccessAssignments(expectedAccessAssignments) {
       }
     }
 
-    if (access.callCount <= assignmentIndex) {
+    if (!accessAssignmentCallExists(expectedUsersAndRoles, expectedChannels)) {
       expect().fail(
         'Missing expected call to assign channel access (' +
         JSON.stringify(expectedChannels) +
         ') to users and roles (' +
         JSON.stringify(expectedUsersAndRoles) +
         ')');
-    } else {
-      expect(access.calls[assignmentIndex].args[0]).to.eql(expectedUsersAndRoles);
-      expect(access.calls[assignmentIndex].args[1]).to.eql(expectedChannels);
     }
   }
 

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -81,7 +81,7 @@ function verifyAccessAssignments(expectedAccessAssignments) {
           var roleName = expectedAssignment.expectedRoles[roleIndex];
           // The prefix "role:" must be applied to roles when calling the access function, as specified by
           // http://developer.couchbase.com/documentation/mobile/current/develop/guides/sync-gateway/channels/developing/index.html#programmatic-authorization
-          if (roleName.startsWith('role:')) {
+          if (roleName.indexOf('role:') >= 0) {
             expectedUsersAndRoles.push(roleName);
           } else {
             expectedUsersAndRoles.push('role:' + roleName);

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -65,26 +65,44 @@ function verifyAccessAssignments(expectedAccessAssignments) {
     var expectedAssignment = expectedAccessAssignments[assignmentIndex];
 
     var expectedUsersAndRoles = [ ];
-    if (expectedAssignment.users) {
-      for (var userIndex = 0; userIndex < expectedAssignment.users.length; userIndex++) {
-        expectedUsersAndRoles.push(expectedAssignment.users[userIndex]);
-      }
-    }
-
-    if (expectedAssignment.roles) {
-      for (var roleIndex = 0; roleIndex < expectedAssignment.roles.length; roleIndex++) {
-        var roleName = expectedAssignment.roles[roleIndex];
-        // The prefix "role:" must be applied to roles when calling the access function, as specified by
-        // http://developer.couchbase.com/documentation/mobile/current/develop/guides/sync-gateway/channels/developing/index.html#programmatic-authorization
-        if (roleName.startsWith('role:')) {
-          expectedUsersAndRoles.push(roleName);
-        } else {
-          expectedUsersAndRoles.push('role:' + roleName);
+    if (expectedAssignment.expectedUsers) {
+      if (expectedAssignment.expectedUsers instanceof Array) {
+        for (var userIndex = 0; userIndex < expectedAssignment.expectedUsers.length; userIndex++) {
+          expectedUsersAndRoles.push(expectedAssignment.expectedUsers[userIndex]);
         }
+      } else {
+        expectedUsersAndRoles.push(expectedAssignment.expectedUsers);
       }
     }
 
-    var expectedChannels = expectedAssignment.channels || [ ];
+    if (expectedAssignment.expectedRoles) {
+      if (expectedAssignment.expectedRoles instanceof Array) {
+        for (var roleIndex = 0; roleIndex < expectedAssignment.expectedRoles.length; roleIndex++) {
+          var roleName = expectedAssignment.expectedRoles[roleIndex];
+          // The prefix "role:" must be applied to roles when calling the access function, as specified by
+          // http://developer.couchbase.com/documentation/mobile/current/develop/guides/sync-gateway/channels/developing/index.html#programmatic-authorization
+          if (roleName.startsWith('role:')) {
+            expectedUsersAndRoles.push(roleName);
+          } else {
+            expectedUsersAndRoles.push('role:' + roleName);
+          }
+        }
+      } else {
+        expectedUsersAndRoles.push(expectedAssignment.expectedRoles);
+      }
+    }
+
+    var expectedChannels = [ ];
+    if (expectedAssignment.expectedChannels) {
+      if (expectedAssignment.expectedChannels instanceof Array) {
+        for (var channelIndex = 0; channelIndex < expectedAssignment.expectedChannels.length; channelIndex++) {
+          expectedChannels.push(expectedAssignment.expectedChannels[channelIndex]);
+        }
+      } else {
+        expectedChannels.push(expectedAssignment.expectedChannels);
+      }
+    }
+
     expect(access.calls[expectedAccessCallCount].args[0]).to.eql(expectedUsersAndRoles);
     expect(access.calls[expectedAccessCallCount].args[1]).to.eql(expectedChannels);
 
@@ -123,8 +141,8 @@ function verifyDocumentReplaced(doc, oldDoc, expectedChannels, expectedAccessAss
   verifyDocumentAccepted(doc, oldDoc, expectedChannels || defaultWriteChannel, expectedAccessAssignments);
 }
 
-function verifyDocumentDeleted(oldDoc, expectedChannels) {
-  verifyDocumentAccepted({ _id: oldDoc._id, _deleted: true }, oldDoc, expectedChannels || defaultWriteChannel);
+function verifyDocumentDeleted(oldDoc, expectedChannels, expectedAccessAssignments) {
+  verifyDocumentAccepted({ _id: oldDoc._id, _deleted: true }, oldDoc, expectedChannels || defaultWriteChannel, expectedAccessAssignments);
 }
 
 function verifyDocumentRejected(doc, oldDoc, docType, expectedErrorMessages, expectedChannels) {

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -60,8 +60,8 @@ function checkChannels(expectedChannels, actualChannels) {
 }
 
 function verifyAccessAssignments(expectedAccessAssignments) {
-  var expectedAccessCallCount = 0;
-  for (var assignmentIndex = 0; assignmentIndex < expectedAccessAssignments.length; assignmentIndex++) {
+  var assignmentIndex;
+  for (assignmentIndex = 0; assignmentIndex < expectedAccessAssignments.length; assignmentIndex++) {
     var expectedAssignment = expectedAccessAssignments[assignmentIndex];
 
     var expectedUsersAndRoles = [ ];
@@ -103,13 +103,22 @@ function verifyAccessAssignments(expectedAccessAssignments) {
       }
     }
 
-    expect(access.calls[expectedAccessCallCount].args[0]).to.eql(expectedUsersAndRoles);
-    expect(access.calls[expectedAccessCallCount].args[1]).to.eql(expectedChannels);
-
-    expectedAccessCallCount++;
+    if (access.callCount <= assignmentIndex) {
+      expect().fail(
+        'Missing expected call to assign channel access (' +
+        JSON.stringify(expectedChannels) +
+        ') to users and roles (' +
+        JSON.stringify(expectedUsersAndRoles) +
+        ')');
+    } else {
+      expect(access.calls[assignmentIndex].args[0]).to.eql(expectedUsersAndRoles);
+      expect(access.calls[assignmentIndex].args[1]).to.eql(expectedChannels);
+    }
   }
 
-  expect(access.callCount).to.be(expectedAccessCallCount);
+  if (access.callCount !== assignmentIndex) {
+    expect().fail('Number of calls to assign channel access (' + access.callCount + ') does not match expected (' + assignmentIndex + ')');
+  }
 }
 
 function verifyDocumentAccepted(doc, oldDoc, expectedChannels, expectedAccessAssignments) {

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -107,14 +107,9 @@ function verifyAccessAssignments(expectedAccessAssignments) {
     if (expectedAssignment.expectedRoles) {
       if (expectedAssignment.expectedRoles instanceof Array) {
         for (var roleIndex = 0; roleIndex < expectedAssignment.expectedRoles.length; roleIndex++) {
-          var roleName = expectedAssignment.expectedRoles[roleIndex];
           // The prefix "role:" must be applied to roles when calling the access function, as specified by
           // http://developer.couchbase.com/documentation/mobile/current/develop/guides/sync-gateway/channels/developing/index.html#programmatic-authorization
-          if (roleName.indexOf('role:') >= 0) {
-            expectedUsersAndRoles.push(roleName);
-          } else {
-            expectedUsersAndRoles.push('role:' + roleName);
-          }
+          expectedUsersAndRoles.push('role:' + expectedAssignment.expectedRoles[roleIndex]);
         }
       } else {
         expectedUsersAndRoles.push(expectedAssignment.expectedRoles);

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -59,7 +59,7 @@ function checkChannels(expectedChannels, actualChannels) {
   }
 }
 
-function areSetsEqual(set1, set2) {
+function areUnorderedListsEqual(set1, set2) {
   if (set1.length !== set2.length) {
     return false;
   }
@@ -80,7 +80,7 @@ function accessAssignmentCallExists(expectedUsersAndRoles, expectedChannels) {
   // Try to find an actual access assignment call that matches the expected call
   for (var accessCallIndex = 0; accessCallIndex < access.callCount; accessCallIndex++) {
     var accessCall = access.calls[accessCallIndex];
-    if (areSetsEqual(accessCall.args[0], expectedUsersAndRoles) && areSetsEqual(accessCall.args[1], expectedChannels)) {
+    if (areUnorderedListsEqual(accessCall.args[0], expectedUsersAndRoles) && areUnorderedListsEqual(accessCall.args[1], expectedChannels)) {
       return true;
     }
   }
@@ -105,14 +105,14 @@ function verifyAccessAssignments(expectedAccessAssignments) {
     }
 
     if (expectedAssignment.expectedRoles) {
+      // The prefix "role:" must be applied to roles when calling the access function, as specified by
+      // http://developer.couchbase.com/documentation/mobile/current/develop/guides/sync-gateway/channels/developing/index.html#programmatic-authorization
       if (expectedAssignment.expectedRoles instanceof Array) {
         for (var roleIndex = 0; roleIndex < expectedAssignment.expectedRoles.length; roleIndex++) {
-          // The prefix "role:" must be applied to roles when calling the access function, as specified by
-          // http://developer.couchbase.com/documentation/mobile/current/develop/guides/sync-gateway/channels/developing/index.html#programmatic-authorization
           expectedUsersAndRoles.push('role:' + expectedAssignment.expectedRoles[roleIndex]);
         }
       } else {
-        expectedUsersAndRoles.push(expectedAssignment.expectedRoles);
+        expectedUsersAndRoles.push('role:' + expectedAssignment.expectedRoles);
       }
     }
 

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -7,6 +7,7 @@ var validationErrorFormatter = require('./validation-error-message-formatter.js'
 // More info: http://developer.couchbase.com/mobile/develop/guides/sync-gateway/sync-function-api-guide/index.html
 var requireAccess;
 var channel;
+var access;
 
 var syncFunction;
 
@@ -20,6 +21,7 @@ function init(syncFunctionPath) {
 
   requireAccess = simple.stub();
   channel = simple.stub();
+  access = simple.stub();
 }
 
 function verifyRequireAccess(expectedChannels) {

--- a/samples/sample-sync-doc-definitions.js
+++ b/samples/sample-sync-doc-definitions.js
@@ -126,7 +126,7 @@ function() {
 
         // Only service users can create new notifications
         return {
-          view: [ toSyncChannel(businessId, 'VIEW_NOTIFICATIONS'), serviceChannel ],
+          view: [ toSyncChannel(businessId, 'VIEW_NOTIFICATIONS'), doc._id + '-VIEW', serviceChannel ],
           add: serviceChannel,
           replace: [ toSyncChannel(businessId, 'CHANGE_NOTIFICATIONS'), serviceChannel ],
           remove: [ toSyncChannel(businessId, 'REMOVE_NOTIFICATIONS'), serviceChannel ]
@@ -135,6 +135,17 @@ function() {
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notification\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
+      accessAssignments: [
+        {
+          users: function(doc, oldDoc) {
+            return doc.users;
+          },
+          roles: function(doc, oldDoc) {
+            return doc.groups;
+          },
+          channels: [ doc._id + '-VIEW' ]
+        }
+      ],
       propertyValidators: {
         sender: {
           // Which Kashoo app/service generated the notification
@@ -142,6 +153,24 @@ function() {
           required: true,
           mustNotBeEmpty: true,
           immutable: true
+        },
+        users: {
+          type: 'array',
+          immutable: true,
+          arrayElementsValidator: {
+            type: 'string',
+            required: true,
+            mustNotBeEmpty: true
+          }
+        },
+        groups: {
+          type: 'array',
+          immutable: true,
+          arrayElementsValidator: {
+            type: 'string',
+            required: true,
+            mustNotBeEmpty: true
+          }
         },
         type: {
           // The type of notification. Corresponds to an entry in the business' notificationsConfig.notificationTypes property.

--- a/test/access-assignment-spec.js
+++ b/test/access-assignment-spec.js
@@ -27,7 +27,7 @@ describe('User and role access assignment:', function() {
   describe('Static assignment of channels to users and roles', function() {
     var expectedStaticAssignments = [
       {
-        expectedUsers: [ 'user2', 'user1' ],
+        expectedUsers: [ 'user2', 'user1', 'user4' ],
         expectedRoles: [ 'role2', 'role1' ],
         expectedChannels: [ 'channel1', 'channel2' ]
       },

--- a/test/access-assignment-spec.js
+++ b/test/access-assignment-spec.js
@@ -27,8 +27,8 @@ describe('User and role access assignment:', function() {
   describe('Static assignment of channels to users and roles', function() {
     var expectedStaticAssignments = [
       {
-        expectedUsers: [ 'user1', 'user2' ],
-        expectedRoles: [ 'role1', 'role2' ],
+        expectedUsers: [ 'user2', 'user1' ],
+        expectedRoles: [ 'role2', 'role1' ],
         expectedChannels: [ 'channel1', 'channel2' ]
       },
       {
@@ -131,7 +131,7 @@ describe('User and role access assignment:', function() {
         {
           expectedUsers: null,
           expectedRoles: null,
-          expectedChannels: [ doc._id + '-channel1', doc._id + '-channel2' ]
+          expectedChannels: [ doc._id + '-channel2', doc._id + '-channel1' ]
         }
       ];
 

--- a/test/access-assignment-spec.js
+++ b/test/access-assignment-spec.js
@@ -1,0 +1,100 @@
+var testHelper = require('../etc/test-helper.js');
+var errorFormatter = testHelper.validationErrorFormatter;
+
+describe('User and role access assignment:', function() {
+  beforeEach(function() {
+    testHelper.init('build/sync-functions/test-access-assignment-sync-function.js');
+  });
+
+  describe('Static assignment of channels to users and roles', function() {
+    var expectedStaticAssignments = [
+      {
+        expectedUsers: [ 'user1', 'user2' ],
+        expectedRoles: [ 'role1', 'role2' ],
+        expectedChannels: [ 'channel1', 'channel2' ]
+      },
+      {
+        expectedUsers: 'user3',
+        expectedChannels: 'channel3'
+      },
+      {
+        expectedRoles: 'role3',
+        expectedChannels: 'channel4'
+      }
+    ];
+
+    it('is applied when creating a document', function() {
+      var doc = { _id: 'staticAccessDoc' };
+
+      testHelper.verifyDocumentCreated(doc, 'write', expectedStaticAssignments);
+    });
+
+    it('is applied when replacing an existing document', function() {
+      var doc = { _id: 'staticAccessDoc' };
+      var oldDoc = { _id: 'staticAccessDoc' };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc, 'write', expectedStaticAssignments);
+    });
+
+    it('is applied when deleting an existing document', function() {
+      var oldDoc = { _id: 'staticAccessDoc' };
+
+      testHelper.verifyDocumentDeleted(oldDoc, 'write', expectedStaticAssignments);
+    });
+  });
+
+  describe('Dynamic assignment of channels to users and roles', function() {
+    var doc = {
+      _id: 'dynamicAccessDoc',
+      users: [ 'user1', 'user2' ],
+      roles: [ 'role1', 'role2' ]
+    };
+    var expectedDynamicAssignments = [
+      {
+        expectedUsers: doc.users,
+        expectedRoles: doc.roles,
+        expectedChannels: [ doc._id + '-channel1', doc._id + '-channel2' ]
+      },
+      {
+        expectedUsers: doc.users,
+        expectedChannels: [ doc._id + '-channel3' ]
+      },
+      {
+        expectedRoles: doc.roles,
+        expectedChannels: [ doc._id + '-channel4' ]
+      }
+    ];
+
+    it('is applied when creating a document', function() {
+      testHelper.verifyDocumentCreated(doc, 'write', expectedDynamicAssignments);
+    });
+
+    it('is applied when replacing an existing document', function() {
+      var oldDoc = { _id: 'dynamicAccessDoc' };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc, 'write', expectedDynamicAssignments);
+    });
+
+    it('is applied when deleting an existing document', function() {
+      var oldDoc = { _id: 'dynamicAccessDoc' };
+
+      var expectedDeleteAssignments = [
+        {
+          expectedUsers: null,
+          expectedRoles: null,
+          expectedChannels: [ doc._id + '-channel1', doc._id + '-channel2' ]
+        },
+        {
+          expectedUsers: null,
+          expectedChannels: [ doc._id + '-channel3' ]
+        },
+        {
+          expectedRoles: null,
+          expectedChannels: [ doc._id + '-channel4' ]
+        }
+      ];
+
+      testHelper.verifyDocumentDeleted(oldDoc, 'write', expectedDeleteAssignments);
+    });
+  });
+});

--- a/test/access-assignment-spec.js
+++ b/test/access-assignment-spec.js
@@ -81,16 +81,16 @@ describe('User and role access assignment:', function() {
       var expectedDeleteAssignments = [
         {
           expectedUsers: null,
-          expectedRoles: null,
-          expectedChannels: [ doc._id + '-channel1', doc._id + '-channel2' ]
-        },
-        {
-          expectedUsers: null,
           expectedChannels: [ doc._id + '-channel3' ]
         },
         {
           expectedRoles: null,
           expectedChannels: [ doc._id + '-channel4' ]
+        },
+        {
+          expectedUsers: null,
+          expectedRoles: null,
+          expectedChannels: [ doc._id + '-channel1', doc._id + '-channel2' ]
         }
       ];
 

--- a/test/resources/access-assignment-doc-definitions.js
+++ b/test/resources/access-assignment-doc-definitions.js
@@ -4,7 +4,6 @@
     typeFilter: function(doc) {
       return doc._id === 'staticAccessDoc';
     },
-    allowUnknownProperties: true,
     accessAssignments: [
       {
         users: 'user3',
@@ -26,7 +25,14 @@
     typeFilter: function(doc) {
       return doc._id === 'dynamicAccessDoc';
     },
-    allowUnknownProperties: true,
+    propertyValidators: {
+      users: {
+        type: 'array'
+      },
+      roles: {
+        type: 'array'
+      }
+    },
     accessAssignments: [
       {
         users: function(doc, oldDoc) {

--- a/test/resources/access-assignment-doc-definitions.js
+++ b/test/resources/access-assignment-doc-definitions.js
@@ -7,17 +7,17 @@
     allowUnknownProperties: true,
     accessAssignments: [
       {
-        users: [ 'user1', 'user2' ],
-        roles: [ 'role1', 'role2' ],
-        channels: [ 'channel1', 'channel2' ]
-      },
-      {
         users: 'user3',
         channels: 'channel3'
       },
       {
         roles: 'role3',
         channels: 'channel4'
+      },
+      {
+        users: [ 'user1', 'user2' ],
+        roles: [ 'role1', 'role2' ],
+        channels: [ 'channel1', 'channel2' ]
       }
     ]
   },
@@ -40,19 +40,19 @@
         }
       },
       {
-        users: function(doc, oldDoc) {
-          return doc.users;
-        },
-        channels: function(doc, oldDoc) {
-          return doc._id + '-channel3';
-        }
-      },
-      {
         roles: function(doc, oldDoc) {
           return doc.roles;
         },
         channels: function(doc, oldDoc) {
           return doc._id + '-channel4';
+        }
+      },
+      {
+        users: function(doc, oldDoc) {
+          return doc.users;
+        },
+        channels: function(doc, oldDoc) {
+          return doc._id + '-channel3';
         }
       }
     ]

--- a/test/resources/access-assignment-doc-definitions.js
+++ b/test/resources/access-assignment-doc-definitions.js
@@ -1,0 +1,60 @@
+{
+  staticAccessDoc: {
+    channels: { write: 'write' },
+    typeFilter: function(doc) {
+      return doc._id === 'staticAccessDoc';
+    },
+    allowUnknownProperties: true,
+    accessAssignments: [
+      {
+        users: [ 'user1', 'user2' ],
+        roles: [ 'role1', 'role2' ],
+        channels: [ 'channel1', 'channel2' ]
+      },
+      {
+        users: 'user3',
+        channels: 'channel3'
+      },
+      {
+        roles: 'role3',
+        channels: 'channel4'
+      }
+    ]
+  },
+  dynamicAccessDoc: {
+    channels: { write: 'write' },
+    typeFilter: function(doc) {
+      return doc._id === 'dynamicAccessDoc';
+    },
+    allowUnknownProperties: true,
+    accessAssignments: [
+      {
+        users: function(doc, oldDoc) {
+          return doc.users;
+        },
+        roles: function(doc, oldDoc) {
+          return doc.roles;
+        },
+        channels: function(doc, oldDoc) {
+          return [ doc._id + '-channel1', doc._id + '-channel2' ];
+        }
+      },
+      {
+        users: function(doc, oldDoc) {
+          return doc.users;
+        },
+        channels: function(doc, oldDoc) {
+          return doc._id + '-channel3';
+        }
+      },
+      {
+        roles: function(doc, oldDoc) {
+          return doc.roles;
+        },
+        channels: function(doc, oldDoc) {
+          return doc._id + '-channel4';
+        }
+      }
+    ]
+  }
+}

--- a/test/resources/access-assignment-doc-definitions.js
+++ b/test/resources/access-assignment-doc-definitions.js
@@ -14,7 +14,7 @@
         channels: 'channel4'
       },
       {
-        users: [ 'user1', 'user2' ],
+        users: [ 'user1', 'user2', 'user4' ],
         roles: [ 'role1', 'role2' ],
         channels: [ 'channel1', 'channel2' ]
       }

--- a/test/sample-sync-doc-definitions-spec.js
+++ b/test/sample-sync-doc-definitions-spec.js
@@ -492,7 +492,8 @@ describe('The sample-sync-doc-definitions sync function', function() {
         subject: 'pay up!',
         message: 'you best pay up now, or else...',
         createdAt: '2016-02-29T17:13:43.666Z',
-        actions: [ { url: 'http://foobar.baz', label: 'pay up here'} ]
+        actions: [ { url: 'http://foobar.baz', label: 'pay up here'} ],
+        recipients: [ 'foobar', 'baz' ]
       };
 
       verifyNotificationCreated(63, doc);
@@ -535,7 +536,8 @@ describe('The sample-sync-doc-definitions sync function', function() {
         message: 'last warning!',
         createdAt: '2016-02-29T17:13:43.666Z',
         firstReadAt: '2016-07-14T21:21:21.212-08:00',
-        actions: [ { url: 'http://foobar.baz/lastwarning', label: 'pay up here'} ]
+        actions: [ { url: 'http://foobar.baz/lastwarning', label: 'pay up here'} ],
+        groups: [ 'my-group1', 'my-group2' ]
       };
       var oldDoc = {
         _id: 'biz.7.notification.3',
@@ -544,7 +546,8 @@ describe('The sample-sync-doc-definitions sync function', function() {
         subject: 'a different subject',
         message: 'last warning!',
         createdAt: '2016-02-29T17:13:43.666Z',
-        actions: [ { 'url': 'http://foobar.baz/lastwarning', 'label': 'pay up here'} ]
+        actions: [ { 'url': 'http://foobar.baz/lastwarning', 'label': 'pay up here'} ],
+        groups: [ 'my-group1', 'my-group2' ]
       };
 
       verifyNotificationReplaced(7, doc, oldDoc);

--- a/test/sample-sync-doc-definitions-spec.js
+++ b/test/sample-sync-doc-definitions-spec.js
@@ -462,9 +462,9 @@ describe('The sample-sync-doc-definitions sync function', function() {
     function getExpectedAccessAssignments(doc, docId) {
       return [
         {
-          channels: [ docId + '-VIEW' ],
-          users: doc ? doc.users : null,
-          roles: doc ? doc.groups : null
+          expectedChannels: [ docId + '-VIEW' ],
+          expectedUsers: doc ? doc.users : null,
+          expectedRoles: doc ? doc.groups : null
         }
       ];
     }

--- a/test/sample-sync-doc-definitions-spec.js
+++ b/test/sample-sync-doc-definitions-spec.js
@@ -459,16 +459,33 @@ describe('The sample-sync-doc-definitions sync function', function() {
     var expectedDocType = 'notification';
     var expectedBasePrivilege = 'NOTIFICATIONS';
 
+    function getExpectedAccessAssignments(doc, docId) {
+      return [
+        {
+          channels: [ docId + '-VIEW' ],
+          users: doc ? doc.users : null,
+          roles: doc ? doc.groups : null
+        }
+      ];
+    }
+
     function verifyNotificationCreated(businessId, doc) {
-      testHelper.verifyDocumentCreated(doc, serviceChannel);
+      testHelper.verifyDocumentCreated(doc, serviceChannel, getExpectedAccessAssignments(doc, doc._id));
     }
 
     function verifyNotificationReplaced(businessId, doc, oldDoc) {
-      testHelper.verifyDocumentReplaced(doc, oldDoc, [ serviceChannel, businessId + '-CHANGE_' + expectedBasePrivilege ]);
+      testHelper.verifyDocumentReplaced(
+        doc,
+        oldDoc,
+        [ serviceChannel, businessId + '-CHANGE_' + expectedBasePrivilege ],
+        getExpectedAccessAssignments(doc, doc._id));
     }
 
     function verifyNotificationDeleted(businessId, oldDoc) {
-      testHelper.verifyDocumentDeleted(oldDoc, [ serviceChannel, businessId + '-REMOVE_' + expectedBasePrivilege ]);
+      testHelper.verifyDocumentDeleted(
+        oldDoc,
+        [ serviceChannel, businessId + '-REMOVE_' + expectedBasePrivilege ],
+        getExpectedAccessAssignments({ }, oldDoc._id));
     }
 
     function verifyNotificationNotCreated(businessId, doc, expectedErrorMessages) {
@@ -493,7 +510,7 @@ describe('The sample-sync-doc-definitions sync function', function() {
         message: 'you best pay up now, or else...',
         createdAt: '2016-02-29T17:13:43.666Z',
         actions: [ { url: 'http://foobar.baz', label: 'pay up here'} ],
-        recipients: [ 'foobar', 'baz' ]
+        users: [ 'foobar', 'baz' ]
       };
 
       verifyNotificationCreated(63, doc);


### PR DESCRIPTION
Introduces a mechanism to configure in the document definition which channels should be dynamically assigned to users and/or roles as a document of that type is created, replaced or deleted. The configuration is flexible enough to allow either static (i.e. predefined lists of users/roles/channels) or dynamic (i.e. functions that return computed lists of users/roles/channels) assignment. Also extends the corresponding test-helper module validation functions so that callers can write specs that verify the channels that are assigned to users and roles.

Addresses issue #24.