### PR TITLE
Issue 94: Dynamic item constraint tests - round 1

### DIFF
--- a/test/array-spec.js
+++ b/test/array-spec.js
@@ -34,4 +34,58 @@ describe('Array validation type', function() {
       testHelper.verifyDocumentNotCreated(doc, 'arrayDoc', errorFormatter.maximumLengthViolation('lengthValidationProp', 2));
     });
   });
+
+  describe('non-empty constraint', function() {
+    describe('with static validation', function() {
+      it('allows a doc with an array that is not empty', function() {
+        var doc = {
+          _id: 'arrayDoc',
+          staticNonEmptyProp: [ 'foo' ]
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('blocks a doc with an empty array', function() {
+        var doc = {
+          _id: 'arrayDoc',
+          staticNonEmptyProp: [ ]
+        };
+
+        testHelper.verifyDocumentNotCreated(doc, 'arrayDoc', errorFormatter.mustNotBeEmptyViolation('staticNonEmptyProp'));
+      });
+    });
+
+    describe('with dynamic validation', function() {
+      it('allows a doc with an array that is not empty', function() {
+        var doc = {
+          _id: 'arrayDoc',
+          dynamicNonEmptyProp: [ 'foo' ],
+          dynamicPropertiesMustNotBeEmpty: true
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a doc with an array that is empty if the constraint is disabled', function() {
+        var doc = {
+          _id: 'arrayDoc',
+          dynamicNonEmptyProp: [ ],
+          dynamicPropertiesMustNotBeEmpty: false
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('blocks a doc with an empty array if the constraint is enabled', function() {
+        var doc = {
+          _id: 'arrayDoc',
+          dynamicNonEmptyProp: [ ],
+          dynamicPropertiesMustNotBeEmpty: true
+        };
+
+        testHelper.verifyDocumentNotCreated(doc, 'arrayDoc', errorFormatter.mustNotBeEmptyViolation('dynamicNonEmptyProp'));
+      });
+    });
+  });
 });

--- a/test/hashtable-spec.js
+++ b/test/hashtable-spec.js
@@ -43,4 +43,58 @@ describe('Hashtable validation type', function() {
       testHelper.verifyDocumentNotCreated(doc, 'hashtableDoc', errorFormatter.hashtableMaximumSizeViolation('sizeValidationProp', 2));
     });
   });
+
+  describe('non-empty key constraint', function() {
+    describe('with static validation', function() {
+      it('allows a doc with a key that is not empty', function() {
+        var doc = {
+          _id: 'hashtableDoc',
+          staticNonEmptyKeyProp: { 'foo': 'bar' }
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('blocks a doc with an empty key', function() {
+        var doc = {
+          _id: 'hashtableDoc',
+          staticNonEmptyKeyProp: { '': 'bar' }
+        };
+
+        testHelper.verifyDocumentNotCreated(doc, 'hashtableDoc', errorFormatter.hashtableKeyEmpty('staticNonEmptyKeyProp'));
+      });
+    });
+
+    describe('with dynamic validation', function() {
+      it('allows a doc with a key that is not empty', function() {
+        var doc = {
+          _id: 'hashtableDoc',
+          dynamicNonEmptyKeyProp: { 'foo': 'bar' },
+          dynamicKeysMustNotBeEmpty: true
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a doc with an empty key when the constraint is disabled', function() {
+        var doc = {
+          _id: 'hashtableDoc',
+          dynamicNonEmptyKeyProp: { '': 'bar' },
+          dynamicKeysMustNotBeEmpty: false
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('blocks a doc with an empty key when the constraint is enabled', function() {
+        var doc = {
+          _id: 'hashtableDoc',
+          dynamicNonEmptyKeyProp: { '': 'bar' },
+          dynamicKeysMustNotBeEmpty: true
+        };
+
+        testHelper.verifyDocumentNotCreated(doc, 'hashtableDoc', errorFormatter.hashtableKeyEmpty('dynamicNonEmptyKeyProp'));
+      });
+    });
+  });
 });

--- a/test/immutable-when-set-spec.js
+++ b/test/immutable-when-set-spec.js
@@ -1,142 +1,192 @@
 var testHelper = require('../etc/test-helper.js');
+var errorFormatter = testHelper.validationErrorFormatter;
 
-describe('An item protected by the immutable-if-set constraint', function() {
+describe('Immutable when set constraint:', function() {
   beforeEach(function() {
     testHelper.init('build/sync-functions/test-immutable-when-set-sync-function.js');
   });
 
-  it('can be set to a value in a new document', function() {
-    var doc = {
-      _id: 'myDoc',
-      myProp: 'foobar'
-    };
+  describe('a property with static validation', function() {
+    it('can be set to a value in a new document', function() {
+      var doc = {
+        _id: 'myDoc',
+        staticValidationProp: 'foobar'
+      };
 
-    testHelper.verifyDocumentCreated(doc);
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('can be left undefined in a new document', function() {
+      var doc = {
+        _id: 'myDoc'
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('can be set to null in a new document', function() {
+      var doc = {
+        _id: 'myDoc',
+        staticValidationProp: null
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('can be set to the same value as was already assigned in the old document', function() {
+      var doc = {
+        _id: 'myDoc',
+        staticValidationProp: 'foobar'
+      };
+      var oldDoc = {
+        _id: 'myDoc',
+        staticValidationProp: 'foobar'
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('can be set to a value if it was left undefined in the old document', function() {
+      var doc = {
+        _id: 'myDoc',
+        staticValidationProp: 'foobar'
+      };
+      var oldDoc = {
+        _id: 'myDoc'
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('can be set to a value if it was null in the old document', function() {
+      var doc = {
+        _id: 'myDoc',
+        staticValidationProp: 'foobar'
+      };
+      var oldDoc = {
+        _id: 'myDoc',
+        staticValidationProp: null
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('can be set to null if it was undefined in the old document', function() {
+      var doc = {
+        _id: 'myDoc',
+        staticValidationProp: null
+      };
+      var oldDoc = {
+        _id: 'myDoc'
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('can be set to undefined if it was null in the old document', function() {
+      var doc = {
+        _id: 'myDoc'
+      };
+      var oldDoc = {
+        _id: 'myDoc',
+        staticValidationProp: null
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+
+    it('cannot be changed to a new value if it was set to a value in the old document', function() {
+      var doc = {
+        _id: 'myDoc',
+        staticValidationProp: 'barfoo'
+      };
+      var oldDoc = {
+        _id: 'myDoc',
+        staticValidationProp: 'foobar'
+      };
+
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'myDoc', errorFormatter.immutableItemViolation('staticValidationProp'));
+    });
+
+    it('cannot be change to undefined if it was set to a value in the old document', function() {
+      var doc = {
+        _id: 'myDoc'
+      };
+      var oldDoc = {
+        _id: 'myDoc',
+        staticValidationProp: 'foobar'
+      };
+
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'myDoc', errorFormatter.immutableItemViolation('staticValidationProp'));
+    });
+
+    it('cannot be changed to null if it was set to a value in the old document', function() {
+      var doc = {
+        _id: 'myDoc',
+        staticValidationProp: null
+      };
+      var oldDoc = {
+        _id: 'myDoc',
+        staticValidationProp: 'foobar'
+      };
+
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'myDoc', errorFormatter.immutableItemViolation('staticValidationProp'));
+    });
+
+    it('does not prevent a document from being deleted if it is set to a value', function() {
+      var oldDoc = {
+        _id: 'myDoc',
+        staticValidationProp: 'foobar'
+      };
+
+      testHelper.verifyDocumentDeleted(oldDoc);
+    });
   });
 
-  it('can be left undefined in a new document', function() {
-    var doc = {
-      _id: 'myDoc'
-    };
+  describe('a property with dynamic validation', function() {
+    it('can be set to the same value as was already assigned in the old document', function() {
+      var doc = {
+        _id: 'myDoc',
+        dynamicValidationProp: 42,
+        dynamicPropertiesAreImmutable: true
+      };
+      var oldDoc = {
+        _id: 'myDoc',
+        dynamicValidationProp: 42,
+        dynamicPropertiesAreImmutable: true
+      };
 
-    testHelper.verifyDocumentCreated(doc);
-  });
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
 
-  it('can be set to null in a new document', function() {
-    var doc = {
-      _id: 'myDoc',
-      myProp: null
-    };
+    it('can be set to a new value if the property is not immutable', function() {
+      var doc = {
+        _id: 'myDoc',
+        dynamicValidationProp: -1,
+        dynamicPropertiesAreImmutable: false
+      };
+      var oldDoc = {
+        _id: 'myDoc',
+        dynamicValidationProp: 42,
+        dynamicPropertiesAreImmutable: false
+      };
 
-    testHelper.verifyDocumentCreated(doc);
-  });
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
 
-  it('can be set to the same value as was already assigned in the old document', function() {
-    var doc = {
-      _id: 'myDoc',
-      myProp: 'foobar'
-    };
-    var oldDoc = {
-      _id: 'myDoc',
-      myProp: 'foobar'
-    };
+    it('can be set to a new value if the property is immutable', function() {
+      var doc = {
+        _id: 'myDoc',
+        dynamicValidationProp: 0,
+        dynamicPropertiesAreImmutable: true
+      };
+      var oldDoc = {
+        _id: 'myDoc',
+        dynamicValidationProp: -1,
+        dynamicPropertiesAreImmutable: true
+      };
 
-    testHelper.verifyDocumentReplaced(doc, oldDoc);
-  });
-
-  it('can be set to a value if it was left undefined in the old document', function() {
-    var doc = {
-      _id: 'myDoc',
-      myProp: 'foobar'
-    };
-    var oldDoc = {
-      _id: 'myDoc'
-    };
-
-    testHelper.verifyDocumentReplaced(doc, oldDoc);
-  });
-
-  it('can be set to a value if it was null in the old document', function() {
-    var doc = {
-      _id: 'myDoc',
-      myProp: 'foobar'
-    };
-    var oldDoc = {
-      _id: 'myDoc',
-      myProp: null
-    };
-
-    testHelper.verifyDocumentReplaced(doc, oldDoc);
-  });
-
-  it('can be set to null if it was undefined in the old document', function() {
-    var doc = {
-      _id: 'myDoc',
-      myProp: null
-    };
-    var oldDoc = {
-      _id: 'myDoc'
-    };
-
-    testHelper.verifyDocumentReplaced(doc, oldDoc);
-  });
-
-  it('can be set to undefined if it was null in the old document', function() {
-    var doc = {
-      _id: 'myDoc'
-    };
-    var oldDoc = {
-      _id: 'myDoc',
-      myProp: null
-    };
-
-    testHelper.verifyDocumentReplaced(doc, oldDoc);
-  });
-
-  it('cannot be changed to a new value if it was set to a value in the old document', function() {
-    var doc = {
-      _id: 'myDoc',
-      myProp: 'barfoo'
-    };
-    var oldDoc = {
-      _id: 'myDoc',
-      myProp: 'foobar'
-    };
-
-    testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'myDoc', 'value of item "myProp" may not be modified');
-  });
-
-  it('cannot be change to undefined if it was set to a value in the old document', function() {
-    var doc = {
-      _id: 'myDoc'
-    };
-    var oldDoc = {
-      _id: 'myDoc',
-      myProp: 'foobar'
-    };
-
-    testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'myDoc', 'value of item "myProp" may not be modified');
-  });
-
-  it('cannot be changed to null if it was set to a value in the old document', function() {
-    var doc = {
-      _id: 'myDoc',
-      myProp: null
-    };
-    var oldDoc = {
-      _id: 'myDoc',
-      myProp: 'foobar'
-    };
-
-    testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'myDoc', 'value of item "myProp" may not be modified');
-  });
-
-  it('does not prevent a document from being deleted if it is set to a value', function() {
-    var oldDoc = {
-      _id: 'myDoc',
-      myProp: 'foobar'
-    };
-
-    testHelper.verifyDocumentDeleted(oldDoc);
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'myDoc', errorFormatter.immutableItemViolation('dynamicValidationProp'));
+    });
   });
 });

--- a/test/resources/array-doc-definitions.js
+++ b/test/resources/array-doc-definitions.js
@@ -1,18 +1,36 @@
-{
-  arrayDoc: {
-    channels: { write: 'write' },
-    typeFilter: function(doc) {
-      return doc._id === 'arrayDoc';
-    },
-    propertyValidators: {
-      lengthValidationProp: {
-        type: 'array',
-        minimumLength: 2,
-        maximumLength: 2,
-        arrayElementsValidator: {
-          type: 'string'
+function() {
+  function isNonEmpty(value, oldValue, doc, oldDoc) {
+    return oldDoc ? oldDoc.dynamicPropertiesMustNotBeEmpty : doc.dynamicPropertiesMustNotBeEmpty;
+  }
+
+  return {
+    arrayDoc: {
+      channels: { write: 'write' },
+      typeFilter: function(doc) {
+        return doc._id === 'arrayDoc';
+      },
+      propertyValidators: {
+        lengthValidationProp: {
+          type: 'array',
+          minimumLength: 2,
+          maximumLength: 2,
+          arrayElementsValidator: {
+            type: 'string'
+          }
+        },
+        staticNonEmptyProp: {
+          type: 'array',
+          mustNotBeEmpty: true
+        },
+        dynamicPropertiesMustNotBeEmpty: {
+          type: 'boolean',
+          immutable: true
+        },
+        dynamicNonEmptyProp: {
+          type: 'array',
+          mustNotBeEmpty: isNonEmpty
         }
       }
     }
-  }
+  };
 }

--- a/test/resources/hashtable-doc-definitions.js
+++ b/test/resources/hashtable-doc-definitions.js
@@ -1,15 +1,37 @@
-{
-  hashtableDoc: {
-    channels: { write: 'write' },
-    typeFilter: function(doc) {
-      return doc._id === 'hashtableDoc';
-    },
-    propertyValidators: {
-      sizeValidationProp: {
-        type: 'hashtable',
-        minimumSize: 2,
-        maximumSize: 2
+function() {
+  function isNonEmpty(value, oldValue, doc, oldDoc) {
+    return oldDoc ? oldDoc.dynamicKeysMustNotBeEmpty : doc.dynamicKeysMustNotBeEmpty;
+  }
+
+  return {
+    hashtableDoc: {
+      channels: { write: 'write' },
+      typeFilter: function(doc) {
+        return doc._id === 'hashtableDoc';
+      },
+      propertyValidators: {
+        sizeValidationProp: {
+          type: 'hashtable',
+          minimumSize: 2,
+          maximumSize: 2
+        },
+        staticNonEmptyKeyProp: {
+          type: 'hashtable',
+          hashtableKeysValidator: {
+            mustNotBeEmpty: true
+          }
+        },
+        dynamicKeysMustNotBeEmpty: {
+          type: 'boolean',
+          immutable: true
+        },
+        dynamicNonEmptyKeyProp: {
+          type: 'hashtable',
+          hashtableKeysValidator: {
+            mustNotBeEmpty: isNonEmpty
+          }
+        }
       }
     }
-  }
+  };
 }

--- a/test/resources/immutable-when-set-doc-definitions.js
+++ b/test/resources/immutable-when-set-doc-definitions.js
@@ -5,9 +5,19 @@
       return doc._id === 'myDoc';
     },
     propertyValidators: {
-      myProp: {
+      staticValidationProp: {
         type: 'string',
         immutableWhenSet: true
+      },
+      dynamicPropertiesAreImmutable: {
+        type: 'boolean',
+        immutable: true
+      },
+      dynamicValidationProp: {
+        type: 'integer',
+        immutableWhenSet: function(value, oldValue, doc, oldDoc) {
+          return oldDoc ? oldDoc.dynamicPropertiesAreImmutable : doc.dynamicPropertiesAreImmutable;
+        }
       }
     }
   }

--- a/test/resources/string-doc-definitions.js
+++ b/test/resources/string-doc-definitions.js
@@ -1,15 +1,33 @@
-{
-  stringDoc: {
-    channels: { write: 'write' },
-    typeFilter: function(doc) {
-      return doc._id === 'stringDoc';
-    },
-    propertyValidators: {
-      lengthValidationProp: {
-        type: 'string',
-        minimumLength: 3,
-        maximumLength: 3
+function() {
+  function isNonEmpty(value, oldValue, doc, oldDoc) {
+    return oldDoc ? oldDoc.dynamicPropertiesMustNotBeEmpty : doc.dynamicPropertiesMustNotBeEmpty;
+  }
+
+  return {
+    stringDoc: {
+      channels: { write: 'write' },
+      typeFilter: function(doc) {
+        return doc._id === 'stringDoc';
+      },
+      propertyValidators: {
+        lengthValidationProp: {
+          type: 'string',
+          minimumLength: 3,
+          maximumLength: 3
+        },
+        staticNonEmptyProp: {
+          type: 'string',
+          mustNotBeEmpty: true
+        },
+        dynamicPropertiesMustNotBeEmpty: {
+          type: 'boolean',
+          immutable: true
+        },
+        dynamicNonEmptyProp: {
+          type: 'string',
+          mustNotBeEmpty: isNonEmpty
+        }
       }
     }
-  }
+  };
 }

--- a/test/string-spec.js
+++ b/test/string-spec.js
@@ -34,4 +34,58 @@ describe('String validation type', function() {
       testHelper.verifyDocumentNotCreated(doc, 'stringDoc', errorFormatter.maximumLengthViolation('lengthValidationProp', 3));
     });
   });
+
+  describe('non-empty constraint', function() {
+    describe('with static validation', function() {
+      it('allows a doc with a string that is not empty', function() {
+        var doc = {
+          _id: 'stringDoc',
+          staticNonEmptyProp: 'foo'
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('blocks a doc with an empty string', function() {
+        var doc = {
+          _id: 'stringDoc',
+          staticNonEmptyProp: ''
+        };
+
+        testHelper.verifyDocumentNotCreated(doc, 'stringDoc', errorFormatter.mustNotBeEmptyViolation('staticNonEmptyProp'));
+      });
+    });
+
+    describe('with dynamic validation', function() {
+      it('allows a doc with a string that is not empty', function() {
+        var doc = {
+          _id: 'stringDoc',
+          dynamicNonEmptyProp: 'bar',
+          dynamicPropertiesMustNotBeEmpty: true
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a doc with a string that is empty if the constraint is disabled', function() {
+        var doc = {
+          _id: 'stringDoc',
+          dynamicNonEmptyProp: '',
+          dynamicPropertiesMustNotBeEmpty: false
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('blocks a doc with an empty string if the constraint is enabled', function() {
+        var doc = {
+          _id: 'stringDoc',
+          dynamicNonEmptyProp: '',
+          dynamicPropertiesMustNotBeEmpty: true
+        };
+
+        testHelper.verifyDocumentNotCreated(doc, 'stringDoc', errorFormatter.mustNotBeEmptyViolation('dynamicNonEmptyProp'));
+      });
+    });
+  });
 });


### PR DESCRIPTION
Follows PR #96 to introduce test cases for additional property/element/key constraints (specifically `immutableWhenSet` and `mustNotBeEmpty`). I strongly recommend viewing the changes with `?w=1` to make it more manageable.

Part 2 of addressing issue #94. Several additional PRs full of test cases will follow this one.