### PR TITLE
Issue 94: Improvements to dynamic item constraints

### DIFF
--- a/etc/sync-function-validation-module.js
+++ b/etc/sync-function-validation-module.js
@@ -103,7 +103,7 @@ function() {
       if (typeof(constraintDefinition) === 'function') {
         var currentItemEntry = itemStack[itemStack.length - 1];
 
-        return constraintDefinition(currentItemEntry.itemValue, currentItemEntry.oldItemValue, doc, oldDoc);
+        return constraintDefinition(doc, oldDoc, currentItemEntry.itemValue, currentItemEntry.oldItemValue);
       } else {
         return constraintDefinition;
       }

--- a/etc/sync-function-validation-module.js
+++ b/etc/sync-function-validation-module.js
@@ -103,7 +103,7 @@ function() {
       if (typeof(constraintDefinition) === 'function') {
         var currentItemEntry = itemStack[itemStack.length - 1];
 
-        return constraintDefinition(doc, oldDoc, currentItemEntry.itemValue, currentItemEntry.oldItemValue);
+        return constraintDefinition(doc, getEffectiveOldDoc(oldDoc), currentItemEntry.itemValue, currentItemEntry.oldItemValue);
       } else {
         return constraintDefinition;
       }

--- a/etc/sync-function-validation-module.js
+++ b/etc/sync-function-validation-module.js
@@ -117,7 +117,7 @@ function() {
       var supportedProperties = [ ];
       for (var propertyValidatorName in propertyValidators) {
         var validator = propertyValidators[propertyValidatorName];
-        if (isValueNullOrUndefined(validator) || isValueNullOrUndefined(validator.type)) {
+        if (isValueNullOrUndefined(validator) || isValueNullOrUndefined(resolveValidationConstraint(validator.type))) {
           // Skip over non-validator fields/properties
           continue;
         }
@@ -162,6 +162,7 @@ function() {
     function validateItemValue(validator) {
       var currentItemEntry = itemStack[itemStack.length - 1];
       var itemValue = currentItemEntry.itemValue;
+      var validatorType = resolveValidationConstraint(validator.type);
 
       if (validator.customValidation) {
         performCustomValidation(validator);
@@ -185,7 +186,7 @@ function() {
           var minComparator = function(left, right) {
             return left < right;
           };
-          validateRangeConstraint(minimumValue, validator.type, minComparator, 'less than');
+          validateRangeConstraint(minimumValue, validatorType, minComparator, 'less than');
         }
 
         var minimumValueExclusive = resolveValidationConstraint(validator.minimumValueExclusive);
@@ -193,7 +194,7 @@ function() {
           var minExclusiveComparator = function(left, right) {
             return left <= right;
           };
-          validateRangeConstraint(minimumValueExclusive, validator.type, minExclusiveComparator, 'less than or equal to');
+          validateRangeConstraint(minimumValueExclusive, validatorType, minExclusiveComparator, 'less than or equal to');
         }
 
         var maximumValue = resolveValidationConstraint(validator.maximumValue);
@@ -201,7 +202,7 @@ function() {
           var maxComparator = function(left, right) {
             return left > right;
           };
-          validateRangeConstraint(maximumValue, validator.type, maxComparator, 'greater than');
+          validateRangeConstraint(maximumValue, validatorType, maxComparator, 'greater than');
         }
 
         var maximumValueExclusive = resolveValidationConstraint(validator.maximumValueExclusive);
@@ -209,7 +210,7 @@ function() {
           var maxExclusiveComparator = function(left, right) {
             return left >= right;
           };
-          validateRangeConstraint(maximumValueExclusive, validator.type, maxExclusiveComparator, 'greater than or equal to');
+          validateRangeConstraint(maximumValueExclusive, validatorType, maxExclusiveComparator, 'greater than or equal to');
         }
 
         var minimumLength = resolveValidationConstraint(validator.minimumLength);
@@ -222,7 +223,7 @@ function() {
           validationErrors.push('length of item "' + buildItemPath(itemStack) + '" must not be greater than ' + maximumLength);
         }
 
-        switch (validator.type) {
+        switch (validatorType) {
           case 'string':
             var regexPattern = resolveValidationConstraint(validator.regexPattern);
             if (typeof itemValue !== 'string') {

--- a/test/dynamic-constraints-spec.js
+++ b/test/dynamic-constraints-spec.js
@@ -1,0 +1,84 @@
+var testHelper = require('../etc/test-helper.js');
+var errorFormatter = testHelper.validationErrorFormatter;
+
+describe('Dynamic constraints', function() {
+  beforeEach(function() {
+    testHelper.init('build/sync-functions/test-dynamic-constraints-sync-function.js');
+  });
+
+  it('allows a doc to be created when the property constraints are satisfied', function() {
+    var doc = {
+      _id: 'my-doc',
+      type: 'myDoc',
+      dynamicReferenceId: 7,
+      validationByDocProperty: 'foo-7-bar',
+      validationByValueProperty: 119
+    };
+
+    testHelper.verifyDocumentCreated(doc);
+  });
+
+  it('allows a doc to be replaced when the property constraints are satisfied', function() {
+    var doc = {
+      _id: 'my-doc',
+      type: 'myDoc',
+      dynamicReferenceId: 0,
+      validationByDocProperty: 'foo-0-bar',
+      validationByValueProperty: -34
+    };
+    var oldDoc = {
+      _id: 'my-doc',
+      type: 'myDoc',
+      dynamicReferenceId: 0,
+      validationByDocProperty: 'foo-0-bar',
+      validationByValueProperty: -35
+    };
+
+    testHelper.verifyDocumentReplaced(doc, oldDoc);
+  });
+
+  it('blocks a doc from being created when the property constraints are violated', function() {
+    var doc = {
+      _id: 'my-doc',
+      type: 'myDoc',
+      dynamicReferenceId: 83,
+      validationByDocProperty: 'foo-38-bar',
+      validationByValueProperty: -1
+    };
+
+    testHelper.verifyDocumentNotCreated(
+      doc,
+      doc.type,
+      [
+        // If the current value of validationByValueProperty is less than zero (as it is in this case), the constraint will be set to zero
+        errorFormatter.minimumValueViolation('validationByValueProperty', 0),
+        errorFormatter.regexPatternItemViolation('validationByDocProperty', /^foo-83-bar$/)
+      ]);
+  });
+
+  it('blocks a doc from being replaced when the property constraints are violated', function() {
+    var doc = {
+      _id: 'my-doc',
+      type: 'myDoc',
+      dynamicReferenceId: 1,
+      validationByDocProperty: 'foo-0-bar',
+      validationByValueProperty: 20
+    };
+    var oldDoc = {
+      _id: 'my-doc',
+      type: 'myDoc',
+      dynamicReferenceId: 1,
+      validationByDocProperty: 'foo-1-bar',
+      validationByValueProperty: 18
+    };
+
+    testHelper.verifyDocumentNotReplaced(
+      doc,
+      oldDoc,
+      doc.type,
+      [
+        errorFormatter.maximumValueViolation('validationByValueProperty', 19),
+        errorFormatter.regexPatternItemViolation('validationByDocProperty', /^foo-1-bar$/)
+      ]);
+  });
+});

--- a/test/dynamic-constraints-spec.js
+++ b/test/dynamic-constraints-spec.js
@@ -6,7 +6,7 @@ describe('Dynamic constraints', function() {
     testHelper.init('build/sync-functions/test-dynamic-constraints-sync-function.js');
   });
 
-  it('allows a doc to be created when the property constraints are satisfied', function() {
+  it('allows a new doc to be created when the property constraints are satisfied', function() {
     var doc = {
       _id: 'my-doc',
       type: 'myDoc',
@@ -18,7 +18,7 @@ describe('Dynamic constraints', function() {
     testHelper.verifyDocumentCreated(doc);
   });
 
-  it('allows a doc to be replaced when the property constraints are satisfied', function() {
+  it('allows an existing doc to be replaced when the property constraints are satisfied', function() {
     var doc = {
       _id: 'my-doc',
       type: 'myDoc',
@@ -32,6 +32,26 @@ describe('Dynamic constraints', function() {
       dynamicReferenceId: 0,
       validationByDocProperty: 'foo-0-bar',
       validationByValueProperty: -35
+    };
+
+    testHelper.verifyDocumentReplaced(doc, oldDoc);
+  });
+
+  it('allows a deleted doc to be replaced when the property constraints are satisfied', function() {
+    var doc = {
+      _id: 'my-doc',
+      type: 'myDoc',
+      dynamicReferenceId: 34,
+      validationByDocProperty: 'foo-34-bar',
+      validationByValueProperty: 7
+    };
+    var oldDoc = {
+      _id: 'my-doc',
+      _deleted: true,
+      type: 'myDoc',
+      dynamicReferenceId: 9,
+      validationByDocProperty: 'foo-9-bar',
+      validationByValueProperty: 500
     };
 
     testHelper.verifyDocumentReplaced(doc, oldDoc);

--- a/test/dynamic-constraints-spec.js
+++ b/test/dynamic-constraints-spec.js
@@ -22,9 +22,9 @@ describe('Dynamic constraints', function() {
     var doc = {
       _id: 'my-doc',
       type: 'myDoc',
-      dynamicReferenceId: 0,
-      validationByDocProperty: 'foo-0-bar',
-      validationByValueProperty: -34
+      dynamicReferenceId: 5,
+      validationByDocProperty: 'foo-0-bar', // Note that the new value must be constructed from the old doc's dynamicReferenceId
+      validationByValueProperty: -34 // Note that the new value must equal the old value + 1
     };
     var oldDoc = {
       _id: 'my-doc',
@@ -80,9 +80,9 @@ describe('Dynamic constraints', function() {
     var doc = {
       _id: 'my-doc',
       type: 'myDoc',
-      dynamicReferenceId: 1,
-      validationByDocProperty: 'foo-0-bar',
-      validationByValueProperty: 20
+      dynamicReferenceId: 2,
+      validationByDocProperty: 'foo-2-bar', // Note that the new value must be constructed from the old doc's dynamicReferenceId
+      validationByValueProperty: 20 // Note that the new value must equal the old value + 1
     };
     var oldDoc = {
       _id: 'my-doc',

--- a/test/general-spec.js
+++ b/test/general-spec.js
@@ -132,6 +132,57 @@ describe('Functionality that is common to all documents:', function() {
 
       testHelper.verifyDocumentNotCreated(doc, 'generalDoc', [ errorFormatter.typeConstraintViolation('stringProp', 'string') ], 'add');
     });
+
+    it('allows a value of the right type for a dynamic property type', function() {
+      var doc = {
+        _id: 'generalDoc',
+        dynamicTypeProp: -56,
+        expectedDynamicType: 'integer',
+        expectedDynamicMinimumValue: -56,
+        expectedDynamicMinimumExclusiveValue: -57,
+        expectedDynamicMaximumValue: -56,
+        expectedDynamicMaximumExclusiveValue: -55
+      };
+
+      testHelper.verifyDocumentCreated(doc, 'add');
+    });
+
+    it('rejects a value that falls outside the minimum and maximum values for a dynamic property type', function() {
+      var doc = {
+        _id: 'generalDoc',
+        dynamicTypeProp: 0,
+        expectedDynamicType: 'integer',
+        expectedDynamicMinimumValue: 1,
+        expectedDynamicMinimumExclusiveValue: 0,
+        expectedDynamicMaximumValue: -1,
+        expectedDynamicMaximumExclusiveValue: 0
+      };
+
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'generalDoc',
+        [
+          errorFormatter.minimumValueViolation('dynamicTypeProp', 1),
+          errorFormatter.minimumValueExclusiveViolation('dynamicTypeProp', 0),
+          errorFormatter.maximumValueViolation('dynamicTypeProp', -1),
+          errorFormatter.maximumValueExclusiveViolation('dynamicTypeProp', 0)
+        ],
+        'add');
+    });
+
+    it('rejects a value of the wrong type for a dynamic property type', function() {
+      var doc = {
+        _id: 'generalDoc',
+        dynamicTypeProp: 9.5,
+        expectedDynamicType: 'string'
+      };
+
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'generalDoc',
+        [ errorFormatter.typeConstraintViolation('dynamicTypeProp', 'string') ],
+        'add');
+    });
   });
 
   it('cannot specify whitelisted properties below the root level of the document', function() {

--- a/test/resources/array-doc-definitions.js
+++ b/test/resources/array-doc-definitions.js
@@ -1,13 +1,13 @@
 function() {
-  function isNonEmpty(value, oldValue, doc, oldDoc) {
+  function isNonEmpty(doc, oldDoc, value, oldValue) {
     return oldDoc ? oldDoc.dynamicMustNotBeEmptyPropertiesEnforced : doc.dynamicMustNotBeEmptyPropertiesEnforced;
   }
 
-  function minimumDynamicLength(value, oldValue, doc, oldDoc) {
+  function minimumDynamicLength(doc, oldDoc, value, oldValue) {
     return doc.dynamicLengthPropertyIsValid ? value.length : value.length + 1;
   }
 
-  function maximumDynamicLength(value, oldValue, doc, oldDoc) {
+  function maximumDynamicLength(doc, oldDoc, value, oldValue) {
     return doc.dynamicLengthPropertyIsValid ? value.length : value.length - 1;
   }
 

--- a/test/resources/dynamic-constraints-doc-definitions.js
+++ b/test/resources/dynamic-constraints-doc-definitions.js
@@ -1,7 +1,7 @@
 function() {
   function sequenceValue(doc, oldDoc, value, oldValue) {
     var effectiveCurrentValue = (value >= 0) ? value : 0;
-    return isValueNullOrUndefined(oldValue) ? effectiveCurrentValue : oldValue + 1;
+    return oldDoc ? oldValue + 1 : effectiveCurrentValue;
   }
 
   return {

--- a/test/resources/dynamic-constraints-doc-definitions.js
+++ b/test/resources/dynamic-constraints-doc-definitions.js
@@ -10,8 +10,7 @@ function() {
       channels: { write: 'write' },
       propertyValidators: {
         dynamicReferenceId: {
-          type: 'integer',
-          immutable: true
+          type: 'integer'
         },
         validationByDocProperty: {
           // This property's regex is defined by another property on the document. It is used to verify that the correct values are passed

--- a/test/resources/dynamic-constraints-doc-definitions.js
+++ b/test/resources/dynamic-constraints-doc-definitions.js
@@ -1,0 +1,36 @@
+function() {
+  function sequenceValue(value, oldValue, doc, oldDoc) {
+    var effectiveCurrentValue = (value >= 0) ? value : 0;
+    return isValueNullOrUndefined(oldValue) ? effectiveCurrentValue : oldValue + 1;
+  }
+
+  return {
+    myDoc: {
+      typeFilter: simpleTypeFilter,
+      channels: { write: 'write' },
+      propertyValidators: {
+        dynamicReferenceId: {
+          type: 'integer',
+          immutable: true
+        },
+        validationByDocProperty: {
+          // This property's regex is defined by another property on the document. It is used to verify that the correct values are passed
+          // as the dynamic validation function's "doc" and "oldDoc" parameters.
+          type: 'string',
+          regexPattern: function(value, oldValue, doc, oldDoc) {
+            var dynamicId = oldDoc ? oldDoc.dynamicReferenceId : doc.dynamicReferenceId;
+
+            return new RegExp('^foo-' + dynamicId + '-bar$');
+          }
+        },
+        validationByValueProperty: {
+          // This property's value is a function of its current or previous value. It is used to verify that the correct values are passed
+          // as the dynamic validation functions "value" and "oldValue" parameters.
+          type: 'integer',
+          minimumValue: sequenceValue,
+          maximumValue: sequenceValue
+        }
+      }
+    }
+  };
+}

--- a/test/resources/dynamic-constraints-doc-definitions.js
+++ b/test/resources/dynamic-constraints-doc-definitions.js
@@ -1,5 +1,5 @@
 function() {
-  function sequenceValue(value, oldValue, doc, oldDoc) {
+  function sequenceValue(doc, oldDoc, value, oldValue) {
     var effectiveCurrentValue = (value >= 0) ? value : 0;
     return isValueNullOrUndefined(oldValue) ? effectiveCurrentValue : oldValue + 1;
   }
@@ -17,7 +17,7 @@ function() {
           // This property's regex is defined by another property on the document. It is used to verify that the correct values are passed
           // as the dynamic validation function's "doc" and "oldDoc" parameters.
           type: 'string',
-          regexPattern: function(value, oldValue, doc, oldDoc) {
+          regexPattern: function(doc, oldDoc, value, oldValue) {
             var dynamicId = oldDoc ? oldDoc.dynamicReferenceId : doc.dynamicReferenceId;
 
             return new RegExp('^foo-' + dynamicId + '-bar$');

--- a/test/resources/enum-doc-definitions.js
+++ b/test/resources/enum-doc-definitions.js
@@ -17,7 +17,7 @@
       },
       dynamicEnumProp: {
         type: 'enum',
-        predefinedValues: function(value, oldValue, doc, oldDoc) {
+        predefinedValues: function(doc, oldDoc, value, oldValue) {
           return doc.dynamicPredefinedValues;
         }
       }

--- a/test/resources/general-doc-definitions.js
+++ b/test/resources/general-doc-definitions.js
@@ -1,50 +1,86 @@
-{
-  generalDoc: {
-    channels: {
-      view: 'view',
-      add: 'add',
-      replace: [ 'replace', 'update' ],
-      remove: [ 'remove', 'delete' ]
-    },
-    typeFilter: function(doc) {
-      return doc._id === 'generalDoc';
-    },
-    propertyValidators: {
-      arrayProp: {
-        type: 'array'
+function() {
+  function dynamicType(value, oldValue, doc, oldDoc) {
+    return doc.expectedDynamicType;
+  }
+
+  return {
+    generalDoc: {
+      channels: {
+        view: 'view',
+        add: 'add',
+        replace: [ 'replace', 'update' ],
+        remove: [ 'remove', 'delete' ]
       },
-      attachmentReferenceProp: {
-        type: 'attachmentReference'
+      typeFilter: function(doc) {
+        return doc._id === 'generalDoc';
       },
-      booleanProp: {
-        type: 'boolean'
-      },
-      dateProp: {
-        type: 'date'
-      },
-      datetimeProp: {
-        type: 'datetime'
-      },
-      floatProp: {
-        type: 'float'
-      },
-      hashtableProp: {
-        type: 'hashtable'
-      },
-      integerProp: {
-        type: 'integer'
-      },
-      objectProp: {
-        type: 'object',
-        propertyValidators: {
-          foo: {
-            type: 'string'
+      propertyValidators: {
+        arrayProp: {
+          type: 'array'
+        },
+        attachmentReferenceProp: {
+          type: 'attachmentReference'
+        },
+        booleanProp: {
+          type: 'boolean'
+        },
+        dateProp: {
+          type: 'date'
+        },
+        datetimeProp: {
+          type: 'datetime'
+        },
+        floatProp: {
+          type: 'float'
+        },
+        hashtableProp: {
+          type: 'hashtable'
+        },
+        integerProp: {
+          type: 'integer'
+        },
+        objectProp: {
+          type: 'object',
+          propertyValidators: {
+            foo: {
+              type: 'string'
+            }
+          }
+        },
+        stringProp: {
+          type: 'string'
+        },
+        expectedDynamicType: {
+          type: 'string'
+        },
+        expectedDynamicMinimumValue: {
+          type: dynamicType
+        },
+        expectedDynamicMinimumExclusiveValue: {
+          type: dynamicType
+        },
+        expectedDynamicMaximumValue: {
+          type: dynamicType
+        },
+        expectedDynamicMaximumExclusiveValue: {
+          type: dynamicType
+        },
+        dynamicTypeProp: {
+          type: dynamicType,
+          minimumValue: function(value, oldValue, doc, oldDoc) {
+            return doc.expectedDynamicMinimumValue;
+          },
+          minimumValueExclusive: function(value, oldValue, doc, oldDoc) {
+            return doc.expectedDynamicMinimumExclusiveValue;
+          },
+          maximumValue: function(value, oldValue, doc, oldDoc) {
+            return doc.expectedDynamicMaximumValue;
+          },
+          maximumValueExclusive: function(value, oldValue, doc, oldDoc) {
+            return doc.expectedDynamicMaximumExclusiveValue;
           }
         }
-      },
-      stringProp: {
-        type: 'string'
       }
     }
-  }
+  };
 }

--- a/test/resources/general-doc-definitions.js
+++ b/test/resources/general-doc-definitions.js
@@ -1,5 +1,5 @@
 function() {
-  function dynamicType(value, oldValue, doc, oldDoc) {
+  function dynamicType(doc, oldDoc, value, oldValue) {
     return doc.expectedDynamicType;
   }
 
@@ -67,16 +67,16 @@ function() {
         },
         dynamicTypeProp: {
           type: dynamicType,
-          minimumValue: function(value, oldValue, doc, oldDoc) {
+          minimumValue: function(doc, oldDoc, value, oldValue) {
             return doc.expectedDynamicMinimumValue;
           },
-          minimumValueExclusive: function(value, oldValue, doc, oldDoc) {
+          minimumValueExclusive: function(doc, oldDoc, value, oldValue) {
             return doc.expectedDynamicMinimumExclusiveValue;
           },
-          maximumValue: function(value, oldValue, doc, oldDoc) {
+          maximumValue: function(doc, oldDoc, value, oldValue) {
             return doc.expectedDynamicMaximumValue;
           },
-          maximumValueExclusive: function(value, oldValue, doc, oldDoc) {
+          maximumValueExclusive: function(doc, oldDoc, value, oldValue) {
             return doc.expectedDynamicMaximumExclusiveValue;
           }
         }

--- a/test/resources/hashtable-doc-definitions.js
+++ b/test/resources/hashtable-doc-definitions.js
@@ -1,9 +1,9 @@
 function() {
-  function isNonEmpty(value, oldValue, doc, oldDoc) {
+  function isNonEmpty(doc, oldDoc, value, oldValue) {
     return oldDoc ? oldDoc.dynamicKeysMustNotBeEmpty : doc.dynamicKeysMustNotBeEmpty;
   }
 
-  function dynamicRegexPattern(value, oldValue, doc, oldDoc) {
+  function dynamicRegexPattern(doc, oldDoc, value, oldValue) {
     return oldDoc ? new RegExp(oldDoc.dynamicKeyRegex) : new RegExp(doc.dynamicKeyRegex);
   }
 

--- a/test/resources/immutable-items-doc-definitions.js
+++ b/test/resources/immutable-items-doc-definitions.js
@@ -1,5 +1,5 @@
 function() {
-  function isImmutable(value, oldValue, doc, oldDoc) {
+  function isImmutable(doc, oldDoc, value, oldValue) {
     return oldDoc ? oldDoc.dynamicPropertiesAreImmutable : doc.dynamicPropertiesAreImmutable;
   }
 

--- a/test/resources/immutable-when-set-doc-definitions.js
+++ b/test/resources/immutable-when-set-doc-definitions.js
@@ -15,7 +15,7 @@
       },
       dynamicValidationProp: {
         type: 'integer',
-        immutableWhenSet: function(value, oldValue, doc, oldDoc) {
+        immutableWhenSet: function(doc, oldDoc, value, oldValue) {
           return oldDoc ? oldDoc.dynamicPropertiesAreImmutable : doc.dynamicPropertiesAreImmutable;
         }
       }

--- a/test/resources/range-constraint-doc-definitions.js
+++ b/test/resources/range-constraint-doc-definitions.js
@@ -1,17 +1,17 @@
 function () {
-  function minimumNumericValue(value, oldValue, doc, oldDoc) {
+  function minimumNumericValue(doc, oldDoc, value, oldValue) {
     return doc.dynamicPropertyValuesAllowed ? value - 1 : value + 1;
   }
 
-  function maximumNumericValue(value, oldValue, doc, oldDoc) {
+  function maximumNumericValue(doc, oldDoc, value, oldValue) {
     return doc.dynamicPropertyValuesAllowed ? value + 1 : value - 1;
   }
 
-  function minimumDateValue(value, oldValue, doc, oldDoc) {
+  function minimumDateValue(doc, oldDoc, value, oldValue) {
     return doc.dynamicPropertyValuesAllowed ? '0000-01-01' : '9999-12-31';
   }
 
-  function maximumDateValue(value, oldValue, doc, oldDoc) {
+  function maximumDateValue(doc, oldDoc, value, oldValue) {
     return doc.dynamicPropertyValuesAllowed ? '9999-12-31' : '0000-01-01';
   }
 

--- a/test/resources/required-doc-definitions.js
+++ b/test/resources/required-doc-definitions.js
@@ -3,7 +3,7 @@ function() {
     return doc._id === docType;
   }
 
-  function isRequired(value, oldValue, doc, oldDoc) {
+  function isRequired(doc, oldDoc, value, oldValue) {
     return oldDoc ? oldDoc.dynamicPropsRequired : doc.dynamicPropsRequired;
   }
 

--- a/test/resources/string-doc-definitions.js
+++ b/test/resources/string-doc-definitions.js
@@ -1,17 +1,17 @@
 function() {
-  function isNonEmpty(value, oldValue, doc, oldDoc) {
+  function isNonEmpty(doc, oldDoc, value, oldValue) {
     return oldDoc ? oldDoc.dynamicMustNotBeEmptyPropertiesEnforced : doc.dynamicMustNotBeEmptyPropertiesEnforced;
   }
 
-  function minimumDynamicLength(value, oldValue, doc, oldDoc) {
+  function minimumDynamicLength(doc, oldDoc, value, oldValue) {
     return doc.dynamicLengthPropertyIsValid ? value.length : value.length + 1;
   }
 
-  function maximumDynamicLength(value, oldValue, doc, oldDoc) {
+  function maximumDynamicLength(doc, oldDoc, value, oldValue) {
     return doc.dynamicLengthPropertyIsValid ? value.length : value.length - 1;
   }
 
-  function dynamicRegexPattern(value, oldValue, doc, oldDoc) {
+  function dynamicRegexPattern(doc, oldDoc, value, oldValue) {
     return oldDoc ? new RegExp(oldDoc.dynamicRegex) : new RegExp(doc.dynamicRegex);
   }
 


### PR DESCRIPTION
Follows pull request #104 to add the following changes:
* Dynamic resolution of the property/element `type` field so that validation type can be specified as a function.
* Changes the order of parameters in the constraint function from `value`, `oldValue`, `doc`, `oldDoc` to `doc`, `oldDoc`, `value`, `oldValue`. Putting `doc` and `oldDoc` first ensures consistency with other functions that accept these parameters.
* Pass an old document that has been deleted (i.e. `oldDoc`'s `_deleted` property is `true`) as `null` in calls to the constraint function so that an implementer doesn't have to include special handling for that case.
* Added general-purpose test cases for dynamic item constraint validation.

Part 5 of addressing issue #94. A few more PRs full of test cases should follow.