### PR TITLE
Update change log for release of v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.6.0] - 2017-01-18
 ### Added
 - [#66](https://github.com/Kashoo/synctos/issues/66): Modular document definition files
 - [#69](https://github.com/Kashoo/synctos/issues/69): Helper function to determine whether a document is missing or deleted
@@ -52,7 +52,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.0.0] - 2016-07-12
 First public release
 
-[Unreleased]: https://github.com/Kashoo/synctos/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/Kashoo/synctos/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/Kashoo/synctos/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/Kashoo/synctos/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/Kashoo/synctos/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/Kashoo/synctos/compare/v1.3.0...v1.3.1


### PR DESCRIPTION
This is the final step before the package is published to npm.

Note that the "Unreleased" section will be restored to the change log after the release is published.