### PR TITLE
Issues #22 & #23: Allow admin API to create documents with no authorization methods

### DIFF
--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -169,14 +169,15 @@ function synctos(doc, oldDoc) {
       }
     }
 
-    var authorizationFailedMessage = 'missing channel access';
     if (!authorizedChannels && !authorizedRoles && !authorizedUsers) {
       // The document type does not define any channels, roles or users that apply to this particular write operation type, so fall back to
-      // Sync Gateway's default behaviour for an empty channel list (i.e. 403 Forbidden)
-      throw({ forbidden: authorizationFailedMessage });
+      // Sync Gateway's default behaviour for an empty channel list. Note that calling requireAccess with an empty channel list will
+      // result in a 403 Forbidden response if the request was received via the public API, but a 2xx response via the admin API, which is
+      // the desired outcome.
+      requireAccess([ ]);
     } else if (!channelMatch && !roleMatch && !userMatch) {
       // None of the authorization methods (e.g. channels, roles, users) succeeded
-      throw({ forbidden: authorizationFailedMessage });
+      throw({ forbidden: 'missing channel access' });
     }
   }
 

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -171,9 +171,9 @@ function synctos(doc, oldDoc) {
 
     if (!authorizedChannels && !authorizedRoles && !authorizedUsers) {
       // The document type does not define any channels, roles or users that apply to this particular write operation type, so fall back to
-      // Sync Gateway's default behaviour for an empty channel list. Note that calling requireAccess with an empty channel list will
-      // result in a 403 Forbidden response if the request was received via the public API, but a 2xx response via the admin API, which is
-      // the desired outcome.
+      // Sync Gateway's default behaviour for an empty channel list: 403 Forbidden for requests via the public API and either 200 OK or 201
+      // Created for requests via the admin API. That way, the admin API will always be able to create, replace or remove documents,
+      // regardless of their authorized channels, roles or users, as intended.
       requireAccess([ ]);
     } else if (!channelMatch && !roleMatch && !userMatch) {
       // None of the authorization methods (e.g. channels, roles, users) succeeded

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -189,8 +189,6 @@ function verifyAuthorization(expectedAuthorization) {
     if (expectedAuthorization.expectedChannels) {
       expectedOperationChannels = expectedAuthorization.expectedChannels;
       verifyRequireAccess(expectedAuthorization.expectedChannels);
-    } else {
-      expect(requireAccess.callCount).to.be(0);
     }
 
     if (expectedAuthorization.expectedRoles) {
@@ -203,6 +201,10 @@ function verifyAuthorization(expectedAuthorization) {
       verifyRequireUser(expectedAuthorization.expectedUsers);
     } else {
       expect(requireUser.callCount).to.be(0);
+    }
+
+    if (!(expectedAuthorization.expectedChannels) && !(expectedAuthorization.expectedRoles) && !(expectedAuthorization.expectedUsers)) {
+      verifyRequireAccess([ ]);
     }
   }
 
@@ -314,7 +316,7 @@ function verifyAccessDenied(doc, oldDoc, expectedAuthorization) {
     if (typeof(expectedAuthorization) === 'string' || expectedAuthorization instanceof Array) {
       expect(ex).to.eql(channelAccessDenied);
     } else if (countAuthorizationTypes(expectedAuthorization) === 0) {
-      expect(ex.forbidden).to.equal(generalAuthFailedMessage);
+      verifyRequireAccess([ ]);
     } else if (countAuthorizationTypes(expectedAuthorization) > 1) {
       expect(ex.forbidden).to.equal(generalAuthFailedMessage);
     } else if (expectedAuthorization.expectedChannels) {


### PR DESCRIPTION
Fixes an edge case where it is not possible to add, replace and/or remove a document via the Sync Gateway admin API if its document definition does not specify any authorization methods (channels, roles or users) for the corresponding operation type. By design, requests via the admin API should **always** be authorized to create, replace or remove documents.

Addresses an issue introduced with the implementations of #22 & #23.