### PR TITLE
Issue 94: Initial implementation of dynamic item validation constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-Nothing yet
+- [#94](https://github.com/Kashoo/synctos/issues/94): Support dynamic validation constraint definitions
 
 ## [1.8.0] - 2017-03-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ At the top level, the document definitions object contains a property for each d
       }
     }
 
-##### Document type definitions:
+#### Document type definitions
 
 Each document type is specified as an object with the following properties:
 
@@ -277,11 +277,13 @@ An example of an `onAuthorizationSucceeded` custom action that stores a property
     }
 ```
 
-##### Content validation:
+#### Content validation
 
 There are a number of validation types that can be used to define each property/element/key's expected format in a document.
 
-Validation for simple data types:
+##### Simple type validation:
+
+Validation for simple data types (e.g. integers, floating point numbers, strings, dates/times, etc.):
 
 * `string`: The value is a string of characters. Additional parameters:
   * `mustNotBeEmpty`: If `true`, an empty string is not allowed. Defaults to `false`.
@@ -310,13 +312,15 @@ Validation for simple data types:
   * `maximumValue`: Reject dates that are greater than this. No restriction by default.
   * `maximumValueExclusive`: Reject dates that are greater than or equal to this. No restriction by default.
 * `enum`: The value must be one of the specified predefined string and/or integer values. Additional parameters:
-  * `predefinedValues`: A list of strings and/or integers that are to be accepted. If this parameter is omitted from an `enum` property's configuration, that property will not accept a value of any kind.
+  * `predefinedValues`: A list of strings and/or integers that are to be accepted. If this parameter is omitted from an `enum` property's configuration, that property will not accept a value of any kind. For example: `[ 1, 2, 3, 'a', 'b', 'c' ]`
 * `attachmentReference`: The value is the name of one of the document's file attachments. Note that, because the addition of an attachment is often a separate Sync Gateway API operation from the creation/replacement of the associated document, this validation type is only applied if the attachment is actually present in the document. However, since the sync function is run twice in such situations (i.e. once when the _document_ is created/replaced and once when the _attachment_ is created/replaced), the validation will be performed eventually. The top-level `allowAttachments` property should be `true` so that documents of this type can actually store attachments. Additional parameters:
-  * `supportedExtensions`: An array of case-insensitive file extensions that are allowed for the attachment's filename (e.g. "txt", "jpg", "pdf"). Takes precedence over the document-level `supportedExtensions` constraint for the referenced attachment. No restriction by default.
-  * `supportedContentTypes`: An array of content/MIME types that are allowed for the attachment's contents (e.g. "image/png", "text/html", "application/xml"). Takes precedence over the document-level `supportedContentTypes` constraint for the referenced attachment. No restriction by default.
-  * `maximumSize`: The maximum file size, in bytes, of the attachment. May not be greater than 20MB (20,971,520 bytes), as Couchbase Server/Sync Gateway sets that as the hard limit per document or attachment. Takes precedence over the document-level `maximumIndividualSize` constraint for the referenced attachment. Unlimited by default.
+  * `supportedExtensions`: An array of case-insensitive file extensions that are allowed for the attachment's filename (e.g. "txt", "jpg", "pdf"). Takes precedence over the document-wide `supportedExtensions` constraint for the referenced attachment. No restriction by default.
+  * `supportedContentTypes`: An array of content/MIME types that are allowed for the attachment's contents (e.g. "image/png", "text/html", "application/xml"). Takes precedence over the document-wide `supportedContentTypes` constraint for the referenced attachment. No restriction by default.
+  * `maximumSize`: The maximum file size, in bytes, of the attachment. May not be greater than 20MB (20,971,520 bytes), as Couchbase Server/Sync Gateway sets that as the hard limit per document or attachment. Takes precedence over the document-wide `maximumIndividualSize` constraint for the referenced attachment. Unlimited by default.
 
-Validation for complex data types, which allow for nesting of child properties and elements:
+##### Complex type validation:
+
+Validation for complex data types (e.g. objects, arrays, hashtables):
 
 * `array`: An array/list of elements. Additional parameters:
   * `mustNotBeEmpty`: If `true`, an array with no elements is not allowed. Defaults to `false`.
@@ -382,7 +386,9 @@ Validation for complex data types, which allow for nesting of child properties a
     }
 ```
 
-**NOTE**: Validation for all simple and complex data types support the following additional parameters:
+##### Universal constraint validation:
+
+Validation for all simple and complex data types support the following additional parameters:
 
 * `required`: The value cannot be null or undefined. Defaults to `false`.
 * `immutable`: The item cannot be changed from its existing value if the document is being replaced. The constraint is applied recursively so that, even if a value that is nested an arbitrary number of levels deep within an immutable complex type is modified, the document change will be rejected. Does not apply when creating a new document or deleting an existing document. Defaults to `false`.
@@ -427,7 +433,9 @@ Validation for complex data types, which allow for nesting of child properties a
     }
 ```
 
-The following predefined property validators may also be useful:
+##### Predefined validators:
+
+The following predefined validators may also be useful:
 
 * `typeIdValidator`: A property validator that is suitable for application to the property that specifies the type of a document. Its constraints include ensuring the value is a string, is neither null nor undefined, is not an empty string and cannot be modified. NOTE: If a document type specifies `simpleTypeFilter` as its type filter, it is not necessary to explicitly include a `type` property validator; it will be supported implicitly as a `typeIdValidator`. An example usage:
 
@@ -521,7 +529,7 @@ function() {
 
 As demonstrated above, the advantage of defining a function rather than an object is that you may also define variables and functions that can be shared between document types but at the cost of some brevity.
 
-##### Modularity
+#### Modularity
 
 Document definitions are also modular. By invoking the `importDocumentDefinitionFragment` macro, the contents of external files can be imported into the main document definitions file. For example, each individual document definition from the example above can be specified as a fragment in its own separate file:
 

--- a/etc/sync-function-validation-module.js
+++ b/etc/sync-function-validation-module.js
@@ -99,13 +99,13 @@ function() {
 
     // The following functions are nested within this function so they can share access to the doc, oldDoc and validationErrors params and
     // the attachmentReferenceValidators and itemStack variables
-    function resolveValidationConstraint(constraint) {
-      if (typeof(constraint) === 'function') {
+    function resolveValidationConstraint(constraintDefinition) {
+      if (typeof(constraintDefinition) === 'function') {
         var currentItemEntry = itemStack[itemStack.length - 1];
 
-        return constraint(currentItemEntry.itemValue, currentItemEntry.oldItemValue, doc, oldDoc);
+        return constraintDefinition(currentItemEntry.itemValue, currentItemEntry.oldItemValue, doc, oldDoc);
       } else {
-        return constraint;
+        return constraintDefinition;
       }
     }
 

--- a/test/immutable-items-spec.js
+++ b/test/immutable-items-spec.js
@@ -6,15 +6,15 @@ describe('Immutable item validation parameter', function() {
     testHelper.init('build/sync-functions/test-immutable-items-sync-function.js');
   });
 
-  describe('array type validation', function() {
+  describe('array type with static property validation', function() {
     it('can replace a document with an immutable array when the simple type elements have not changed', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 46.0 ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 46.0 ]
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 46 ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 46 ]
       };
 
       testHelper.verifyDocumentReplaced(doc, oldDoc);
@@ -23,11 +23,11 @@ describe('Immutable item validation parameter', function() {
     it('can replace a document with an immutable array when the nested complex type elements have not changed', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], null, { foo: 'bar' } ]
+        staticImmutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], null, { foo: 'bar' } ]
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], undefined, { foo: 'bar' } ]
+        staticImmutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], undefined, { foo: 'bar' } ]
       };
 
       testHelper.verifyDocumentReplaced(doc, oldDoc);
@@ -37,7 +37,7 @@ describe('Immutable item validation parameter', function() {
       var doc = { _id: 'immutableItemsDoc' };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: null
+        staticImmutableArrayProp: null
       };
 
       testHelper.verifyDocumentReplaced(doc, oldDoc);
@@ -46,7 +46,7 @@ describe('Immutable item validation parameter', function() {
     it('can create a document with an immutable array when the old document does not exist', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], { foo: 'bar' } ]
+        staticImmutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], { foo: 'bar' } ]
       };
 
       testHelper.verifyDocumentCreated(doc);
@@ -55,7 +55,7 @@ describe('Immutable item validation parameter', function() {
     it('can create a document with an immutable array when the old document was deleted', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], { foo: 'bar' } ]
+        staticImmutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], { foo: 'bar' } ]
       };
       var oldDoc = { _id: 'immutableItemsDoc', _deleted: true };
 
@@ -65,7 +65,7 @@ describe('Immutable item validation parameter', function() {
     it('can delete a document with an immutable array', function() {
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9 ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9 ]
       };
 
       testHelper.verifyDocumentDeleted(oldDoc);
@@ -74,97 +74,144 @@ describe('Immutable item validation parameter', function() {
     it('cannot replace a document with an immutable array when the elements are not equal', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 15.0 ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 15.0 ]
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9 ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9 ]
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableArrayProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableArrayProp'));
     });
 
     it('cannot replace a document with an immutable array when a nested element is not equal', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ], { foo: 'bar' } ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9, [ ], { foo: 'bar' } ]
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ], { bar: null } ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9, [ ], { bar: null } ]
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableArrayProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableArrayProp'));
     });
 
     it('cannot replace a document with an immutable array when one is a subset of the other', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, { } ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9, { } ]
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, { }, [ ] ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9, { }, [ ] ]
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableArrayProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableArrayProp'));
     });
 
     it('cannot replace a document with an immutable array when nested complex type elements are not the same type', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, { } ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9, { } ]
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ] ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9, [ ] ]
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableArrayProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableArrayProp'));
     });
 
     it('cannot replace a document with an immutable array when the element order has changed', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ [ ], 'foobar', 3, false, 45.9 ]
+        staticImmutableArrayProp: [ [ ], 'foobar', 3, false, 45.9 ]
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ] ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9, [ ] ]
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableArrayProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableArrayProp'));
     });
 
     it('cannot replace a document with an immutable array when it is missing in the new document', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: null
+        staticImmutableArrayProp: null
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ] ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9, [ ] ]
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableArrayProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableArrayProp'));
     });
 
     it('cannot replace a document with an immutable array when it is missing in the old document', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableArrayProp: [ 'foobar', 3, false, 45.9, [ ] ]
+        staticImmutableArrayProp: [ 'foobar', 3, false, 45.9, [ ] ]
       };
       var oldDoc = { _id: 'immutableItemsDoc' };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableArrayProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableArrayProp'));
     });
   });
 
-  describe('object type validation', function() {
+  describe('array type with dynamic property validation', function() {
+    it('can replace a document when the array property elements have not changed', function() {
+      var doc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableArrayProp: [ 'barfoo', -72.0, true, 3.9 ],
+        dynamicPropertiesAreImmutable: true
+      };
+      var oldDoc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableArrayProp: [ 'barfoo', -72, true, 3.9 ],
+        dynamicPropertiesAreImmutable: true
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('can replace a document when the array property is not immutable', function() {
+      var doc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableArrayProp: [ 2 ],
+        dynamicPropertiesAreImmutable: false
+      };
+      var oldDoc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableArrayProp: [ '#1' ],
+        dynamicPropertiesAreImmutable: false
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('cannot replace a document when the array property is immutable and its elements have changed', function() {
+      var doc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableArrayProp: [ '#4' ],
+        dynamicPropertiesAreImmutable: true
+      };
+      var oldDoc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableArrayProp: [ 3.0 ],
+        dynamicPropertiesAreImmutable: true
+      };
+
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('dynamicImmutableArrayProp'));
+    });
+  });
+
+  describe('object type with static property validation', function() {
     it('can replace a document with an immutable object when the simple type properties have not changed', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myStringProp: 'foobar',
           myIntegerProp: 8,
           myBooleanProp: true,
@@ -173,7 +220,7 @@ describe('Immutable item validation parameter', function() {
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myStringProp: 'foobar',
           myIntegerProp: 8,
           myBooleanProp: true,
@@ -187,14 +234,14 @@ describe('Immutable item validation parameter', function() {
     it('can replace a document with an immutable object when the nested complex type elements have not changed', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ null ], { } ],
           myObjectProp: { foo: 'bar', baz: 73, qux: [ ] }
         }
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ null ], { } ],
           myObjectProp: { foo: 'bar', baz: 73, qux: [ ] }
         }
@@ -206,7 +253,7 @@ describe('Immutable item validation parameter', function() {
     it('can replace a document with an immutable object when the property is null or undefined', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: null
+        staticImmutableObjectProp: null
       };
       var oldDoc = {
         _id: 'immutableItemsDoc'
@@ -218,14 +265,14 @@ describe('Immutable item validation parameter', function() {
     it('can replace a document with an immutable object when the property order has changed and a null property becomes undefined', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myIntegerProp: 8,
           myStringProp: 'foobar'
         }
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myStringProp: 'foobar',
           myIntegerProp: 8,
           myNullProp: null
@@ -238,7 +285,7 @@ describe('Immutable item validation parameter', function() {
     it('can create a document with an immutable object when the old document does not exist', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
@@ -250,7 +297,7 @@ describe('Immutable item validation parameter', function() {
     it('can create a document with an immutable object when the old document was deleted', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
@@ -263,7 +310,7 @@ describe('Immutable item validation parameter', function() {
     it('can delete a document with an immutable object', function() {
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
@@ -275,26 +322,26 @@ describe('Immutable item validation parameter', function() {
     it('cannot replace a document with an immutable object when the nested properties are not equal', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ { foo: 'bar' } ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ { } ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableObjectProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableObjectProp'));
     });
 
     it('cannot replace a document with an immutable object when a nested property is missing', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myStringProp: 'foobar',
           myBooleanProp: true,
           myFloatProp: 88.92
@@ -302,7 +349,7 @@ describe('Immutable item validation parameter', function() {
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myStringProp: 'foobar',
           myIntegerProp: 8,
           myBooleanProp: true,
@@ -310,42 +357,89 @@ describe('Immutable item validation parameter', function() {
         }
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableObjectProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableObjectProp'));
     });
 
     it('cannot replace a document with an immutable object when it is missing in the new document', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: null
+        staticImmutableObjectProp: null
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: {
+        staticImmutableObjectProp: {
           myStringProp: 'foobar',
           myBooleanProp: true,
           myFloatProp: 88.92
         }
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableObjectProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableObjectProp'));
     });
 
     it('cannot replace a document with an immutable object when it is missing in the old document', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableObjectProp: { }
+        staticImmutableObjectProp: { }
       };
       var oldDoc = { _id: 'immutableItemsDoc' };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableObjectProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableObjectProp'));
     });
   });
 
-  describe('hashtable type validation', function() {
+  describe('object type with dynamic property validation', function() {
+    it('can replace a document when the object property value has not changed', function() {
+      var doc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableObjectProp: { myFloatProp: 88.92 },
+        dynamicPropertiesAreImmutable: true
+      };
+      var oldDoc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableObjectProp: { myFloatProp: 88.92 },
+        dynamicPropertiesAreImmutable: true
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('can replace a document when the object property is not immutable', function() {
+      var doc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableObjectProp: { myIntegerProp: -33 },
+        dynamicPropertiesAreImmutable: false
+      };
+      var oldDoc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableObjectProp: { myFloatProp: 88.92 },
+        dynamicPropertiesAreImmutable: false
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('cannot replace a document when the object property is immutable and its value has changed', function() {
+      var doc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableObjectProp: { myStringProp: 'foo' },
+        dynamicPropertiesAreImmutable: true
+      };
+      var oldDoc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableObjectProp: { myIntegerProp: -33 },
+        dynamicPropertiesAreImmutable: true
+      };
+
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('dynamicImmutableObjectProp'));
+    });
+  });
+
+  describe('hashtable type with static validation', function() {
     it('can replace a document with an immutable hashtable when the simple type properties have not changed', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myStringProp: 'foobar',
           myIntegerProp: 8,
           myBooleanProp: true,
@@ -354,7 +448,7 @@ describe('Immutable item validation parameter', function() {
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myStringProp: 'foobar',
           myIntegerProp: 8,
           myBooleanProp: true,
@@ -368,14 +462,14 @@ describe('Immutable item validation parameter', function() {
     it('can replace a document with an immutable hashtable when the nested complex type elements have not changed', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ undefined ], { foobar: 18.0 } ],
           myObjectProp: { foo: 'bar', baz: 73, qux: [ ] }
         }
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ null ], { foobar: 18 } ],
           myObjectProp: { foo: 'bar', baz: 73, qux: [ ] }
         }
@@ -390,7 +484,7 @@ describe('Immutable item validation parameter', function() {
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: null
+        staticImmutableHashtableProp: null
       };
 
       testHelper.verifyDocumentReplaced(doc, oldDoc);
@@ -399,7 +493,7 @@ describe('Immutable item validation parameter', function() {
     it('can replace a document with an immutable hashtable when the property order has changed and an undefined property becomes null', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myIntegerProp: 8,
           myStringProp: 'foobar',
           myUndefinedProp: null
@@ -407,7 +501,7 @@ describe('Immutable item validation parameter', function() {
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myStringProp: 'foobar',
           myIntegerProp: 8
         }
@@ -419,7 +513,7 @@ describe('Immutable item validation parameter', function() {
     it('can create a document with an immutable hashtable when the old document does not exist', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
@@ -431,7 +525,7 @@ describe('Immutable item validation parameter', function() {
     it('can create a document with an immutable hashtable when the old document was deleted', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
@@ -444,7 +538,7 @@ describe('Immutable item validation parameter', function() {
     it('can delete a document with an immutable hashtable', function() {
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ null ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
@@ -456,26 +550,26 @@ describe('Immutable item validation parameter', function() {
     it('cannot replace a document with an immutable hashtable when the properties are not equal', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ { foo: 'bar' } ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myArrayProp: [ 'foobar', 3, false, 45.9, [ { } ] ],
           myObjectProp: { foo: 'bar', baz: 73 }
         }
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableHashtableProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableHashtableProp'));
     });
 
     it('cannot replace a document with an immutable hashtable when a property is missing', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myStringProp: 'foobar',
           myBooleanProp: true,
           myFloatProp: 88.92
@@ -483,7 +577,7 @@ describe('Immutable item validation parameter', function() {
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myStringProp: 'foobar',
           myIntegerProp: 8,
           myBooleanProp: true,
@@ -491,34 +585,81 @@ describe('Immutable item validation parameter', function() {
         }
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableHashtableProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableHashtableProp'));
     });
 
     it('cannot replace a document with an immutable hashtable when it is missing in the new document', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: null
+        staticImmutableHashtableProp: null
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: {
+        staticImmutableHashtableProp: {
           myStringProp: 'foobar',
           myBooleanProp: true,
           myFloatProp: 88.92
         }
       };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableHashtableProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableHashtableProp'));
     });
 
     it('cannot replace a document with an immutable hashtable when it is missing in the old document', function() {
       var doc = {
         _id: 'immutableItemsDoc',
-        immutableHashtableProp: { }
+        staticImmutableHashtableProp: { }
       };
       var oldDoc = { _id: 'immutableItemsDoc' };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('immutableHashtableProp'));
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('staticImmutableHashtableProp'));
+    });
+  });
+
+  describe('hashtable type with dynamic property validation', function() {
+    it('can replace a document when the hashtable property value has not changed', function() {
+      var doc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableHashtableProp: { myDateProp: '2017-04-07' },
+        dynamicPropertiesAreImmutable: true
+      };
+      var oldDoc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableHashtableProp: { myDateProp: '2017-04-07' },
+        dynamicPropertiesAreImmutable: true
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('can replace a document when the object property is not immutable', function() {
+      var doc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableHashtableProp: { myIntegerProp: -33 },
+        dynamicPropertiesAreImmutable: false
+      };
+      var oldDoc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableHashtableProp: { myBoolean: true },
+        dynamicPropertiesAreImmutable: false
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('cannot replace a document when the object property is immutable and its value has changed', function() {
+      var doc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableHashtableProp: { myStringProp: 'foo' },
+        dynamicPropertiesAreImmutable: true
+      };
+      var oldDoc = {
+        _id: 'immutableItemsDoc',
+        dynamicImmutableHashtableProp: { myIntegerProp: -33 },
+        dynamicPropertiesAreImmutable: true
+      };
+
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableItemsDoc', errorFormatter.immutableItemViolation('dynamicImmutableHashtableProp'));
     });
   });
 });

--- a/test/resources/immutable-items-doc-definitions.js
+++ b/test/resources/immutable-items-doc-definitions.js
@@ -1,22 +1,44 @@
-{
-  immutableItemsDoc: {
-    channels: { write: 'write' },
-    typeFilter: function(doc) {
-      return doc._id === 'immutableItemsDoc';
-    },
-    propertyValidators: {
-      immutableArrayProp: {
-        type: 'array',
-        immutable: true
+function() {
+  function isImmutable(value, oldValue, doc, oldDoc) {
+    return oldDoc ? oldDoc.dynamicPropertiesAreImmutable : doc.dynamicPropertiesAreImmutable;
+  }
+
+  return {
+    immutableItemsDoc: {
+      channels: { write: 'write' },
+      typeFilter: function(doc) {
+        return doc._id === 'immutableItemsDoc';
       },
-      immutableObjectProp: {
-        type: 'object',
-        immutable: true
-      },
-      immutableHashtableProp: {
-        type: 'hashtable',
-        immutable: true
+      propertyValidators: {
+        staticImmutableArrayProp: {
+          type: 'array',
+          immutable: true
+        },
+        staticImmutableObjectProp: {
+          type: 'object',
+          immutable: true
+        },
+        staticImmutableHashtableProp: {
+          type: 'hashtable',
+          immutable: true
+        },
+        dynamicPropertiesAreImmutable: {
+          type: 'boolean',
+          immutable: true
+        },
+        dynamicImmutableArrayProp: {
+          type: 'array',
+          immutable: isImmutable
+        },
+        dynamicImmutableObjectProp: {
+          type: 'object',
+          immutable: isImmutable
+        },
+        dynamicImmutableHashtableProp: {
+          type: 'hashtable',
+          immutable: isImmutable
+        }
       }
     }
-  }
+  };
 }


### PR DESCRIPTION
Includes support for setting item validation constraints (e.g. `mustNotBeEmpty`, `required`, `immutable`, etc.) dynamically, via a function, in addition to the existing "static" method. While functionally complete, this should be considered a work in progress; a series of future pull requests will gradually increase test coverage for all of the validation constraints that are affected.

The first step in addressing issue #94.