### PR TITLE
Issue 79: Hashtable size constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - [#73](https://github.com/Kashoo/synctos/issues/73): Include an implicit type property when a simple type filter is used
+- [#79](https://github.com/Kashoo/synctos/issues/79): Support minimum/maximum size constraint on hashtable validation type
 
 ## [1.6.0] - 2017-01-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Validation for complex data types, which allow for nesting of child properties a
 ```
 
 * `hashtable`: An object/hash that, unlike the `object` type, does not declare the names of the properties it supports and may optionally define a single validator that is applied to all of its element values. Additional parameters:
+  * `minimumSize`: The minimum number of elements allowed in the hashtable. Unconstrained by default.
+  * `maximumSize`: The maximum number of elements allowed in the hashtable. Unconstrained by default.
   * `hashtableKeysValidator`: The validation that is applied to each of the keys in the object/hash. Undefined by default. Additional parameters:
     * `mustNotBeEmpty`: If `true`, empty key strings are not allowed. Defaults to `false`.
     * `regexPattern`: A regular expression pattern that must be satisfied for key strings to be accepted. Undefined by default.

--- a/etc/validation-error-message-formatter.js
+++ b/etc/validation-error-message-formatter.js
@@ -49,6 +49,26 @@ exports.hashtableKeyEmpty = function(hashtablePath) {
 };
 
 /**
+ * Formats a message for the error that occurs when a hashtable has more than the maximum number of elements.
+ *
+ * @param {string} hashtablePath The full path of the hashtable in which the error occurs (e.g. "objectProp.arrayProp[2].hashtableProp")
+ * @param {integer} expectedMaximumSize The maximum number of elements
+ */
+exports.hashtableMaximumSizeViolation = function(hashtablePath, expectedMaximumSize) {
+  return 'hashtable "' + hashtablePath + '" must not be larger than ' + expectedMaximumSize + ' elements';
+};
+
+/**
+ * Formats a message for the error that occurs when a hashtable has less than the minimum number of elements.
+ *
+ * @param {string} hashtablePath The full path of the hashtable in which the error occurs (e.g. "objectProp.arrayProp[2].hashtableProp")
+ * @param {integer} expectedMinimumSize The minimum number of elements
+ */
+exports.hashtableMinimumSizeViolation = function(hashtablePath, expectedMinimumSize) {
+  return 'hashtable "' + hashtablePath + '" must not be smaller than ' + expectedMinimumSize + ' elements';
+};
+
+/**
  * Formats a message for the error that occurs when there is an attempt to replace or delete an immutable document.
  */
 exports.immutableDocViolation = function() {

--- a/test/hashtable-spec.js
+++ b/test/hashtable-spec.js
@@ -1,0 +1,46 @@
+var testHelper = require('../etc/test-helper.js');
+var errorFormatter = testHelper.validationErrorFormatter;
+
+describe('Hashtable validation type', function() {
+  beforeEach(function() {
+    testHelper.init('build/sync-functions/test-hashtable-sync-function.js');
+  });
+
+  describe('size validation', function() {
+    it('allows a hashtable that is within the minimum and maximum sizes', function() {
+      var doc = {
+        _id: 'hashtableDoc',
+        sizeValidationProp: {
+          foo: 1,
+          bar: 2
+        }
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('rejects a hashtable that is smaller than the minimum size', function() {
+      var doc = {
+        _id: 'hashtableDoc',
+        sizeValidationProp: {
+          foo: 1
+        }
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'hashtableDoc', errorFormatter.hashtableMinimumSizeViolation('sizeValidationProp', 2));
+    });
+
+    it('rejects a hashtable that is larger than the maximum size', function() {
+      var doc = {
+        _id: 'hashtableDoc',
+        sizeValidationProp: {
+          foo: 1,
+          bar: 2,
+          baz: 3
+        }
+      };
+
+      testHelper.verifyDocumentNotCreated(doc, 'hashtableDoc', errorFormatter.hashtableMaximumSizeViolation('sizeValidationProp', 2));
+    });
+  });
+});

--- a/test/resources/hashtable-doc-definitions.js
+++ b/test/resources/hashtable-doc-definitions.js
@@ -1,0 +1,15 @@
+{
+  hashtableDoc: {
+    channels: { write: 'write' },
+    typeFilter: function(doc) {
+      return doc._id === 'hashtableDoc';
+    },
+    propertyValidators: {
+      sizeValidationProp: {
+        type: 'hashtable',
+        minimumSize: 2,
+        maximumSize: 2
+      }
+    }
+  }
+}


### PR DESCRIPTION
Allows a document definition to declare the minimum and maximum number of elements that a hashtable may hold.

Addresses issue #79.