### PR TITLE
Update change log for release of v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.5.0] - 2016-12-14
 ### Added
 - [#25](https://github.com/Kashoo/synctos/issues/25): Support custom actions to be executed on a document type
 - [#61](https://github.com/Kashoo/synctos/issues/61): Support dynamic assignment of roles to users
@@ -43,7 +43,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [#36](https://github.com/Kashoo/synctos/issues/36): Does not return a non-zero exit status when sync function generation fails
 
-[Unreleased]: https://github.com/Kashoo/synctos/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/Kashoo/synctos/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/Kashoo/synctos/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/Kashoo/synctos/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/Kashoo/synctos/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/Kashoo/synctos/compare/v1.2.0...v1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [#36](https://github.com/Kashoo/synctos/issues/36): Does not return a non-zero exit status when sync function generation fails
 
+## [1.0.0] - 2016-07-12
+First public release
+
 [Unreleased]: https://github.com/Kashoo/synctos/compare/v1.5.0...HEAD
 [1.5.0]: https://github.com/Kashoo/synctos/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/Kashoo/synctos/compare/v1.3.1...v1.4.0
@@ -50,3 +53,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [1.3.0]: https://github.com/Kashoo/synctos/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Kashoo/synctos/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Kashoo/synctos/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/Kashoo/synctos/compare/57a18bd...v1.0.0


### PR DESCRIPTION
This is the final step before the package is published to npm.

Note the "Unreleased" section will be restored to the change log after the release is published.

Also, I added a link to the commits for v1.0.0 to the change log.