### PR TITLE
Issue 73: Implicitly allow type property when using the simple type filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#66](https://github.com/Kashoo/synctos/issues/66): Modular document definition files
 - [#69](https://github.com/Kashoo/synctos/issues/69): Helper function to determine whether a document is missing or deleted
 - [#72](https://github.com/Kashoo/synctos/issues/72): New property validation type for type identifier properties
+- [#73](https://github.com/Kashoo/synctos/issues/73): Include an implicit type property when a simple type filter is used
 
 ## [1.5.0] - 2016-12-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ At the top level, the document definitions object contains a property for each d
 
 Each document type is specified as an object with the following properties:
 
-* `typeFilter`: (required) A function that is used to identify documents of this type. It accepts as function parameters (1) the new document, (2) the old document that is being replaced (if any) and (3) the name of the current document type. For the sake of convenience, a simple type filter function (`simpleTypeFilter`) is available that attempts to match the document's `type` property to the document type's name (e.g. if a document definition is named "message", then a candidate document's `type` property must be "message" to be considered a document of that type). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be `true`, so be sure to account for such cases. And, if the old document has been deleted or simply does not exist, the second parameter will be `null`.
+* `typeFilter`: (required) A function that is used to identify documents of this type. It accepts as function parameters (1) the new document, (2) the old document that is being replaced (if any) and (3) the name of the current document type. For the sake of convenience, a simple type filter function (`simpleTypeFilter`) is available that attempts to match the document's `type` property value to the document type's name (e.g. if a document definition is named "message", then a candidate document's `type` property value must be "message" to be considered a document of that type); if the document definition does not include an explicit `type` property validator, then, for convenience, the `type` property will be implicitly validated with the built in `typeIdValidator` (see the validator's description for more info). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be `true`, so be sure to account for such cases. And, if the old document has been deleted or simply does not exist, the second parameter will be `null`.
 
 An example of the simple type filter:
 
@@ -418,7 +418,7 @@ Validation for complex data types, which allow for nesting of child properties a
 
 The following predefined property validators may also be useful:
 
-* `typeIdValidator`: A property validator that is suitable for application to the property that specifies the type of a document. Its constraints include ensuring the value is a string, is neither null nor undefined, is not an empty string and cannot be modified. An example:
+* `typeIdValidator`: A property validator that is suitable for application to the property that specifies the type of a document. Its constraints include ensuring the value is a string, is neither null nor undefined, is not an empty string and cannot be modified. NOTE: If a document type specifies `simpleTypeFilter` as its type filter, it is not necessary to explicitly include a `type` property validator; it will be supported implicitly as a `typeIdValidator`. An example usage:
 
 ```
 propertyValidators: {

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -853,6 +853,11 @@ function synctos(doc, oldDoc) {
 
   var theDocDefinition = docDefinitions[theDocType];
 
+  // Ensure that, if the document type uses the simple type filter, it supports the "type" property
+  if (theDocDefinition.typeFilter === simpleTypeFilter && isValueNullOrUndefined(theDocDefinition.propertyValidators.type)) {
+    theDocDefinition.propertyValidators.type = typeIdValidator;
+  }
+
   var customActionMetadata = {
     documentTypeId: theDocType,
     documentDefinition: theDocDefinition

--- a/test/resources/simple-type-filter-doc-definitions.js
+++ b/test/resources/simple-type-filter-doc-definitions.js
@@ -1,5 +1,5 @@
 {
-  myDoc: {
+  myExplicitTypeValidatorDoc: {
     channels: { write: 'write' },
     typeFilter: simpleTypeFilter,
     propertyValidators: {
@@ -7,5 +7,10 @@
         type: 'string'
       }
     }
+  },
+  myImplicitTypeValidatorDoc: {
+    channels: { write: 'write' },
+    typeFilter: simpleTypeFilter,
+    propertyValidators: { }
   }
 }

--- a/test/simple-type-filter-spec.js
+++ b/test/simple-type-filter-spec.js
@@ -1,107 +1,117 @@
 var testHelper = require('../etc/test-helper.js');
 
-describe('Default type filter', function() {
+describe('Simple type filter', function() {
   beforeEach(function() {
     testHelper.init('build/sync-functions/test-simple-type-filter-sync-function.js');
   });
 
-  it('identifies a brand new document by its type property', function() {
-    var doc = {
-      _id: 'my-doc',
-      type: 'myDoc'
-    };
+  function testSimpleTypeFilter(docTypeId) {
+    it('identifies a brand new document by its type property', function() {
+      var doc = {
+        _id: 'my-doc',
+        type: docTypeId
+      };
 
-    testHelper.verifyDocumentCreated(doc);
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('identifies a new document that is replacing a deleted document by its type property', function() {
+      var doc = {
+        _id: 'my-doc',
+        type: docTypeId
+      };
+      var oldDoc = {
+        _id: 'my-doc',
+        _deleted: true
+      };
+
+      testHelper.verifyDocumentAccepted(doc, oldDoc, 'write');
+    });
+
+    it('identifies an updated document by its type property when it matches that of the old document', function() {
+      var doc = {
+        _id: 'my-doc',
+        type: docTypeId
+      };
+      var oldDoc = {
+        _id: 'my-doc',
+        type: docTypeId
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('identifies a deleted document by the type property of the old document', function() {
+      var doc = {
+        _id: 'my-doc',
+        _deleted: true
+      };
+      var oldDoc = {
+        _id: 'my-doc',
+        type: docTypeId
+      };
+
+      testHelper.verifyDocumentDeleted(oldDoc);
+    });
+
+    it('refuses to identify an updated document by its type property when it differs from that of the old document', function() {
+      var doc = {
+        _id: 'my-doc',
+        type: docTypeId
+      };
+      var oldDoc = {
+        _id: 'my-doc',
+        type: 'somethingElse'
+      };
+
+      testHelper.verifyUnknownDocumentType(doc, oldDoc);
+    });
+
+    it('cannot identify a document when the type property is not set', function() {
+      var doc = {
+        _id: 'my-doc'
+      };
+
+      testHelper.verifyUnknownDocumentType(doc);
+    });
+
+    it('cannot identify a document when the type property is set to an unknown type', function() {
+      var doc = {
+        _id: 'my-doc',
+        type: 'somethingElse'
+      };
+
+      testHelper.verifyUnknownDocumentType(doc);
+    });
+
+    it('cannot identify a deleted document when the old document does not exist', function() {
+      var doc = {
+        _id: 'my-doc',
+        _deleted: true
+      };
+
+      testHelper.verifyUnknownDocumentType(doc);
+    });
+
+    it('cannot identify a deleted document when the old document is also deleted', function() {
+      var doc = {
+        _id: 'my-doc',
+        _deleted: true
+      };
+      var oldDoc = {
+        _id: 'my-doc',
+        _deleted: true
+      };
+
+      testHelper.verifyUnknownDocumentType(doc, oldDoc);
+    });
+  }
+
+  describe('when a type property validator is explicitly defined', function() {
+    testSimpleTypeFilter('myExplicitTypeValidatorDoc');
   });
 
-  it('identifies a new document that is replacing a deleted document by its type property', function() {
-    var doc = {
-      _id: 'my-doc',
-      type: 'myDoc'
-    };
-    var oldDoc = {
-      _id: 'my-doc',
-      _deleted: true
-    };
-
-    testHelper.verifyDocumentAccepted(doc, oldDoc, 'write');
-  });
-
-  it('identifies an updated document by its type property when it matches that of the old document', function() {
-    var doc = {
-      _id: 'my-doc',
-      type: 'myDoc'
-    };
-    var oldDoc = {
-      _id: 'my-doc',
-      type: 'myDoc'
-    };
-
-    testHelper.verifyDocumentReplaced(doc, oldDoc);
-  });
-
-  it('identifies a deleted document by the type property of the old document', function() {
-    var doc = {
-      _id: 'my-doc',
-      _deleted: true
-    };
-    var oldDoc = {
-      _id: 'my-doc',
-      type: 'myDoc'
-    };
-
-    testHelper.verifyDocumentDeleted(oldDoc);
-  });
-
-  it('refuses to identify an updated document by its type property when it differs from that of the old document', function() {
-    var doc = {
-      _id: 'my-doc',
-      type: 'myDoc'
-    };
-    var oldDoc = {
-      _id: 'my-doc',
-      type: 'somethingElse'
-    };
-
-    testHelper.verifyUnknownDocumentType(doc, oldDoc);
-  });
-
-  it('cannot identify a document when the type property is not set', function() {
-    var doc = {
-      _id: 'my-doc'
-    };
-
-    testHelper.verifyUnknownDocumentType(doc);
-  });
-
-  it('cannot identify a document when the type property is set to an unknown type', function() {
-    var doc = {
-      _id: 'my-doc',
-      type: 'somethingElse'
-    };
-
-    testHelper.verifyUnknownDocumentType(doc);
-  });
-
-  it('cannot identify a deleted document when the old document does not exist', function() {
-    var doc = {
-      _id: 'my-doc',
-      _deleted: true
-    };
-
-    testHelper.verifyUnknownDocumentType(doc);
-  });
-
-  it('cannot identify a deleted document when the old document is also deleted', function() {
-    var doc = {
-      _id: 'my-doc',
-      _deleted: true
-    };
-    var oldDoc = {
-      _id: 'my-doc',
-      _deleted: true
-    };
-
-    testHelper.verifyUnknownDocumentType(doc, oldDoc);
+  describe('when a type property validator is implied (i.e. not defined)', function() {
+    testSimpleTypeFilter('myImplicitTypeValidatorDoc');
   });
 });


### PR DESCRIPTION
The simple type filter (`simpleTypeFilter`) is a convenience that specifies that a document's type is defined by the value of its "type" property. For the sake of convenience, if a document definition uses a `simpleTypeFilter` but does not explicitly include a property validator for a "type" property, automatically allow the "type" property at the document root and validate it with the built in `typeIdValidator` (as implemented in #74).

Addresses issue #73.