### PR TITLE
Issue #23: Authorization by username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - [#22](https://github.com/Kashoo/synctos/issues/22): Support document authorization by role
+- [#23](https://github.com/Kashoo/synctos/issues/23): Support document authorization by specific users
 
 ## [1.3.1] - 2016-11-24
 ### Changed

--- a/samples/sample-sync-doc-definitions.js
+++ b/samples/sample-sync-doc-definitions.js
@@ -2,6 +2,9 @@ function() {
   // The role that confers universal privileges and is only applicable to Kashoo services
   var serviceRole = 'SERVICE';
 
+  // A special user that has universal privileges
+  var adminUser = 'ADMIN';
+
   // Matches values that look like three-letter ISO 4217 currency codes. It is not comprehensive.
   var iso4217CurrencyCodeRegex = new RegExp('^[A-Z]{3}$');
 
@@ -65,6 +68,8 @@ function() {
 
   var defaultAuthorizedRoles = { write: serviceRole };
 
+  var defaultAuthorizedUsers = { write: adminUser };
+
   // The document type definitions. For everyone's sanity, please keep the document types in case-insensitive alphabetical order
   return {
     // The general business configuration
@@ -82,6 +87,7 @@ function() {
         };
       },
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return new RegExp('^biz\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
@@ -134,6 +140,7 @@ function() {
         };
       },
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notification\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
@@ -242,6 +249,7 @@ function() {
     notificationsConfig: {
       channels: toDefaultSyncChannels(doc, oldDoc, 'NOTIFICATIONS_CONFIG'),
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notificationsConfig$').test(doc._id);
       },
@@ -284,6 +292,7 @@ function() {
     notificationsReference: {
       channels: toDefaultSyncChannels(doc, oldDoc, 'NOTIFICATIONS'),
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notifications$').test(doc._id);
       },
@@ -315,6 +324,7 @@ function() {
     notificationTransport: {
       channels: toDefaultSyncChannels(doc, oldDoc, 'NOTIFICATIONS_CONFIG'),
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notificationTransport\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
@@ -341,6 +351,7 @@ function() {
         write: 'notification-transport-write'
       },
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('notification\\.[A-Za-z0-9_-]+\\.processedTransport\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
@@ -387,6 +398,7 @@ function() {
         };
       },
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return new RegExp('^paymentAttempt\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
@@ -452,6 +464,7 @@ function() {
     paymentProcessorDefinition: {
       channels: toDefaultSyncChannels(doc, oldDoc, 'CUSTOMER_PAYMENT_PROCESSORS'),
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('paymentProcessor\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
@@ -495,6 +508,7 @@ function() {
     paymentRequisition: {
       channels: toDefaultSyncChannels(doc, oldDoc, 'INVOICE_PAYMENT_REQUISITIONS'),
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return new RegExp('^paymentRequisition\\.[A-Za-z0-9_-]+$').test(doc._id);
       },
@@ -532,6 +546,7 @@ function() {
     paymentRequisitionsReference: {
       channels: toDefaultSyncChannels(doc, oldDoc, 'INVOICE_PAYMENT_REQUISITIONS'),
       authorizedRoles: defaultAuthorizedRoles,
+      authorizedUsers: defaultAuthorizedUsers,
       typeFilter: function(doc, oldDoc) {
         return createBusinessEntityRegex('invoice\\.[A-Za-z0-9_-]+.paymentRequisitions$').test(doc._id);
       },

--- a/test/authorization-spec.js
+++ b/test/authorization-spec.js
@@ -50,45 +50,50 @@ describe('Authorization:', function() {
     });
   });
 
-  describe('for a document with dynamically-assigned roles and channels', function() {
-    var expectedWriteChannels = [ 'dynamicChannelsAndRolesDoc-write' ];
-    var expectedWriteRoles = [ 'write1', 'write2' ];
+  describe('for a document with dynamically-assigned roles, channels and users', function() {
+    var expectedWriteChannels = [ 'dynamicChannelsRolesAndUsersDoc-write' ];
+    var expectedWriteRoles = [ 'write-role1', 'write-role2' ];
+    var expectedWriteUsers = [ 'write-user1', 'write-user2' ];
     var expectedAuthorization = {
       expectedChannels: expectedWriteChannels,
-      expectedRoles: expectedWriteRoles
+      expectedRoles: expectedWriteRoles,
+      expectedUsers: expectedWriteUsers
     };
 
-    it('rejects document creation for a user with no matching channels or roles', function() {
+    it('rejects document creation for a user with no matching channels, roles or users', function() {
       var doc = {
-        _id: 'dynamicChannelsAndRolesDoc',
+        _id: 'dynamicChannelsRolesAndUsersDoc',
         stringProp: 'foobar',
-        roles: expectedWriteRoles
+        roles: expectedWriteRoles,
+        users: expectedWriteUsers
       };
 
       testHelper.verifyAccessDenied(doc, null, expectedAuthorization);
     });
 
-    it('rejects document replacement for a user with no matching channels or roles', function() {
+    it('rejects document replacement for a user with no matching channels, roles or users', function() {
       var doc = {
-        _id: 'dynamicChannelsAndRolesDoc',
+        _id: 'dynamicChannelsRolesAndUsersDoc',
         stringProp: 'foobar'
       };
       var oldDoc = {
-        _id: 'dynamicChannelsAndRolesDoc',
-        roles: expectedWriteRoles
+        _id: 'dynamicChannelsRolesAndUsersDoc',
+        roles: expectedWriteRoles,
+        users: expectedWriteUsers
       };
 
       testHelper.verifyAccessDenied(doc, oldDoc, expectedAuthorization);
     });
 
-    it('rejects document deletion for a user with no matching channels or roles', function() {
+    it('rejects document deletion for a user with no matching channels, roles or users', function() {
       var doc = {
-        _id: 'dynamicChannelsAndRolesDoc',
+        _id: 'dynamicChannelsRolesAndUsersDoc',
         _deleted: true
       };
       var oldDoc = {
-        _id: 'dynamicChannelsAndRolesDoc',
-        roles: expectedWriteRoles
+        _id: 'dynamicChannelsRolesAndUsersDoc',
+        roles: expectedWriteRoles,
+        users: expectedWriteUsers
       };
 
       testHelper.verifyAccessDenied(doc, oldDoc, expectedAuthorization);
@@ -127,6 +132,41 @@ describe('Authorization:', function() {
       };
 
       testHelper.verifyAccessDenied(doc, oldDoc, { expectedRoles: [ 'remove' ] });
+    });
+  });
+
+  describe('for a document with statically-assigned users and no channels', function() {
+    it('rejects document creation for a user without a matching username', function() {
+      var doc = {
+        _id: 'noChannelsAndStaticUsersDoc',
+        stringProp: 'foobar'
+      };
+
+      testHelper.verifyAccessDenied(doc, null, { expectedUsers: [ 'add1', 'add2' ] });
+    });
+
+    it('rejects document replacement for a user without a matching username', function() {
+      var doc = {
+        _id: 'noChannelsAndStaticUsersDoc',
+        stringProp: 'foobar'
+      };
+      var oldDoc = {
+        _id: 'noChannelsAndStaticUsersDoc'
+      };
+
+      testHelper.verifyAccessDenied(doc, oldDoc, { expectedUsers: [ 'replace1', 'replace2' ] });
+    });
+
+    it('rejects document deletion for a user without a matching username', function() {
+      var doc = {
+        _id: 'noChannelsAndStaticUsersDoc',
+        _deleted: true
+      };
+      var oldDoc = {
+        _id: 'noChannelsAndStaticUsersDoc'
+      };
+
+      testHelper.verifyAccessDenied(doc, oldDoc, { expectedUsers: [ 'remove1', 'remove2' ] });
     });
   });
 

--- a/test/channel-assignment-spec.js
+++ b/test/channel-assignment-spec.js
@@ -59,19 +59,22 @@ describe('Channel assignment:', function() {
   });
 
   describe('for a document with dynamically-assigned roles and channels', function() {
-    var allExpectedChannels = [ 'dynamicChannelsAndRolesDoc-write', 'dynamicChannelsAndRolesDoc-view' ];
-    var expectedWriteChannels = [ 'dynamicChannelsAndRolesDoc-write' ];
-    var expectedWriteRoles = [ 'write1', 'write2' ];
+    var allExpectedChannels = [ 'dynamicChannelsRolesAndUsersDoc-write', 'dynamicChannelsRolesAndUsersDoc-view' ];
+    var expectedWriteChannels = [ 'dynamicChannelsRolesAndUsersDoc-write' ];
+    var expectedWriteRoles = [ 'write-role1', 'write-role2' ];
+    var expectedWriteUsers = [ 'write-user1', 'write-user2' ];
     var expectedAuthorization = {
       expectedChannels: expectedWriteChannels,
-      expectedRoles: expectedWriteRoles
+      expectedRoles: expectedWriteRoles,
+      expectedUsers: expectedWriteUsers
     };
 
     it('includes all configured channels when assigning channels to a new document', function() {
       var doc = {
-        _id: 'dynamicChannelsAndRolesDoc',
+        _id: 'dynamicChannelsRolesAndUsersDoc',
         stringProp: 'foobar',
-        roles: expectedWriteRoles
+        roles: expectedWriteRoles,
+        users: expectedWriteUsers
       };
 
       testHelper.verifyDocumentCreated(doc, expectedAuthorization);
@@ -80,12 +83,13 @@ describe('Channel assignment:', function() {
 
     it('includes all configured channels when assigning channels to a replaced document', function() {
       var doc = {
-        _id: 'dynamicChannelsAndRolesDoc',
+        _id: 'dynamicChannelsRolesAndUsersDoc',
         stringProp: 'foobar'
       };
       var oldDoc = {
-        _id: 'dynamicChannelsAndRolesDoc',
-        roles: expectedWriteRoles
+        _id: 'dynamicChannelsRolesAndUsersDoc',
+        roles: expectedWriteRoles,
+        users: expectedWriteUsers
       };
 
       testHelper.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
@@ -94,8 +98,9 @@ describe('Channel assignment:', function() {
 
     it('includes all configured channels when assigning channels to a deleted document', function() {
       var oldDoc = {
-        _id: 'dynamicChannelsAndRolesDoc',
-        roles: expectedWriteRoles
+        _id: 'dynamicChannelsRolesAndUsersDoc',
+        roles: expectedWriteRoles,
+        users: expectedWriteUsers
       };
 
       testHelper.verifyDocumentDeleted(oldDoc, expectedAuthorization);
@@ -133,6 +138,40 @@ describe('Channel assignment:', function() {
       };
 
       testHelper.verifyDocumentDeleted(oldDoc, { expectedRoles: 'remove' });
+      testHelper.verifyChannelAssignment([ ]);
+    });
+  });
+
+  describe('for a document with statically-assigned users and no channels', function() {
+    it('includes all configured channels when assigning channels to a new document', function() {
+      var doc = {
+        _id: 'noChannelsAndStaticUsersDoc',
+        stringProp: 'foobar'
+      };
+
+      testHelper.verifyDocumentCreated(doc, { expectedUsers: [ 'add1', 'add2' ] });
+      testHelper.verifyChannelAssignment([ ]);
+    });
+
+    it('includes all configured channels when assigning channels to a replaced document', function() {
+      var doc = {
+        _id: 'noChannelsAndStaticUsersDoc',
+        stringProp: 'foobar'
+      };
+      var oldDoc = {
+        _id: 'noChannelsAndStaticUsersDoc'
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc, { expectedUsers: [ 'replace1', 'replace2' ] });
+      testHelper.verifyChannelAssignment([ ]);
+    });
+
+    it('includes all configured channels when assigning channels to a deleted document', function() {
+      var oldDoc = {
+        _id: 'noChannelsAndStaticUsersDoc'
+      };
+
+      testHelper.verifyDocumentDeleted(oldDoc, { expectedUsers: [ 'remove1', 'remove2' ] });
       testHelper.verifyChannelAssignment([ ]);
     });
   });

--- a/test/general-spec.js
+++ b/test/general-spec.js
@@ -13,12 +13,14 @@ eval('var syncFunction = ' + fs.readFileSync('build/sync-functions/test-general-
 // More info: http://developer.couchbase.com/mobile/develop/guides/sync-gateway/sync-function-api-guide/index.html
 var requireAccess;
 var requireRole;
+var requireUser;
 var channel;
 
 describe('Functionality that is common to all documents:', function() {
   beforeEach(function() {
     requireAccess = simple.stub();
     requireRole = simple.stub();
+    requireUser = simple.stub();
     channel = simple.stub();
   });
 

--- a/test/resources/authorization-doc-definitions.js
+++ b/test/resources/authorization-doc-definitions.js
@@ -28,9 +28,9 @@
       }
     }
   },
-  dynamicChannelsAndRolesDoc: {
+  dynamicChannelsRolesAndUsersDoc: {
     typeFilter: function(doc) {
-      return doc._id === 'dynamicChannelsAndRolesDoc';
+      return doc._id === 'dynamicChannelsRolesAndUsersDoc';
     },
     channels: function(doc, oldDoc) {
       return {
@@ -41,11 +41,17 @@
     authorizedRoles: function(doc, oldDoc) {
       return { write: oldDoc ? oldDoc.roles : doc.roles };
     },
+    authorizedUsers: function(doc, oldDoc) {
+      return { write: oldDoc ? oldDoc.users : doc.users };
+    },
     propertyValidators: {
       stringProp: {
         type: 'string'
       },
       roles: {
+        type: 'array'
+      },
+      users: {
         type: 'array'
       }
     }
@@ -58,6 +64,21 @@
       add: 'add',
       replace: 'replace',
       remove: 'remove'
+    },
+    propertyValidators: {
+      stringProp: {
+        type: 'string'
+      }
+    }
+  },
+  noChannelsAndStaticUsersDoc: {
+    typeFilter: function(doc) {
+      return doc._id === 'noChannelsAndStaticUsersDoc';
+    },
+    authorizedUsers: {
+      add: [ 'add1', 'add2' ],
+      replace: [ 'replace1', 'replace2' ],
+      remove: [ 'remove1', 'remove2' ]
     },
     propertyValidators: {
       stringProp: {

--- a/test/sample-sync-doc-definitions-spec.js
+++ b/test/sample-sync-doc-definitions-spec.js
@@ -1051,6 +1051,7 @@ function verifyDocumentNotReplaced(basePrivilegeName, businessId, doc, oldDoc, e
 function getExpectedAuthorization(expectedChannels) {
   return {
     expectedRoles: [ 'SERVICE' ],
+    expectedUsers: [ 'ADMIN' ],
     expectedChannels: expectedChannels
   };
 }


### PR DESCRIPTION
Allows document definitions to explicitly specify which users have access to which operation types (add, replace or remove) via an additional top-level document definition property: `authorizedUsers`. Uses the same format as the `channels` and `authorizedRoles` properties. When used in combination with either or both of those properties, allows the user to specify that authorization will be granted if the user has at least one of the authorized channels, roles and/or usernames for the corresponding operation type. Changes are backward compatible.

Addresses issue #23.