### PR TITLE
Issue #25: Custom action metadata parameter

### DIFF
--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -832,7 +832,7 @@ function synctos(doc, oldDoc) {
     theDocDefinition.customActions.onValidationSucceeded(doc, oldDoc, customActionMetadata);
   }
 
-  if (theDocDefinition.accessAssignments) {
+  if (theDocDefinition.accessAssignments && theDocDefinition.accessAssignments.length > 0) {
     customActionMetadata.accessAssignments = assignUserAccess(doc, oldDoc, theDocDefinition.accessAssignments);
 
     if (theDocDefinition.customActions && typeof(theDocDefinition.customActions.onAccessAssignmentsSucceeded) === 'function') {

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -179,6 +179,12 @@ function synctos(doc, oldDoc) {
       // None of the authorization methods (e.g. channels, roles, users) succeeded
       throw({ forbidden: 'missing channel access' });
     }
+
+    return {
+      channels: authorizedChannels,
+      roles: authorizedRoles,
+      users: authorizedUsers
+    };
   }
 
   // Constructs the fully qualified path of the item at the top of the given stack
@@ -742,6 +748,7 @@ function synctos(doc, oldDoc) {
   function assignUserAccess(doc, oldDoc, accessAssignmentDefinitions) {
     var effectiveOldDoc = getEffectiveOldDoc(oldDoc);
 
+    var effectiveAssignments = [ ];
     for (var assignmentIndex = 0; assignmentIndex < accessAssignmentDefinitions.length; assignmentIndex++) {
       var definition = accessAssignmentDefinitions[assignmentIndex];
       var usersAndRoles = [ ];
@@ -760,7 +767,15 @@ function synctos(doc, oldDoc) {
       var channels = resolveCollectionDefinition(doc, effectiveOldDoc, definition.channels);
 
       access(usersAndRoles, channels);
+
+      effectiveAssignments.push({
+        type: 'channel',
+        usersAndRoles: usersAndRoles,
+        channels: channels
+      });
     }
+
+    return effectiveAssignments;
   }
 
   var rawDocDefinitions = %SYNC_DOCUMENT_DEFINITIONS%;
@@ -796,34 +811,41 @@ function synctos(doc, oldDoc) {
 
   var theDocDefinition = docDefinitions[theDocType];
 
+  var customActionMetadata = {
+    documentTypeId: theDocType,
+    documentDefinition: theDocDefinition
+  };
+
   if (theDocDefinition.customActions && typeof(theDocDefinition.customActions.onTypeIdentificationSucceeded) === 'function') {
-    theDocDefinition.customActions.onTypeIdentificationSucceeded(doc, oldDoc);
+    theDocDefinition.customActions.onTypeIdentificationSucceeded(doc, oldDoc, customActionMetadata);
   }
 
-  authorize(doc, oldDoc, theDocDefinition);
+  customActionMetadata.authorization = authorize(doc, oldDoc, theDocDefinition);
 
   if (theDocDefinition.customActions && typeof(theDocDefinition.customActions.onAuthorizationSucceeded) === 'function') {
-    theDocDefinition.customActions.onAuthorizationSucceeded(doc, oldDoc);
+    theDocDefinition.customActions.onAuthorizationSucceeded(doc, oldDoc, customActionMetadata);
   }
 
   validateDoc(doc, oldDoc, theDocDefinition, theDocType);
 
   if (theDocDefinition.customActions && typeof(theDocDefinition.customActions.onValidationSucceeded) === 'function') {
-    theDocDefinition.customActions.onValidationSucceeded(doc, oldDoc);
+    theDocDefinition.customActions.onValidationSucceeded(doc, oldDoc, customActionMetadata);
   }
 
   if (theDocDefinition.accessAssignments) {
-    assignUserAccess(doc, oldDoc, theDocDefinition.accessAssignments);
+    customActionMetadata.accessAssignments = assignUserAccess(doc, oldDoc, theDocDefinition.accessAssignments);
 
     if (theDocDefinition.customActions && typeof(theDocDefinition.customActions.onAccessAssignmentsSucceeded) === 'function') {
-      theDocDefinition.customActions.onAccessAssignmentsSucceeded(doc, oldDoc);
+      theDocDefinition.customActions.onAccessAssignmentsSucceeded(doc, oldDoc, customActionMetadata);
     }
   }
 
   // Getting here means the document write is authorized and valid, and the appropriate channel(s) should now be assigned
-  channel(getAllDocChannels(doc, oldDoc, theDocDefinition));
+  var allDocChannels = getAllDocChannels(doc, oldDoc, theDocDefinition);
+  channel(allDocChannels);
+  customActionMetadata.documentChannels = allDocChannels;
 
   if (theDocDefinition.customActions && typeof(theDocDefinition.customActions.onDocumentChannelAssignmentSucceeded) === 'function') {
-    theDocDefinition.customActions.onDocumentChannelAssignmentSucceeded(doc, oldDoc);
+    theDocDefinition.customActions.onDocumentChannelAssignmentSucceeded(doc, oldDoc, customActionMetadata);
   }
 }

--- a/test/access-assignment-spec.js
+++ b/test/access-assignment-spec.js
@@ -1,27 +1,9 @@
 var expect = require('expect.js');
-var simple = require('simple-mock');
-var fs = require('fs');
 var testHelper = require('../etc/test-helper.js');
-var errorFormatter = testHelper.validationErrorFormatter;
-
-// Load the contents of the sync function file into a global variable called syncFunction
-/*jslint evil: true */
-eval('var syncFunction = ' + fs.readFileSync('build/sync-functions/test-access-assignment-sync-function.js').toString());
-/*jslint evil: false */
-
-// Placeholders for stubbing built-in Sync Gateway support functions.
-// More info: http://developer.couchbase.com/mobile/develop/guides/sync-gateway/sync-function-api-guide/index.html
-var requireAccess;
-var channel;
-var access;
 
 describe('User and role access assignment:', function() {
   beforeEach(function() {
     testHelper.init('build/sync-functions/test-access-assignment-sync-function.js');
-
-    requireAccess = simple.stub();
-    channel = simple.stub();
-    access = simple.stub();
   });
 
   describe('Static assignment of channels to users and roles', function() {
@@ -66,8 +48,8 @@ describe('User and role access assignment:', function() {
         invalidProperty: 'foobar'
       };
 
-      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
-        expect(access.callCount).to.be(0);
+      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(testHelper.access.callCount).to.be(0);
       });
     });
 
@@ -78,8 +60,8 @@ describe('User and role access assignment:', function() {
       };
       var oldDoc = { _id: 'staticAccessDoc' };
 
-      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
-        expect(access.callCount).to.be(0);
+      expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        expect(testHelper.access.callCount).to.be(0);
       });
     });
   });
@@ -158,8 +140,8 @@ describe('User and role access assignment:', function() {
         invalidProperty: 'foobar'
       };
 
-      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
-        expect(access.callCount).to.be(0);
+      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+        expect(testHelper.access.callCount).to.be(0);
       });
     });
 
@@ -172,8 +154,8 @@ describe('User and role access assignment:', function() {
       };
       var oldDoc = { _id: 'dynamicAccessDoc' };
 
-      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
-        expect(access.callCount).to.be(0);
+      expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        expect(testHelper.access.callCount).to.be(0);
       });
     });
   });

--- a/test/custom-actions-spec.js
+++ b/test/custom-actions-spec.js
@@ -3,6 +3,11 @@ var errorFormatter = testHelper.validationErrorFormatter;
 var expect = require('expect.js');
 
 describe('Custom actions:', function() {
+  var expectedAuthorization = {
+    expectedChannels: [ 'write-channel' ],
+    expectedRoles: [ 'write-role' ],
+    expectedUsers: [ 'write-user' ]
+  };
 
   beforeEach(function() {
     testHelper.init('build/sync-functions/test-custom-actions-sync-function.js');
@@ -10,34 +15,29 @@ describe('Custom actions:', function() {
 
   describe('the onTypeIdentificationSucceeded event', function() {
     var docType = 'onTypeIdentifiedDoc';
+    var doc = { _id: docType };
+    var oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', function() {
-      var doc = { _id: docType };
-
-      testHelper.verifyDocumentCreated(doc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentCreated(doc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, undefined, 'onTypeIdentificationSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
-      var doc = { _id: docType };
-      var oldDoc = { _id: docType };
-
-      testHelper.verifyDocumentReplaced(doc, oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, oldDoc, 'onTypeIdentificationSucceeded');
     });
 
     it('executes a custom action when a document is deleted', function() {
-      var oldDoc = { _id: docType };
-
-      testHelper.verifyDocumentDeleted(oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentDeleted(oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(getDeletedDoc(docType), oldDoc, 'onTypeIdentificationSucceeded');
     });
 
     it('does not execute a custom action if the type cannot be identified', function() {
       var unknownDocType = 'foo';
       var doc = { _id: unknownDocType };
 
-      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+      expect(testHelper.syncFunction).withArgs(doc, expectedAuthorization).to.throwException(function(ex) {
         testHelper.verifyValidationErrors(unknownDocType, errorFormatter.unknownDocumentType(), ex);
       });
       verifyCustomActionNotExecuted();
@@ -46,60 +46,48 @@ describe('Custom actions:', function() {
 
   describe('the onAuthorizationSucceeded event', function() {
     var docType = 'onAuthorizationDoc';
+    var doc = { _id: docType };
+    var oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', function() {
-      var doc = { _id: docType };
-
-      testHelper.verifyDocumentCreated(doc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentCreated(doc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, undefined, 'onAuthorizationSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
-      var doc = { _id: docType };
-      var oldDoc = { _id: docType };
-
-      testHelper.verifyDocumentReplaced(doc, oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, oldDoc, 'onAuthorizationSucceeded');
     });
 
     it('executes a custom action when a document is deleted', function() {
-      var oldDoc = { _id: docType };
-
-      testHelper.verifyDocumentDeleted(oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentDeleted(oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(getDeletedDoc(docType), oldDoc, 'onAuthorizationSucceeded');
     });
 
     it('does not execute a custom action if authorization was denied', function() {
-      var doc = { _id: docType };
-
-      testHelper.verifyAccessDenied(doc, null, [ 'write' ]);
+      testHelper.verifyAccessDenied(doc, null, expectedAuthorization);
       verifyCustomActionNotExecuted();
     });
   });
 
   describe('the onValidationSucceeded event', function() {
     var docType = 'onValidationDoc';
+    var doc = { _id: docType };
+    var oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', function() {
-      var doc = { _id: docType };
-
-      testHelper.verifyDocumentCreated(doc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentCreated(doc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, undefined, 'onValidationSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
-      var doc = { _id: docType };
-      var oldDoc = { _id: docType };
-
-      testHelper.verifyDocumentReplaced(doc, oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, oldDoc, 'onValidationSucceeded');
     });
 
     it('executes a custom action when a document is deleted', function() {
-      var oldDoc = { _id: docType };
-
-      testHelper.verifyDocumentDeleted(oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentDeleted(oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(getDeletedDoc(docType), oldDoc, 'onValidationSucceeded');
     });
 
     it('does not execute a custom action if the document contents are invalid', function() {
@@ -108,74 +96,63 @@ describe('Custom actions:', function() {
         unsupportedProperty: 'foobar'
       };
 
-      testHelper.verifyDocumentNotCreated(doc, docType, errorFormatter.unsupportedProperty('unsupportedProperty'));
+      testHelper.verifyDocumentNotCreated(doc, docType, errorFormatter.unsupportedProperty('unsupportedProperty'), expectedAuthorization);
       verifyCustomActionNotExecuted();
     });
   });
 
   describe('the onAccessAssignmentsSucceeded event', function() {
     var docType = 'onAccessAssignmentsDoc';
+    var doc = { _id: docType };
+    var oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', function() {
-      var doc = { _id: docType };
-
-      testHelper.verifyDocumentCreated(doc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentCreated(doc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, undefined, 'onAccessAssignmentsSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
-      var doc = { _id: docType };
-      var oldDoc = { _id: docType };
-
-      testHelper.verifyDocumentReplaced(doc, oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, oldDoc, 'onAccessAssignmentsSucceeded');
     });
 
     it('executes a custom action when a document is deleted', function() {
-      var oldDoc = { _id: docType };
-
-      testHelper.verifyDocumentDeleted(oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentDeleted(oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(getDeletedDoc(docType), oldDoc, 'onAccessAssignmentsSucceeded');
     });
 
     it('does not execute a custom action if the document definition does not define access assignments', function() {
       var doc = { _id: 'missingAccessAssignmentsDoc' };
 
-      testHelper.verifyDocumentCreated(doc);
+      testHelper.verifyDocumentCreated(doc, expectedAuthorization);
       verifyCustomActionNotExecuted();
     });
   });
 
   describe('the onDocumentChannelAssignmentSucceeded event', function() {
     var docType = 'onDocChannelsAssignedDoc';
+    var doc = { _id: docType };
+    var oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', function() {
-      var doc = { _id: docType };
-
-      testHelper.verifyDocumentCreated(doc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentCreated(doc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, undefined, 'onDocumentChannelAssignmentSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
-      var doc = { _id: docType };
-      var oldDoc = { _id: docType };
 
-      testHelper.verifyDocumentReplaced(doc, oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(doc, oldDoc, 'onDocumentChannelAssignmentSucceeded');
     });
 
     it('executes a custom action when a document is deleted', function() {
-      var oldDoc = { _id: docType };
-
-      testHelper.verifyDocumentDeleted(oldDoc);
-      verifyCustomActionExecuted(docType);
+      testHelper.verifyDocumentDeleted(oldDoc, expectedAuthorization);
+      verifyCustomActionExecuted(getDeletedDoc(docType), oldDoc, 'onDocumentChannelAssignmentSucceeded');
     });
 
     it('does not execute a custom action if doc channel assignment fails', function() {
       var expectedError = new Error('bad channels!');
       testHelper.channel.throwWith(expectedError);
-
-      var doc = { _id: docType };
 
       expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
         expect(ex).to.equal(expectedError);
@@ -185,11 +162,68 @@ describe('Custom actions:', function() {
   });
 });
 
-function verifyCustomActionExecuted(docType) {
+function verifyCustomActionExecuted(doc, oldDoc, expectedActionType) {
   expect(testHelper.customActionStub.callCount).to.be(1);
-  expect(testHelper.customActionStub.calls[0].arg).to.eql(docType);
+  expect(testHelper.customActionStub.calls[0].args[0]).to.eql(doc);
+  expect(testHelper.customActionStub.calls[0].args[1]).to.eql(oldDoc);
+
+  verifyCustomActionMetadata(testHelper.customActionStub.calls[0].args[2], doc._id, expectedActionType);
 }
 
 function verifyCustomActionNotExecuted() {
   expect(testHelper.customActionStub.callCount).to.be(0);
+}
+
+function verifyCustomActionMetadata(actualMetadata, docType, expectedActionType) {
+  verifyTypeMetadata(actualMetadata, docType);
+  verifyAuthorizationMetadata(actualMetadata);
+  verifyAccessAssignmentMetadata(actualMetadata);
+  verifyDocChannelsMetadata(actualMetadata);
+  verifyCustomActionTypeMetadata(actualMetadata, expectedActionType);
+}
+
+function verifyTypeMetadata(actualMetadata, docType) {
+  expect(actualMetadata.documentTypeId).to.be(docType);
+  expect(actualMetadata.documentDefinition.typeFilter({ _id: docType })).to.be(true);
+}
+
+function verifyAuthorizationMetadata(actualMetadata) {
+  var expectedAuthMetadata = {
+    channels: [ 'write-channel' ],
+    roles: [ 'write-role' ],
+    users: [ 'write-user' ]
+  };
+  expect(actualMetadata.authorization).to.eql(expectedAuthMetadata);
+}
+
+function verifyAccessAssignmentMetadata(actualMetadata) {
+  if (actualMetadata.documentDefinition.accessAssignments) {
+    var expectedAssignments = [ ];
+    for (var i = 0; i < actualMetadata.documentDefinition.accessAssignments.length; i++) {
+      var assignment = actualMetadata.documentDefinition.accessAssignments[i];
+      expectedAssignments.push({
+        type: 'channel',
+        channels: [ assignment.channels ],
+        usersAndRoles: [ assignment.users, 'role:' + assignment.roles ]
+      });
+    }
+    expect(actualMetadata.accessAssignments).to.eql(expectedAssignments);
+  } else {
+    expect(actualMetadata.accessAssignments).to.be(undefined);
+  }
+}
+
+function verifyDocChannelsMetadata(actualMetadata) {
+  expect(actualMetadata.documentChannels).to.eql([ 'write-channel' ]);
+}
+
+function verifyCustomActionTypeMetadata(actualMetadata, expectedActionType) {
+  expect(actualMetadata.actionType).to.be(expectedActionType);
+}
+
+function getDeletedDoc(docType) {
+  return {
+    _id: docType,
+    _deleted: true
+  };
 }

--- a/test/custom-actions-spec.js
+++ b/test/custom-actions-spec.js
@@ -127,6 +127,13 @@ describe('Custom actions:', function() {
       testHelper.verifyDocumentCreated(doc, expectedAuthorization);
       verifyCustomActionNotExecuted();
     });
+
+    it('does not execute a custom action if the document definition has an empty access assignments definition', function() {
+      var doc = { _id: 'emptyAccessAssignmentsDoc' };
+
+      testHelper.verifyDocumentCreated(doc, expectedAuthorization);
+      verifyCustomActionNotExecuted();
+    });
   });
 
   describe('the onDocumentChannelAssignmentSucceeded event', function() {

--- a/test/general-spec.js
+++ b/test/general-spec.js
@@ -1,34 +1,17 @@
 var expect = require('expect.js');
-var simple = require('simple-mock');
-var fs = require('fs');
 var testHelper = require('../etc/test-helper.js');
 var errorFormatter = testHelper.validationErrorFormatter;
 
-// Load the contents of the sync function file into a global variable called syncFunction
-/*jslint evil: true */
-eval('var syncFunction = ' + fs.readFileSync('build/sync-functions/test-general-sync-function.js').toString());
-/*jslint evil: false */
-
-// Placeholders for stubbing built-in Sync Gateway support functions.
-// More info: http://developer.couchbase.com/mobile/develop/guides/sync-gateway/sync-function-api-guide/index.html
-var requireAccess;
-var requireRole;
-var requireUser;
-var channel;
-
 describe('Functionality that is common to all documents:', function() {
   beforeEach(function() {
-    requireAccess = simple.stub();
-    requireRole = simple.stub();
-    requireUser = simple.stub();
-    channel = simple.stub();
+    testHelper.init('build/sync-functions/test-general-sync-function.js');
   });
 
   describe('the document type identifier', function() {
     it('rejects document creation with an unrecognized doc type', function() {
       var doc = { _id: 'my-invalid-doc' };
 
-      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
         expect(ex).to.eql({ forbidden: 'Unknown document type' });
       });
     });
@@ -37,7 +20,7 @@ describe('Functionality that is common to all documents:', function() {
       var doc = { _id: 'my-invalid-doc', foo: 'bar' };
       var oldDoc = { _id: 'my-invalid-doc' };
 
-      expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+      expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
         expect(ex).to.eql({ forbidden: 'Unknown document type' });
       });
     });
@@ -45,7 +28,7 @@ describe('Functionality that is common to all documents:', function() {
     it('rejects document deletion with an unrecognized type', function() {
       var doc = { _id: 'my-invalid-doc', _deleted: true };
 
-      expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
         expect(ex).to.eql({ forbidden: 'Unknown document type' });
       });
     });
@@ -164,7 +147,7 @@ describe('Functionality that is common to all documents:', function() {
       }
     };
 
-    expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+    expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
       testHelper.verifyValidationErrors(
         'generalDoc',
         [
@@ -189,7 +172,7 @@ describe('Functionality that is common to all documents:', function() {
       }
     };
 
-    expect(syncFunction).withArgs(doc).to.throwException(function(ex) {
+    expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
       testHelper.verifyValidationErrors('generalDoc', errorFormatter.allowAttachmentsViolation(), ex);
     });
   });

--- a/test/resources/custom-actions-doc-definitions.js
+++ b/test/resources/custom-actions-doc-definitions.js
@@ -1,39 +1,55 @@
 function() {
-  function customAction(doc, oldDoc) {
-    // This function is defined as a stub by the test-helper module to make it easy to verify whether a custom action has been executed
-    customActionStub(doc._id);
+  function customAction(actionType) {
+    return function(doc, oldDoc, customActionMetadata) {
+      customActionMetadata.actionType = actionType;
+
+      // This function is defined as a stub by the test-helper module to make it easy to verify whether a custom action has been executed
+      customActionStub(doc, oldDoc, customActionMetadata);
+    };
   }
+
+  var channels = { write: 'write-channel' };
+  var authorizedRoles = { write: 'write-role' };
+  var authorizedUsers = { write: 'write-user' };
 
   return {
     onTypeIdentifiedDoc: {
       typeFilter: function(doc, oldDoc) {
         return doc._id === 'onTypeIdentifiedDoc';
       },
-      channels: { write: 'write' },
+      channels: channels,
+      authorizedRoles: authorizedRoles,
+      authorizedUsers: authorizedUsers,
       propertyValidators: { },
-      customActions: { onTypeIdentificationSucceeded: customAction }
+      customActions: { onTypeIdentificationSucceeded: customAction('onTypeIdentificationSucceeded') }
     },
     onAuthorizationDoc: {
       typeFilter: function(doc, oldDoc) {
         return doc._id === 'onAuthorizationDoc';
       },
-      channels: { write: 'write' },
+      channels: channels,
+      authorizedRoles: authorizedRoles,
+      authorizedUsers: authorizedUsers,
       propertyValidators: { },
-      customActions: { onAuthorizationSucceeded: customAction }
+      customActions: { onAuthorizationSucceeded: customAction('onAuthorizationSucceeded') }
     },
     onValidationDoc: {
       typeFilter: function(doc, oldDoc) {
         return doc._id === 'onValidationDoc';
       },
-      channels: { write: 'write' },
+      channels: channels,
+      authorizedRoles: authorizedRoles,
+      authorizedUsers: authorizedUsers,
       propertyValidators: { },
-      customActions: { onValidationSucceeded: customAction }
+      customActions: { onValidationSucceeded: customAction('onValidationSucceeded') }
     },
     onAccessAssignmentsDoc: {
       typeFilter: function(doc, oldDoc) {
         return doc._id === 'onAccessAssignmentsDoc';
       },
-      channels: { write: 'write' },
+      channels: channels,
+      authorizedRoles: authorizedRoles,
+      authorizedUsers: authorizedUsers,
       propertyValidators: { },
       accessAssignments: [
         {
@@ -42,23 +58,27 @@ function() {
           channels: 'channel1'
         }
       ],
-      customActions: { onAccessAssignmentsSucceeded: customAction }
+      customActions: { onAccessAssignmentsSucceeded: customAction('onAccessAssignmentsSucceeded') }
     },
     missingAccessAssignmentsDoc: {
       typeFilter: function(doc, oldDoc) {
         return doc._id === 'missingAccessAssignmentsDoc';
       },
-      channels: { write: 'write' },
+      channels: channels,
+      authorizedRoles: authorizedRoles,
+      authorizedUsers: authorizedUsers,
       propertyValidators: { },
-      customActions: { onAccessAssignmentsSucceeded: customAction }
+      customActions: { onAccessAssignmentsSucceeded: customAction('onAccessAssignmentsSucceeded') }
     },
     onDocChannelsAssignedDoc: {
       typeFilter: function(doc, oldDoc) {
         return doc._id === 'onDocChannelsAssignedDoc';
       },
-      channels: { write: 'write' },
+      channels: channels,
+      authorizedRoles: authorizedRoles,
+      authorizedUsers: authorizedUsers,
       propertyValidators: { },
-      customActions: { onDocumentChannelAssignmentSucceeded: customAction }
+      customActions: { onDocumentChannelAssignmentSucceeded: customAction('onDocumentChannelAssignmentSucceeded') }
     }
   };
 }

--- a/test/resources/custom-actions-doc-definitions.js
+++ b/test/resources/custom-actions-doc-definitions.js
@@ -70,6 +70,17 @@ function() {
       propertyValidators: { },
       customActions: { onAccessAssignmentsSucceeded: customAction('onAccessAssignmentsSucceeded') }
     },
+    emptyAccessAssignmentsDoc: {
+      typeFilter: function(doc, oldDoc) {
+        return doc._id === 'emptyAccessAssignmentsDoc';
+      },
+      channels: channels,
+      authorizedRoles: authorizedRoles,
+      authorizedUsers: authorizedUsers,
+      propertyValidators: { },
+      accessAssignments: [ ],
+      customActions: { onAccessAssignmentsSucceeded: customAction('onAccessAssignmentsSucceeded') }
+    },
     onDocChannelsAssignedDoc: {
       typeFilter: function(doc, oldDoc) {
         return doc._id === 'onDocChannelsAssignedDoc';


### PR DESCRIPTION
Adds support for an additional function parameter passed to custom actions that specifies, depending on the event, the document type ID and definition, the authorization that was applied for the operation, the channel access that was assigned to users/roles and the channels that were assigned to the document. Also allows for custom metadata to be passed from one custom action to another. Refer to the updated README for more info.

With this PR and #62, issue #25 should be fully addressed.