### PR TITLE
Issue 61: Assign role access to users

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,6 +16,7 @@
     "customActionStub": false,
     "requireAccess": false,
     "requireRole": false,
-    "requireUser": false
+    "requireUser": false,
+    "role": false
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - [#25](https://github.com/Kashoo/synctos/issues/25): Support custom actions to be executed on a document type
+- [#61](https://github.com/Kashoo/synctos/issues/61): Support dynamic assignment of roles to users
 
 ## [1.4.0] - 2016-11-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -270,19 +270,33 @@ Or:
     }
 ```
 
-* `accessAssignments`: (optional) Defines the channels to dynamically assign to users and/or roles when a document of the corresponding type is successfully created, replaced or deleted. It is specified as a list, where each entry is an object that defines `users`, `roles` and/or `channels` properties. The value of each property can be either a list of strings that specify the raw user/role/channel names or a function that returns the corresponding values as a dynamically-constructed list and accepts the following parameters: (1) the new document and (2) the old document that is being replaced/deleted (if any). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be `true`, so be sure to account for such cases. And, if the old document has been deleted or simply does not exist, the second parameter will be `null`. An example:
+* `accessAssignments`: (optional) Defines either the channel access to assign to users/roles or the role access to assign to users when a document of the corresponding type is successfully created, replaced or deleted. It is specified as a list, where each entry is an object that defines `users`, `roles` and/or `channels` properties, depending on the access assignment type. The value of each property can be either a list of strings that specify the raw user/role/channel names or a function that returns the corresponding values as a dynamically-constructed list and accepts the following parameters: (1) the new document and (2) the old document that is being replaced/deleted (if any). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be `true`, so be sure to account for such cases. And, if the old document has been deleted or simply does not exist, the second parameter will be `null`. The assignment types are specified as follows:
+  * Channel access assignments:
+    * `type`: May be either "channel", `null` or `undefined`.
+    * `channels`: The channels to assign to users and/or roles.
+    * `roles`: The roles to which to assign the channels.
+    * `users`: The users to which to assign the channels.
+  * Role access assignments:
+    * `type`: Must be "role".
+    * `roles`: The roles to assign to users.
+    * `users`: The users to which to assign the roles.
+
+An example of a mix of channel and role access assignments:
 
 ```
     accessAssignments: [
       {
+        type: 'role',
+        users: [ 'user3', 'user4' ],
+        roles: [ 'role1', 'role2' ]
+      },
+      {
+        type: 'channel',
         users: [ 'user1', 'user2' ],
         channels: [ 'channel1' ]
       },
       {
-        roles: [ 'role1', 'role2' ],
-        channels: [ 'channel2' ]
-      },
-      {
+        type: 'channel',
         users: function(doc, oldDoc) {
           return doc.users;
         },
@@ -309,7 +323,15 @@ Or:
     * `authorization`: An object that indicates which channels, roles and users were used to authorize the current operation, as specified by the `channels`, `roles` and `users` list properties.
   3. `onValidationSucceeded`: Executed immediately after the document's contents are validated and before channels are assigned to users/roles and the document. Not executed if the document's contents are invalid. The custom action metadata object parameter includes properties from all previous events but does not include any additional properties.
   4. `onAccessAssignmentsSucceeded`: Executed immediately after channel access is assigned to users/roles and before channels are assigned to the document. Not executed if the document definition does not include an `accessAssignments` property. The custom action metadata object parameter includes properties from all previous events in addition to the following properties:
-    * `accessAssignments`: A list that contains each of the access assignments that were applied, where each element's `usersAndRoles` property is a list of the users and roles and the `channels` property is a list of the channels that were granted to them. Note that, as per the sync function API, each role element's value is prefixed with "role:".
+    * `accessAssignments`: A list that contains each of the access assignments that were applied. Each element is an object that represents either a channel access assignment or a role access assignment depending on the value of its `type` property. The assignment types are specified as follows:
+      * Channel access assignments:
+        * `type`: Value of "channel".
+        * `channels`: A list of channels that were assigned to the users/roles.
+        * `usersAndRoles`: A list of the combined users and/or roles to which the channels were assigned. Note that, as per the sync function API, each role element's value is prefixed with "role:".
+      * Role access assignments:
+        * `type`: Value of "role".
+        * `roles`: A list of roles that were assigned to the users.
+        * `users`: A list of users to which the roles were assigned. Note that, as per the sync function API, each role element's value is prefixed with "role:".
   5. `onDocumentChannelAssignmentSucceeded`: Executed immediately after channels are assigned to the document. The last step before the sync function is finished executing and the document revision is written. The custom action metadata object parameter includes properties from all previous events in addition to the following properties:
     * `documentChannels`: A list of channels that were assigned to the document.
 

--- a/etc/.jshintrc
+++ b/etc/.jshintrc
@@ -7,6 +7,7 @@
     "customActionStub": true,
     "requireAccess": true,
     "requireRole": true,
-    "requireUser": true
+    "requireUser": true,
+    "role": true
   }
 }

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -796,7 +796,6 @@ function synctos(doc, oldDoc) {
     for (var assignmentIndex = 0; assignmentIndex < accessAssignmentDefinitions.length; assignmentIndex++) {
       var definition = accessAssignmentDefinitions[assignmentIndex];
 
-      var effectiveAssignment = null;
       if (definition.type === 'role') {
         effectiveAssignments.push(assignRolesToUsers(doc, effectiveOldDoc, definition));
       } else if (definition.type === 'channel' || isValueNullOrUndefined(definition.type)) {

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -744,35 +744,64 @@ function synctos(doc, oldDoc) {
     }
   }
 
-  // Assigns channels to users and roles according to the given access assignment definitions
+  // Transforms a role collection definition into a simple list and prefixes each element with "role:"
+  function resolveRoleCollectionDefinition(doc, oldDoc, rolesDefinition) {
+    return resolveCollectionDefinition(doc, oldDoc, rolesDefinition, 'role:');
+  }
+
+  // Assigns channel access to users/roles
+  function assignChannelsToUsersAndRoles(doc, oldDoc, accessAssignmentDefinition) {
+    var usersAndRoles = [ ];
+
+    var users = resolveCollectionDefinition(doc, oldDoc, accessAssignmentDefinition.users);
+    for (var userIndex = 0; userIndex < users.length; userIndex++) {
+      usersAndRoles.push(users[userIndex]);
+    }
+
+    var roles = resolveRoleCollectionDefinition(doc, oldDoc, accessAssignmentDefinition.roles);
+    for (var roleIndex = 0; roleIndex < roles.length; roleIndex++) {
+      usersAndRoles.push(roles[roleIndex]);
+    }
+
+    var channels = resolveCollectionDefinition(doc, oldDoc, accessAssignmentDefinition.channels);
+
+    access(usersAndRoles, channels);
+
+    return {
+      type: 'channel',
+      usersAndRoles: usersAndRoles,
+      channels: channels
+    };
+  }
+
+  // Assigns role access to users
+  function assignRolesToUsers(doc, oldDoc, accessAssignmentDefinition) {
+    var users = resolveCollectionDefinition(doc, oldDoc, accessAssignmentDefinition.users);
+    var roles = resolveRoleCollectionDefinition(doc, oldDoc, accessAssignmentDefinition.roles);
+
+    role(users, roles);
+
+    return {
+      type: 'role',
+      users: users,
+      roles: roles
+    };
+  }
+
+  // Assigns role access to users and/or channel access to users/roles according to the given access assignment definitions
   function assignUserAccess(doc, oldDoc, accessAssignmentDefinitions) {
     var effectiveOldDoc = getEffectiveOldDoc(oldDoc);
 
     var effectiveAssignments = [ ];
     for (var assignmentIndex = 0; assignmentIndex < accessAssignmentDefinitions.length; assignmentIndex++) {
       var definition = accessAssignmentDefinitions[assignmentIndex];
-      var usersAndRoles = [ ];
 
-      var users = resolveCollectionDefinition(doc, effectiveOldDoc, definition.users);
-      for (var userIndex = 0; userIndex < users.length; userIndex++) {
-        usersAndRoles.push(users[userIndex]);
+      var effectiveAssignment = null;
+      if (definition.type === 'role') {
+        effectiveAssignments.push(assignRolesToUsers(doc, effectiveOldDoc, definition));
+      } else if (definition.type === 'channel' || isValueNullOrUndefined(definition.type)) {
+        effectiveAssignments.push(assignChannelsToUsersAndRoles(doc, effectiveOldDoc, definition));
       }
-
-      // Role names must begin with the special token "role:" to distinguish them from users
-      var roles = resolveCollectionDefinition(doc, effectiveOldDoc, definition.roles, 'role:');
-      for (var roleIndex = 0; roleIndex < roles.length; roleIndex++) {
-        usersAndRoles.push(roles[roleIndex]);
-      }
-
-      var channels = resolveCollectionDefinition(doc, effectiveOldDoc, definition.channels);
-
-      access(usersAndRoles, channels);
-
-      effectiveAssignments.push({
-        type: 'channel',
-        usersAndRoles: usersAndRoles,
-        channels: channels
-      });
     }
 
     return effectiveAssignments;
@@ -840,7 +869,7 @@ function synctos(doc, oldDoc) {
     }
   }
 
-  // Getting here means the document write is authorized and valid, and the appropriate channel(s) should now be assigned
+  // Getting here means the document revision is authorized and valid, and the appropriate channel(s) should now be assigned
   var allDocChannels = getAllDocChannels(doc, oldDoc, theDocDefinition);
   channel(allDocChannels);
   customActionMetadata.documentChannels = allDocChannels;

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -104,23 +104,11 @@ function areUnorderedListsEqual(list1, list2) {
   return true;
 }
 
-function channelAccessAssignmentCallExists(expectedUsersAndRoles, expectedChannels) {
-  // Try to find an actual channel access assignment call that matches the expected call
-  for (var accessCallIndex = 0; accessCallIndex < access.callCount; accessCallIndex++) {
-    var accessCall = access.calls[accessCallIndex];
-    if (areUnorderedListsEqual(accessCall.args[0], expectedUsersAndRoles) && areUnorderedListsEqual(accessCall.args[1], expectedChannels)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function roleAccessAssignmentCallExists(expectedUsers, expectedRoles) {
-  // Try to find an actual role access assignment call that matches the expected call
-  for (var accessCallIndex = 0; accessCallIndex < role.callCount; accessCallIndex++) {
-    var accessCall = role.calls[accessCallIndex];
-    if (areUnorderedListsEqual(accessCall.args[0], expectedUsers) && areUnorderedListsEqual(accessCall.args[1], expectedRoles)) {
+function accessAssignmentCallExists(accessFunction, expectedParam1, expectedParam2) {
+  // Try to find an actual channel/role access assignment call that matches the expected call
+  for (var accessCallIndex = 0; accessCallIndex < accessFunction.callCount; accessCallIndex++) {
+    var accessCall = accessFunction.calls[accessCallIndex];
+    if (areUnorderedListsEqual(accessCall.args[0], expectedParam1) && areUnorderedListsEqual(accessCall.args[1], expectedParam2)) {
       return true;
     }
   }
@@ -167,7 +155,7 @@ function verifyChannelAccessAssignment(expectedAssignment) {
     }
   }
 
-  if (!channelAccessAssignmentCallExists(expectedUsersAndRoles, expectedChannels)) {
+  if (!accessAssignmentCallExists(access, expectedUsersAndRoles, expectedChannels)) {
     expect().fail(
       'Missing expected call to assign channel access (' +
       JSON.stringify(expectedChannels) +
@@ -200,7 +188,7 @@ function verifyRoleAccessAssignment(expectedAssignment) {
     }
   }
 
-  if (!roleAccessAssignmentCallExists(expectedUsers, expectedRoles)) {
+  if (!accessAssignmentCallExists(role, expectedUsers, expectedRoles)) {
     expect().fail(
       'Missing expected call to assign role access (' +
       JSON.stringify(expectedRoles) +

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -2,11 +2,12 @@
   "extends": "../.jshintrc",
   "undef": false,
   "globals": {
-    "access": true,
-    "channel": true,
-    "customActionStub": true,
-    "requireAccess": true,
-    "requireRole": true,
-    "requireUser": true
+    "access": false,
+    "channel": false,
+    "customActionStub": false,
+    "requireAccess": false,
+    "requireRole": false,
+    "requireUser": false,
+    "role": false
   }
 }

--- a/test/access-assignment-spec.js
+++ b/test/access-assignment-spec.js
@@ -9,17 +9,25 @@ describe('User and role access assignment:', function() {
   describe('Static assignment of channels to users and roles', function() {
     var expectedStaticAssignments = [
       {
+        expectedType: 'channel',
         expectedUsers: [ 'user2', 'user1', 'user4' ],
         expectedRoles: [ 'role2', 'role1' ],
         expectedChannels: [ 'channel1', 'channel2' ]
       },
       {
+        expectedType: 'channel',
         expectedUsers: 'user3',
         expectedChannels: 'channel3'
       },
       {
+        expectedType: 'channel',
         expectedRoles: 'role3',
         expectedChannels: 'channel4'
+      },
+      {
+        expectedType: 'role',
+        expectedUsers: 'user5',
+        expectedRoles: 'role4'
       }
     ];
 
@@ -74,17 +82,25 @@ describe('User and role access assignment:', function() {
     };
     var expectedDynamicAssignments = [
       {
+        expectedType: 'channel',
         expectedUsers: doc.users,
         expectedRoles: doc.roles,
         expectedChannels: [ doc._id + '-channel1', doc._id + '-channel2' ]
       },
       {
+        expectedType: 'channel',
         expectedUsers: doc.users,
         expectedChannels: [ doc._id + '-channel3' ]
       },
       {
+        expectedType: 'channel',
         expectedRoles: doc.roles,
         expectedChannels: [ doc._id + '-channel4' ]
+      },
+      {
+        expectedType: 'role',
+        expectedUsers: doc.users,
+        expectedRoles: doc.roles
       }
     ];
 
@@ -115,17 +131,25 @@ describe('User and role access assignment:', function() {
 
       var expectedDeleteAssignments = [
         {
+          expectedType: 'channel',
           expectedUsers: null,
           expectedChannels: [ doc._id + '-channel3' ]
         },
         {
+          expectedType: 'channel',
           expectedRoles: null,
           expectedChannels: [ doc._id + '-channel4' ]
         },
         {
+          expectedType: 'channel',
           expectedUsers: null,
           expectedRoles: null,
           expectedChannels: [ doc._id + '-channel2', doc._id + '-channel1' ]
+        },
+        {
+          expectedType: 'role',
+          expectedUsers: null,
+          expectedRoles: null
         }
       ];
 

--- a/test/resources/access-assignment-doc-definitions.js
+++ b/test/resources/access-assignment-doc-definitions.js
@@ -6,17 +6,25 @@
     },
     accessAssignments: [
       {
+        type: 'channel',
         users: 'user3',
         channels: 'channel3'
       },
       {
+        type: 'channel',
         roles: 'role3',
         channels: 'channel4'
       },
       {
+        // With no "type" property defined, it should default to channel access assignment
         users: [ 'user1', 'user2', 'user4' ],
         roles: [ 'role1', 'role2' ],
         channels: [ 'channel1', 'channel2' ]
+      },
+      {
+        type: 'role',
+        users: 'user5',
+        roles: 'role4'
       }
     ]
   },
@@ -35,8 +43,18 @@
     },
     accessAssignments: [
       {
+        type: 'role',
         users: function(doc, oldDoc) {
           // The sync function template should automatically replace the oldDoc param value with null if its _deleted property is true
+          return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.users;
+        },
+        roles: function(doc, oldDoc) {
+          return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.roles;
+        }
+      },
+      {
+        type: 'channel',
+        users: function(doc, oldDoc) {
           return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.users;
         },
         roles: function(doc, oldDoc) {
@@ -47,6 +65,7 @@
         }
       },
       {
+        // With no "type" property defined, it should default to channel access assignment
         roles: function(doc, oldDoc) {
           return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.roles;
         },
@@ -55,6 +74,7 @@
         }
       },
       {
+        // With no "type" property defined, it should default to channel access assignment
         users: function(doc, oldDoc) {
           return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.users;
         },


### PR DESCRIPTION
Adds a new type of access assignment that dynamically assigns roles to users by way of the standard sync function API's `role` function. Complementary to the channel access assignment feature that was introduced for #24 (Support dynamic assignment of channels to roles and users).

Addresses issue #61.