### PR TITLE
Issue 78: New property validation type for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - [#73](https://github.com/Kashoo/synctos/issues/73): Include an implicit type property when a simple type filter is used
+- [#78](https://github.com/Kashoo/synctos/issues/78): Enum property validation type
 
 ## [1.6.0] - 2017-01-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ Validation for simple data types:
   * `minimumValueExclusive`: Reject dates that are less than or equal to this. No restriction by default.
   * `maximumValue`: Reject dates that are greater than this. No restriction by default.
   * `maximumValueExclusive`: Reject dates that are greater than or equal to this. No restriction by default.
+* `enum`: The value must be one of the specified predefined string and/or integer values. Additional parameters:
+  * `predefinedValues`: A list of strings and/or integers that are to be accepted. If this parameter is omitted from an `enum` property's configuration, that property will not accept a value of any kind.
 * `attachmentReference`: The value is the name of one of the document's file attachments. Note that, because the addition of an attachment is often a separate Sync Gateway API operation from the creation/replacement of the associated document, this validation type is only applied if the attachment is actually present in the document. However, since the sync function is run twice in such situations (i.e. once when the document is created/replaced and once when the attachment is created/replaced), the validation will be performed eventually. Additional parameters:
   * `supportedExtensions`: An array of case-insensitive file extensions that are allowed for the attachment's filename (e.g. "txt", "jpg", "pdf"). No restriction by default.
   * `supportedContentTypes`: An array of content/MIME types that are allowed for the attachment's contents (e.g. "image/png", "text/html", "application/xml"). No restriction by default.

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -429,6 +429,13 @@ function synctos(doc, oldDoc) {
             validationErrors.push('item "' + buildItemPath(itemStack) + '" must be an ISO 8601 date string with no time or time zone components');
           }
           break;
+        case 'enum':
+          if (!(validator.predefinedValues instanceof Array)) {
+            validationErrors.push('item "' + buildItemPath(itemStack) + '" belongs to an enum that has no predefined values');
+          } else if (validator.predefinedValues.indexOf(itemValue) < 0) {
+            validationErrors.push('item "' + buildItemPath(itemStack) + '" must be one of the predefined values: ' + validator.predefinedValues.toString());
+          }
+          break;
         case 'object':
           if (typeof itemValue !== 'object' || itemValue instanceof Array) {
             validationErrors.push('item "' + buildItemPath(itemStack) + '" must be an object');

--- a/etc/validation-error-message-formatter.js
+++ b/etc/validation-error-message-formatter.js
@@ -45,7 +45,7 @@ exports.datetimeFormatInvalid = function(itemPath) {
  * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "objectProp.arrayProp[3].enumProp")
  * @param {(string[]|integer[])} expectedPredefinedValues A list of predefined values that are allowed for the item in question
  */
-exports.enumPredefinedValueConstraint = function(itemPath, expectedPredefinedValues) {
+exports.enumPredefinedValueViolation = function(itemPath, expectedPredefinedValues) {
   return 'item "' + itemPath + '" must be one of the predefined values: ' + expectedPredefinedValues.toString();
 };
 

--- a/etc/validation-error-message-formatter.js
+++ b/etc/validation-error-message-formatter.js
@@ -40,6 +40,16 @@ exports.datetimeFormatInvalid = function(itemPath) {
 };
 
 /**
+ * Formats a message for the error that occurs when the value of an enum field is not one of the predefined values.
+ *
+ * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "objectProp.arrayProp[3].enumProp")
+ * @param {(string[]|integer[])} expectedPredefinedValues A list of predefined values that are allowed for the item in question
+ */
+exports.enumPredefinedValueConstraint = function(itemPath, expectedPredefinedValues) {
+  return 'item "' + itemPath + '" must be one of the predefined values: ' + expectedPredefinedValues.toString();
+};
+
+/**
  * Formats a message for the error that occurs when a hashtable key is an empty string.
  *
  * @param {string} hashtablePath The full path of the hashtable in which the error occurs (e.g. "objectProp.arrayProp[2].hashtableProp")

--- a/test/enum-spec.js
+++ b/test/enum-spec.js
@@ -1,0 +1,62 @@
+var testHelper = require('../etc/test-helper.js');
+var errorFormatter = testHelper.validationErrorFormatter;
+
+describe('Enum validation type', function() {
+  beforeEach(function() {
+    testHelper.init('build/sync-functions/test-enum-sync-function.js');
+  });
+
+  it('accepts an allowed string', function() {
+    var doc = {
+      _id: 'enumDoc',
+      enumProp: 'value1'
+    };
+
+    testHelper.verifyDocumentCreated(doc);
+  });
+
+  it('accepts an allowed integer', function() {
+    var doc = {
+      _id: 'enumDoc',
+      enumProp: 2
+    };
+
+    testHelper.verifyDocumentCreated(doc);
+  });
+
+  it('rejects a string value that is not in the list of predefined values', function() {
+    var doc = {
+      _id: 'enumDoc',
+      enumProp: 'value2'
+    };
+
+    testHelper.verifyDocumentNotCreated(
+      doc,
+      'enumDoc',
+      errorFormatter.enumPredefinedValueConstraint('enumProp', [ 'value1', 2 ]));
+  });
+
+  it('rejects an integer value that is not in the list of predefined values', function() {
+    var doc = {
+      _id: 'enumDoc',
+      enumProp: 1
+    };
+
+    testHelper.verifyDocumentNotCreated(
+      doc,
+      'enumDoc',
+      errorFormatter.enumPredefinedValueConstraint('enumProp', [ 'value1', 2 ]));
+  });
+
+  it('rejects a value when the property does not declare a list of predefined values', function() {
+    var doc = {
+      _id: 'enumDoc',
+      invalidEnumProp: 2
+    };
+
+    testHelper.verifyDocumentNotCreated(
+      doc,
+      'enumDoc',
+      'item "invalidEnumProp" belongs to an enum that has no predefined values');
+  });
+});

--- a/test/enum-spec.js
+++ b/test/enum-spec.js
@@ -33,7 +33,7 @@ describe('Enum validation type', function() {
     testHelper.verifyDocumentNotCreated(
       doc,
       'enumDoc',
-      errorFormatter.enumPredefinedValueConstraint('enumProp', [ 'value1', 2 ]));
+      errorFormatter.enumPredefinedValueViolation('enumProp', [ 'value1', 2 ]));
   });
 
   it('rejects an integer value that is not in the list of predefined values', function() {
@@ -45,7 +45,7 @@ describe('Enum validation type', function() {
     testHelper.verifyDocumentNotCreated(
       doc,
       'enumDoc',
-      errorFormatter.enumPredefinedValueConstraint('enumProp', [ 'value1', 2 ]));
+      errorFormatter.enumPredefinedValueViolation('enumProp', [ 'value1', 2 ]));
   });
 
   it('rejects a value when the property does not declare a list of predefined values', function() {

--- a/test/resources/enum-doc-definitions.js
+++ b/test/resources/enum-doc-definitions.js
@@ -1,0 +1,17 @@
+{
+  enumDoc: {
+    typeFilter: function(doc, oldDoc) {
+      return doc._id === 'enumDoc';
+    },
+    channels: { write: 'write' },
+    propertyValidators: {
+      enumProp: {
+        type: 'enum',
+        predefinedValues: [ 'value1', 2 ]
+      },
+      invalidEnumProp: {
+        type: 'enum'
+      }
+    }
+  }
+}


### PR DESCRIPTION
An enum property validation type specifies a predefined list of valid values. For its document to be considered valid, a value assigned to a property of this type must belong to the predefined values list.

Addresses issue #78.