### PR TITLE
Issue 97: Implementation of dynamic document constraint validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - [#94](https://github.com/Kashoo/synctos/issues/94): Support dynamic item validation constraints
+- [#97](https://github.com/Kashoo/synctos/issues/97): Support dynamic document constraints
 
 ## [1.8.0] - 2017-03-21
 ### Added

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -81,11 +81,6 @@ function synctos(doc, oldDoc) {
 
   var theDocDefinition = docDefinitions[theDocType];
 
-  // Ensure that, if the document type uses the simple type filter, it supports the "type" property
-  if (theDocDefinition.typeFilter === simpleTypeFilter && isValueNullOrUndefined(theDocDefinition.propertyValidators.type)) {
-    theDocDefinition.propertyValidators.type = typeIdValidator;
-  }
-
   var customActionMetadata = {
     documentTypeId: theDocType,
     documentDefinition: theDocDefinition

--- a/etc/sync-function-validation-module.js
+++ b/etc/sync-function-validation-module.js
@@ -18,6 +18,7 @@ function() {
     return regex.test(value);
   }
 
+  // A regular expression that matches one of the given file extensions
   function buildSupportedExtensionsRegex(extensions) {
     return new RegExp('\\.(' + extensions.join('|') + ')$', 'i');
   }
@@ -39,6 +40,11 @@ function() {
     }
 
     return nameComponents.join('');
+  }
+
+  // Resolves a constraint defined (e.g. `propertyValidators`, `allowUnknownProperties`, `immutable`) at the document level.
+  function resolveDocConstraint(doc, oldDoc, constraint) {
+    return (typeof(constraint) === 'function') ? constraint(doc, oldDoc) : constraint;
   }
 
   // Ensures the document structure and content are valid
@@ -63,14 +69,14 @@ function() {
 
   function validateDocImmutability(doc, oldDoc, docDefinition, validationErrors) {
     if (!isDocumentMissingOrDeleted(oldDoc)) {
-      if (docDefinition.immutable) {
+      if (resolveDocConstraint(doc, oldDoc, docDefinition.immutable)) {
         validationErrors.push('documents of this type cannot be replaced or deleted');
       } else if (doc._deleted) {
-        if (docDefinition.cannotDelete) {
+        if (resolveDocConstraint(doc, oldDoc, docDefinition.cannotDelete)) {
           validationErrors.push('documents of this type cannot be deleted');
         }
       } else {
-        if (docDefinition.cannotReplace) {
+        if (resolveDocConstraint(doc, oldDoc, docDefinition.cannotReplace)) {
           validationErrors.push('documents of this type cannot be replaced');
         }
       }
@@ -87,10 +93,17 @@ function() {
       }
     ];
 
+    var resolvedPropertyValidators = resolveTopLevelConstraint(docDefinition.propertyValidators);
+
+    // Ensure that, if the document type uses the simple type filter, it supports the "type" property
+    if (docDefinition.typeFilter === simpleTypeFilter && isValueNullOrUndefined(resolvedPropertyValidators.type)) {
+      resolvedPropertyValidators.type = typeIdValidator;
+    }
+
     // Execute each of the document's property validators while ignoring the specified whitelisted properties at the root level
     validateProperties(
-      docDefinition.propertyValidators,
-      docDefinition.allowUnknownProperties,
+      resolvedPropertyValidators,
+      resolveTopLevelConstraint(docDefinition.allowUnknownProperties),
       [ '_id', '_rev', '_deleted', '_revisions', '_attachments' ]);
 
     if (doc._attachments) {
@@ -107,6 +120,10 @@ function() {
       } else {
         return constraintDefinition;
       }
+    }
+
+    function resolveTopLevelConstraint(constraint) {
+      return resolveDocConstraint(doc, oldDoc, constraint);
     }
 
     function validateProperties(propertyValidators, allowUnknownProperties, whitelistedProperties) {
@@ -541,18 +558,20 @@ function() {
     }
 
     function validateAttachments() {
-      var attachmentConstraints = docDefinition.attachmentConstraints;
+      var attachmentConstraints = resolveTopLevelConstraint(docDefinition.attachmentConstraints);
 
-      var maximumAttachmentCount = attachmentConstraints ? attachmentConstraints.maximumAttachmentCount : null;
-      var maximumIndividualAttachmentSize = attachmentConstraints ? attachmentConstraints.maximumIndividualSize : null;
-      var maximumTotalAttachmentSize = attachmentConstraints ? attachmentConstraints.maximumTotalSize : null;
+      var maximumAttachmentCount = attachmentConstraints ? resolveTopLevelConstraint(attachmentConstraints.maximumAttachmentCount) : null;
+      var maximumIndividualAttachmentSize =
+        attachmentConstraints ? resolveTopLevelConstraint(attachmentConstraints.maximumIndividualSize) : null;
+      var maximumTotalAttachmentSize = attachmentConstraints ? resolveTopLevelConstraint(attachmentConstraints.maximumTotalSize) : null;
 
-      var supportedExtensions = attachmentConstraints ? attachmentConstraints.supportedExtensions : null;
+      var supportedExtensions = attachmentConstraints ? resolveTopLevelConstraint(attachmentConstraints.supportedExtensions) : null;
       var supportedExtensionsRegex = supportedExtensions ? buildSupportedExtensionsRegex(supportedExtensions) : null;
 
-      var supportedContentTypes = attachmentConstraints ? attachmentConstraints.supportedContentTypes : null;
+      var supportedContentTypes = attachmentConstraints ? resolveTopLevelConstraint(attachmentConstraints.supportedContentTypes) : null;
 
-      var requireAttachmentReferences = attachmentConstraints ? attachmentConstraints.requireAttachmentReferences : false;
+      var requireAttachmentReferences =
+        attachmentConstraints ? resolveTopLevelConstraint(attachmentConstraints.requireAttachmentReferences) : false;
 
       var totalSize = 0;
       var attachmentCount = 0;
@@ -602,7 +621,7 @@ function() {
         validationErrors.push('the total number of attachments must not exceed ' + maximumAttachmentCount);
       }
 
-      if (!docDefinition.allowAttachments && attachmentCount > 0) {
+      if (!resolveTopLevelConstraint(docDefinition.allowAttachments) && attachmentCount > 0) {
         validationErrors.push('document type does not support attachments');
       }
     }

--- a/samples/fragment-payment-processor-settlement.js
+++ b/samples/fragment-payment-processor-settlement.js
@@ -55,9 +55,9 @@ function() {
         mustNotBeEmpty: true,
         immutable: true,
         regexPattern: function(doc, oldDoc, value, oldValue) {
-          var expectedSettlementId = typeRegexMatchGroups[PROCESSOR_ID_MATCH_GROUP];
+          var expectedProcessorId = typeRegexMatchGroups[PROCESSOR_ID_MATCH_GROUP];
 
-          return new RegExp('^' + expectedSettlementId + '$');
+          return new RegExp('^' + expectedProcessorId + '$');
         }
       },
       capturedAt: {

--- a/test/immutable-docs-spec.js
+++ b/test/immutable-docs-spec.js
@@ -7,257 +7,424 @@ describe('Immutable document validation:', function() {
   });
 
   describe('full document immutability constraint', function() {
-    it('allows a document to be created if the old document does not exist', function() {
-      var doc = {
-        _id: 'immutableDoc',
-        stringProp: 'foobar'
-      };
+    describe('with static validation', function() {
+      it('allows a document to be created if the old document does not exist', function() {
+        var doc = {
+          _id: 'staticImmutableDoc',
+          stringProp: 'foobar'
+        };
 
-      testHelper.verifyDocumentCreated(doc);
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a document to be created if the old document was deleted', function() {
+        var doc = {
+          _id: 'staticImmutableDoc',
+          stringProp: 'barfoo'
+        };
+        var oldDoc = { _id: 'staticImmutableDoc', _deleted: true };
+
+        testHelper.verifyDocumentAccepted(doc, oldDoc, 'write');
+      });
+
+      it('allows a document to be deleted if the old document was already deleted', function() {
+        // There doesn't seem to be much point in deleting something that is already deleted, but since Sync Gateway allows you to do it, check
+        // that it works properly
+        var oldDoc = { _id: 'staticImmutableDoc', _deleted: true };
+
+        testHelper.verifyDocumentDeleted(oldDoc);
+      });
+
+      it('allows a document to be deleted if the old document does not exist', function() {
+        // There doesn't seem to be much point in deleting something that doesn't exist, but since Sync Gateway allows you to do it, check
+        // that it works properly
+        var doc = {
+          _id: 'staticImmutableDoc',
+          _deleted: true
+        };
+
+        testHelper.verifyDocumentAccepted(doc, undefined, 'write');
+      });
+
+      it('refuses to replace an existing document even if its properties have not been modified', function() {
+        var doc = {
+          _id: 'staticImmutableDoc',
+          stringProp: 'foobar'
+        };
+        var oldDoc = {
+          _id: 'staticImmutableDoc',
+          stringProp: 'foobar'
+        };
+
+        testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'staticImmutableDoc', errorFormatter.immutableDocViolation());
+      });
+
+      it('refuses to delete an existing document', function() {
+        var oldDoc = {
+          _id: 'staticImmutableDoc',
+          stringProp: 'foobar'
+        };
+
+        testHelper.verifyDocumentNotDeleted(oldDoc, 'staticImmutableDoc', errorFormatter.immutableDocViolation());
+      });
+
+      it('refuses to allow modification of attachments after the document has been created', function() {
+        var doc = {
+          _id: 'staticImmutableDoc',
+          _attachments: {
+            'bar.pdf': {
+              'content_type': 'application/pdf'
+            }
+          },
+          stringProp: 'foobar'
+        };
+        var oldDoc = {
+          _id: 'staticImmutableDoc',
+          _attachments: {
+            'foo.pdf': {
+              'content_type': 'application/pdf'
+            }
+          },
+          stringProp: 'foobar'
+        };
+
+        testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'staticImmutableDoc', errorFormatter.immutableDocViolation());
+      });
     });
 
-    it('allows a document to be created if the old document was deleted', function() {
-      var doc = {
-        _id: 'immutableDoc',
-        stringProp: 'barfoo'
-      };
-      var oldDoc = { _id: 'immutableDoc', _deleted: true };
+    describe('with dynamic validation', function() {
+      it('allows a new document to be created', function() {
+        var doc = {
+          _id: 'dynamicImmutableDoc',
+          integerProp: 17,
+          applyImmutability: true
+        };
 
-      testHelper.verifyDocumentAccepted(doc, oldDoc, 'write');
-    });
+        testHelper.verifyDocumentCreated(doc);
+      });
 
-    it('allows a document to be deleted if the old document was already deleted', function() {
-      // There doesn't seem to be much point in deleting something that is already deleted, but since Sync Gateway allows you to do it, check
-      // that it works properly
-      var oldDoc = { _id: 'immutableDoc', _deleted: true };
+      it('allows a document to be replaced if the constraint is disabled', function() {
+        var doc = {
+          _id: 'dynamicImmutableDoc',
+          integerProp: 71,
+          applyImmutability: true
+        };
+        var oldDoc = {
+          _id: 'dynamicImmutableDoc',
+          integerProp: -81,
+          applyImmutability: false
+        };
 
-      testHelper.verifyDocumentDeleted(oldDoc);
-    });
+        testHelper.verifyDocumentReplaced(doc, oldDoc);
+      });
 
-    it('allows a document to be deleted if the old document does not exist', function() {
-      // There doesn't seem to be much point in deleting something that doesn't exist, but since Sync Gateway allows you to do it, check
-      // that it works properly
-      var doc = {
-        _id: 'immutableDoc',
-        _deleted: true
-      };
+      it('allows a document to be deleted if the constraint is disabled', function() {
+        var oldDoc = {
+          _id: 'dynamicImmutableDoc',
+          integerProp: 909,
+          applyImmutability: false
+        };
 
-      testHelper.verifyDocumentAccepted(doc, undefined, 'write');
-    });
+        testHelper.verifyDocumentDeleted(oldDoc);
+      });
 
-    it('refuses to replace an existing document even if its properties have not been modified', function() {
-      var doc = {
-        _id: 'immutableDoc',
-        stringProp: 'foobar'
-      };
-      var oldDoc = {
-        _id: 'immutableDoc',
-        stringProp: 'foobar'
-      };
+      it('blocks a document from being replaced if the constraint is enabled', function() {
+        var doc = {
+          _id: 'dynamicImmutableDoc',
+          integerProp: 7,
+          applyImmutability: false
+        };
+        var oldDoc = {
+          _id: 'dynamicImmutableDoc',
+          integerProp: 14,
+          applyImmutability: true
+        };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableDoc', errorFormatter.immutableDocViolation());
-    });
+        testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'dynamicImmutableDoc', errorFormatter.immutableDocViolation());
+      });
 
-    it('refuses to delete an existing document', function() {
-      var oldDoc = {
-        _id: 'immutableDoc',
-        stringProp: 'foobar'
-      };
+      it('blocks a document from being deleted if the constraint is enabled', function() {
+        var oldDoc = {
+          _id: 'dynamicImmutableDoc',
+          integerProp: -111,
+          applyImmutability: true
+        };
 
-      testHelper.verifyDocumentNotDeleted(oldDoc, 'immutableDoc', errorFormatter.immutableDocViolation());
-    });
-
-    it('refuses to allow modification of attachments after the document has been created', function() {
-      var doc = {
-        _id: 'immutableDoc',
-        _attachments: {
-          'bar.pdf': {
-            'content_type': 'application/pdf'
-          }
-        },
-        stringProp: 'foobar'
-      };
-      var oldDoc = {
-        _id: 'immutableDoc',
-        _attachments: {
-          'foo.pdf': {
-            'content_type': 'application/pdf'
-          }
-        },
-        stringProp: 'foobar'
-      };
-
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'immutableDoc', errorFormatter.immutableDocViolation());
+        testHelper.verifyDocumentNotDeleted(oldDoc, 'dynamicImmutableDoc', errorFormatter.immutableDocViolation());
+      });
     });
   });
 
   describe('cannot replace document constraint', function() {
-    it('allows a document to be created if the old document does not exist', function() {
-      var doc = {
-        _id: 'cannotReplaceDoc',
-        stringProp: 'foobar'
-      };
+    describe('with static validation', function() {
+      it('allows a document to be created if the old document does not exist', function() {
+        var doc = {
+          _id: 'staticCannotReplaceDoc',
+          stringProp: 'foobar'
+        };
 
-      testHelper.verifyDocumentCreated(doc);
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a document to be created if the old document was deleted', function() {
+        var doc = {
+          _id: 'staticCannotReplaceDoc',
+          stringProp: 'barfoo'
+        };
+        var oldDoc = { _id: 'staticCannotReplaceDoc', _deleted: true };
+
+        testHelper.verifyDocumentAccepted(doc, oldDoc, 'write');
+      });
+
+      it('allows a document to be deleted', function() {
+        var oldDoc = {
+          _id: 'staticCannotReplaceDoc',
+          stringProp: 'foobar'
+        };
+
+        testHelper.verifyDocumentDeleted(oldDoc);
+      });
+
+      it('allows a document to be deleted if the old document was already deleted', function() {
+        // There doesn't seem to be much point in deleting something that is already deleted, but since Sync Gateway allows you to do it, check
+        // that it works properly
+        var oldDoc = { _id: 'staticCannotReplaceDoc', _deleted: true };
+
+        testHelper.verifyDocumentDeleted(oldDoc);
+      });
+
+      it('allows a document to be deleted if the old document does not exist', function() {
+        // There doesn't seem to be much point in deleting something that doesn't exist, but since Sync Gateway allows you to do it, check
+        // that it works properly
+        var doc = {
+          _id: 'staticCannotReplaceDoc',
+          _deleted: true
+        };
+
+        testHelper.verifyDocumentAccepted(doc, undefined, 'write');
+      });
+
+      it('refuses to replace an existing document even if its properties have not been modified', function() {
+        var doc = {
+          _id: 'staticCannotReplaceDoc',
+          stringProp: 'foobar'
+        };
+        var oldDoc = {
+          _id: 'staticCannotReplaceDoc',
+          stringProp: 'foobar'
+        };
+
+        testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'staticCannotReplaceDoc', errorFormatter.cannotReplaceDocViolation());
+      });
+
+      it('refuses to allow modification of attachments after the document has been created', function() {
+        var doc = {
+          _id: 'staticCannotReplaceDoc',
+          _attachments: {
+            'bar.pdf': {
+              'content_type': 'application/pdf'
+            }
+          },
+          stringProp: 'foobar'
+        };
+        var oldDoc = {
+          _id: 'staticCannotReplaceDoc',
+          _attachments: {
+            'foo.pdf': {
+              'content_type': 'application/pdf'
+            }
+          },
+          stringProp: 'foobar'
+        };
+
+        testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'staticCannotReplaceDoc', errorFormatter.cannotReplaceDocViolation());
+      });
     });
 
-    it('allows a document to be created if the old document was deleted', function() {
-      var doc = {
-        _id: 'cannotReplaceDoc',
-        stringProp: 'barfoo'
-      };
-      var oldDoc = { _id: 'cannotReplaceDoc', _deleted: true };
+    describe('with dynamic validation', function() {
+      it('allows a new document to be created', function() {
+        var doc = {
+          _id: 'dynamicCannotReplaceDoc',
+          integerProp: 0,
+          applyImmutability: true
+        };
 
-      testHelper.verifyDocumentAccepted(doc, oldDoc, 'write');
-    });
+        testHelper.verifyDocumentCreated(doc);
+      });
 
-    it('allows a document to be deleted', function() {
-      var oldDoc = {
-        _id: 'cannotReplaceDoc',
-        stringProp: 'foobar'
-      };
+      it('allows a document to be deleted', function() {
+        var oldDoc = {
+          _id: 'dynamicCannotReplaceDoc',
+          integerProp: 1,
+          applyImmutability: true
+        };
 
-      testHelper.verifyDocumentDeleted(oldDoc);
-    });
+        testHelper.verifyDocumentDeleted(oldDoc);
+      });
 
-    it('allows a document to be deleted if the old document was already deleted', function() {
-      // There doesn't seem to be much point in deleting something that is already deleted, but since Sync Gateway allows you to do it, check
-      // that it works properly
-      var oldDoc = { _id: 'cannotReplaceDoc', _deleted: true };
+      it('allows a document to be replaced if the constraint is disabled', function() {
+        var doc = {
+          _id: 'dynamicCannotReplaceDoc',
+          integerProp: 1,
+          applyImmutability: true
+        };
+        var oldDoc = {
+          _id: 'dynamicCannotReplaceDoc',
+          integerProp: 0,
+          applyImmutability: false
+        };
 
-      testHelper.verifyDocumentDeleted(oldDoc);
-    });
+        testHelper.verifyDocumentReplaced(doc, oldDoc);
+      });
 
-    it('allows a document to be deleted if the old document does not exist', function() {
-      // There doesn't seem to be much point in deleting something that doesn't exist, but since Sync Gateway allows you to do it, check
-      // that it works properly
-      var doc = {
-        _id: 'cannotReplaceDoc',
-        _deleted: true
-      };
+      it('blocks a document from being replaced if the constraint is enabled', function() {
+        var doc = {
+          _id: 'dynamicCannotReplaceDoc',
+          integerProp: 2,
+          applyImmutability: false
+        };
+        var oldDoc = {
+          _id: 'dynamicCannotReplaceDoc',
+          integerProp: 1,
+          applyImmutability: true
+        };
 
-      testHelper.verifyDocumentAccepted(doc, undefined, 'write');
-    });
-
-    it('refuses to replace an existing document even if its properties have not been modified', function() {
-      var doc = {
-        _id: 'cannotReplaceDoc',
-        stringProp: 'foobar'
-      };
-      var oldDoc = {
-        _id: 'cannotReplaceDoc',
-        stringProp: 'foobar'
-      };
-
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'cannotReplaceDoc', errorFormatter.cannotReplaceDocViolation());
-    });
-
-    it('refuses to allow modification of attachments after the document has been created', function() {
-      var doc = {
-        _id: 'cannotReplaceDoc',
-        _attachments: {
-          'bar.pdf': {
-            'content_type': 'application/pdf'
-          }
-        },
-        stringProp: 'foobar'
-      };
-      var oldDoc = {
-        _id: 'cannotReplaceDoc',
-        _attachments: {
-          'foo.pdf': {
-            'content_type': 'application/pdf'
-          }
-        },
-        stringProp: 'foobar'
-      };
-
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'cannotReplaceDoc', errorFormatter.cannotReplaceDocViolation());
+        testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'dynamicCannotReplaceDoc', errorFormatter.cannotReplaceDocViolation());
+      });
     });
   });
 
   describe('cannot delete document constraint', function() {
-    it('allows a document to be created if the old document does not exist', function() {
-      var doc = {
-        _id: 'cannotDeleteDoc',
-        stringProp: 'foobar'
-      };
+    describe('with static validation', function() {
+      it('allows a document to be created if the old document does not exist', function() {
+        var doc = {
+          _id: 'staticCannotDeleteDoc',
+          stringProp: 'foobar'
+        };
 
-      testHelper.verifyDocumentCreated(doc);
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a document to be created if the old document was deleted', function() {
+        var doc = {
+          _id: 'staticCannotDeleteDoc',
+          stringProp: 'barfoo'
+        };
+        var oldDoc = { _id: 'staticCannotDeleteDoc', _deleted: true };
+
+        testHelper.verifyDocumentAccepted(doc, oldDoc, 'write');
+      });
+
+      it('allows a document to be deleted if the old document was already deleted', function() {
+        // There doesn't seem to be much point in deleting something that is already deleted, but since Sync Gateway allows you to do it, check
+        // that it works properly
+        var oldDoc = { _id: 'staticCannotDeleteDoc', _deleted: true };
+
+        testHelper.verifyDocumentDeleted(oldDoc);
+      });
+
+      it('allows a document to be deleted if the old document does not exist', function() {
+        // There doesn't seem to be much point in deleting something that doesn't exist, but since Sync Gateway allows you to do it, check
+        // that it works properly
+        var doc = {
+          _id: 'staticCannotDeleteDoc',
+          _deleted: true
+        };
+
+        testHelper.verifyDocumentAccepted(doc, undefined, 'write');
+      });
+
+      it('allows a document to be replaced', function() {
+        var doc = {
+          _id: 'staticCannotDeleteDoc',
+          stringProp: 'barfoo'
+        };
+        var oldDoc = {
+          _id: 'staticCannotDeleteDoc',
+          stringProp: 'foobar'
+        };
+
+        testHelper.verifyDocumentReplaced(doc, oldDoc);
+      });
+
+      it('allows modifification of attachments after the document has been created', function() {
+        var doc = {
+          _id: 'staticCannotDeleteDoc',
+          _attachments: {
+            'bar.pdf': {
+              'content_type': 'application/pdf'
+            }
+          },
+          stringProp: 'foobar'
+        };
+        var oldDoc = {
+          _id: 'staticCannotDeleteDoc',
+          _attachments: {
+            'foo.pdf': {
+              'content_type': 'application/pdf'
+            }
+          },
+          stringProp: 'foobar'
+        };
+
+        testHelper.verifyDocumentReplaced(doc, oldDoc);
+      });
+
+      it('refuses to delete an existing document', function() {
+        var oldDoc = {
+          _id: 'staticCannotDeleteDoc',
+          stringProp: 'foobar'
+        };
+
+        testHelper.verifyDocumentNotDeleted(oldDoc, 'staticCannotDeleteDoc', errorFormatter.cannotDeleteDocViolation());
+      });
     });
 
-    it('allows a document to be created if the old document was deleted', function() {
-      var doc = {
-        _id: 'cannotDeleteDoc',
-        stringProp: 'barfoo'
-      };
-      var oldDoc = { _id: 'cannotDeleteDoc', _deleted: true };
+    describe('with dynamic validation', function() {
+      it('allows a new document to be created', function() {
+        var doc = {
+          _id: 'dynamicCannotDeleteDoc',
+          integerProp: 9,
+          applyImmutability: true
+        };
 
-      testHelper.verifyDocumentAccepted(doc, oldDoc, 'write');
-    });
+        testHelper.verifyDocumentCreated(doc);
+      });
 
-    it('allows a document to be deleted if the old document was already deleted', function() {
-      // There doesn't seem to be much point in deleting something that is already deleted, but since Sync Gateway allows you to do it, check
-      // that it works properly
-      var oldDoc = { _id: 'cannotDeleteDoc', _deleted: true };
+      it('allows a document to be replaced', function() {
+        var doc = {
+          _id: 'dynamicCannotDeleteDoc',
+          integerProp: 8,
+          applyImmutability: true
+        };
+        var oldDoc = {
+          _id: 'dynamicCannotDeleteDoc',
+          integerProp: 9,
+          applyImmutability: true
+        };
 
-      testHelper.verifyDocumentDeleted(oldDoc);
-    });
+        testHelper.verifyDocumentReplaced(doc, oldDoc);
+      });
 
-    it('allows a document to be deleted if the old document does not exist', function() {
-      // There doesn't seem to be much point in deleting something that doesn't exist, but since Sync Gateway allows you to do it, check
-      // that it works properly
-      var doc = {
-        _id: 'cannotDeleteDoc',
-        _deleted: true
-      };
+      it('allows a document to be deleted if the constraint is disabled', function() {
+        var oldDoc = {
+          _id: 'dynamicCannotDeleteDoc',
+          integerProp: 7,
+          applyImmutability: false
+        };
 
-      testHelper.verifyDocumentAccepted(doc, undefined, 'write');
-    });
+        testHelper.verifyDocumentDeleted(oldDoc);
+      });
 
-    it('allows a document to be replaced', function() {
-      var doc = {
-        _id: 'cannotDeleteDoc',
-        stringProp: 'barfoo'
-      };
-      var oldDoc = {
-        _id: 'cannotDeleteDoc',
-        stringProp: 'foobar'
-      };
+      it('blocks a document from being deleted if the constraint is enabled', function() {
+        var oldDoc = {
+          _id: 'dynamicCannotDeleteDoc',
+          integerProp: 6,
+          applyImmutability: true
+        };
 
-      testHelper.verifyDocumentReplaced(doc, oldDoc);
-    });
-
-    it('allows modifification of attachments after the document has been created', function() {
-      var doc = {
-        _id: 'cannotDeleteDoc',
-        _attachments: {
-          'bar.pdf': {
-            'content_type': 'application/pdf'
-          }
-        },
-        stringProp: 'foobar'
-      };
-      var oldDoc = {
-        _id: 'cannotDeleteDoc',
-        _attachments: {
-          'foo.pdf': {
-            'content_type': 'application/pdf'
-          }
-        },
-        stringProp: 'foobar'
-      };
-
-      testHelper.verifyDocumentReplaced(doc, oldDoc);
-    });
-
-    it('refuses to delete an existing document', function() {
-      var oldDoc = {
-        _id: 'cannotDeleteDoc',
-        stringProp: 'foobar'
-      };
-
-      testHelper.verifyDocumentNotDeleted(oldDoc, 'cannotDeleteDoc', errorFormatter.cannotDeleteDocViolation());
+        testHelper.verifyDocumentNotDeleted(oldDoc, 'dynamicCannotDeleteDoc', errorFormatter.cannotDeleteDocViolation());
+      });
     });
   });
 });

--- a/test/property-validators-spec.js
+++ b/test/property-validators-spec.js
@@ -9,7 +9,7 @@ describe('Property validators:', function() {
   describe('static validation at the document level', function() {
     it('allow unknown properties when a document is created and the option is enabled', function() {
       var doc = {
-        _id: 'allowUnknownDoc',
+        _id: 'staticAllowUnknownDoc',
         unknownProperty1: 15
       };
 
@@ -18,11 +18,11 @@ describe('Property validators:', function() {
 
     it('allow unknown properties when a document is replaced and the option is enabled', function() {
       var doc = {
-        _id: 'allowUnknownDoc',
+        _id: 'staticAllowUnknownDoc',
         unknownProperty1: 'foo'
       };
       var oldDoc = {
-        _id: 'allowUnknownDoc',
+        _id: 'staticAllowUnknownDoc',
         unknownProperty2: true
       };
 
@@ -31,21 +31,21 @@ describe('Property validators:', function() {
 
     it('reject unknown properties when a document is created and the option is disabled', function() {
       var doc = {
-        _id: 'preventUnknownDoc',
+        _id: 'staticPreventUnknownDoc',
         unknownProperty1: 15
       };
 
-      testHelper.verifyDocumentNotCreated(doc, 'preventUnknownDoc', [ errorFormatter.unsupportedProperty('unknownProperty1') ]);
+      testHelper.verifyDocumentNotCreated(doc, 'staticPreventUnknownDoc', [ errorFormatter.unsupportedProperty('unknownProperty1') ]);
     });
 
     it('reject unknown properties when a document is replaced and the option is disabled', function() {
       var doc = {
-        _id: 'preventUnknownDoc',
+        _id: 'staticPreventUnknownDoc',
         unknownProperty1: 73.7
       };
-      var oldDoc = { _id: 'preventUnknownDoc' };
+      var oldDoc = { _id: 'staticPreventUnknownDoc' };
 
-      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'preventUnknownDoc', [ errorFormatter.unsupportedProperty('unknownProperty1') ]);
+      testHelper.verifyDocumentNotReplaced(doc, oldDoc, 'staticPreventUnknownDoc', [ errorFormatter.unsupportedProperty('unknownProperty1') ]);
     });
   });
 
@@ -94,7 +94,7 @@ describe('Property validators:', function() {
   describe('static validation in a nested object', function() {
     it('allow unknown properties when a document is created and the option is enabled', function() {
       var doc = {
-        _id: 'preventUnknownDoc',
+        _id: 'staticPreventUnknownDoc',
         allowUnknownProp: {
           myStringProp: 'foo',
           myUnknownProp: 'bar'
@@ -106,20 +106,20 @@ describe('Property validators:', function() {
 
     it('allow unknown properties when a document is replaced and the option is enabled', function() {
       var doc = {
-        _id: 'preventUnknownDoc',
+        _id: 'staticPreventUnknownDoc',
         allowUnknownProp: {
           myStringProp: 'foo',
           myUnknownProp: 'bar'
         }
       };
-      var oldDoc = { _id: 'preventUnknownDoc' };
+      var oldDoc = { _id: 'staticPreventUnknownDoc' };
 
       testHelper.verifyDocumentReplaced(doc, oldDoc);
     });
 
     it('reject unknown properties when a document is created and the option is disabled', function() {
       var doc = {
-        _id: 'allowUnknownDoc',
+        _id: 'staticAllowUnknownDoc',
         preventUnknownProp: {
           myStringProp: 'foo',
           myUnknownProp: 'bar'
@@ -128,24 +128,24 @@ describe('Property validators:', function() {
 
       testHelper.verifyDocumentNotCreated(
         doc,
-        'allowUnknownDoc',
+        'staticAllowUnknownDoc',
         [ errorFormatter.unsupportedProperty('preventUnknownProp.myUnknownProp') ]);
     });
 
     it('reject unknown properties when a document is replaced and the option is disabled', function() {
       var doc = {
-        _id: 'allowUnknownDoc',
+        _id: 'staticAllowUnknownDoc',
         preventUnknownProp: {
           myStringProp: 'foo',
           myUnknownProp: 'bar'
         }
       };
-      var oldDoc = { _id: 'allowUnknownDoc' };
+      var oldDoc = { _id: 'staticAllowUnknownDoc' };
 
       testHelper.verifyDocumentNotReplaced(
         doc,
         oldDoc,
-        'allowUnknownDoc',
+        'staticAllowUnknownDoc',
         [ errorFormatter.unsupportedProperty('preventUnknownProp.myUnknownProp') ]);
     });
   });

--- a/test/property-validators-spec.js
+++ b/test/property-validators-spec.js
@@ -49,6 +49,48 @@ describe('Property validators:', function() {
     });
   });
 
+  describe('dynamic validation at the document level', function() {
+    it('allows a document with no unknown properties', function() {
+      var doc = {
+        _id: 'foobar',
+        type: 'dynamicPropertiesValidationDoc',
+        extraProperty: 1.5,
+        unknownPropertiesAllowed: false
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('allows a document with unknown properties when they are enabled', function() {
+      var doc = {
+        _id: 'foobar',
+        type: 'dynamicPropertiesValidationDoc',
+        unrecognizedProperty: 'foobar',
+        unknownPropertiesAllowed: true
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('blocks a document with unknown properties when they are disabled', function() {
+      var doc = {
+        _id: 'my-doc',
+        type: 'dynamicPropertiesValidationDoc',
+        extraProperty: 99, // Since the ID is not "foobar", extraProperty is expected to be a string
+        unrecognizedProperty: [ ],
+        unknownPropertiesAllowed: false
+      };
+
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'dynamicPropertiesValidationDoc',
+        [
+          errorFormatter.unsupportedProperty('unrecognizedProperty'),
+          errorFormatter.typeConstraintViolation('extraProperty', 'string')
+        ]);
+    });
+  });
+
   describe('static validation in a nested object', function() {
     it('allow unknown properties when a document is created and the option is enabled', function() {
       var doc = {
@@ -112,7 +154,7 @@ describe('Property validators:', function() {
     it('allows a document with no nested unknown properties', function() {
       var doc = {
         _id: 'foobar',
-        type: 'dynamicValidationDoc',
+        type: 'dynamicObjectValidationDoc',
         subObject: {
           extraProperty: 1.5,
           unknownPropertiesAllowed: false
@@ -125,7 +167,7 @@ describe('Property validators:', function() {
     it('allows a document with nested unknown properties when they are enabled', function() {
       var doc = {
         _id: 'foobar',
-        type: 'dynamicValidationDoc',
+        type: 'dynamicObjectValidationDoc',
         subObject: {
           unrecognizedProperty: 'foobar',
           unknownPropertiesAllowed: true
@@ -138,7 +180,7 @@ describe('Property validators:', function() {
     it('blocks a document with nested unknown properties when they are disabled', function() {
       var doc = {
         _id: 'my-doc',
-        type: 'dynamicValidationDoc',
+        type: 'dynamicObjectValidationDoc',
         subObject: {
           extraProperty: 99, // Since the ID is not "foobar", extraProperty is expected to be a string
           unrecognizedProperty: [ ],
@@ -148,7 +190,7 @@ describe('Property validators:', function() {
 
       testHelper.verifyDocumentNotCreated(
         doc,
-        'dynamicValidationDoc',
+        'dynamicObjectValidationDoc',
         [
           errorFormatter.unsupportedProperty('subObject.unrecognizedProperty'),
           errorFormatter.typeConstraintViolation('subObject.extraProperty', 'string')

--- a/test/resources/immutable-docs-doc-definitions.js
+++ b/test/resources/immutable-docs-doc-definitions.js
@@ -1,41 +1,86 @@
-{
-  immutableDoc: {
-    channels: { write: 'write' },
-    typeFilter: function(doc) {
-      return doc._id === 'immutableDoc';
-    },
-    propertyValidators: {
-      stringProp: {
-        type: 'string'
-      }
-    },
-    immutable: true,
-    allowAttachments: true
-  },
-  cannotReplaceDoc: {
-    channels: { write: 'write' },
-    typeFilter: function(doc) {
-      return doc._id === 'cannotReplaceDoc';
-    },
-    propertyValidators: {
-      stringProp: {
-        type: 'string'
-      }
-    },
-    cannotReplace: true,
-    allowAttachments: true
-  },
-  cannotDeleteDoc: {
-    channels: { write: 'write' },
-    typeFilter: function(doc) {
-      return doc._id === 'cannotDeleteDoc';
-    },
-    propertyValidators: {
-      stringProp: {
-        type: 'string'
-      }
-    },
-    cannotDelete: true,
-    allowAttachments: true
+function() {
+  function docTypeFilter(doc, oldDoc, docType) {
+    return doc._id === docType;
   }
+
+  function isImmutable(doc, oldDoc, value, oldValue) {
+    return oldDoc ? oldDoc.applyImmutability : doc.applyImmutability;
+  }
+
+  var docChannels = { write: 'write' };
+
+  return {
+    staticImmutableDoc: {
+      typeFilter: docTypeFilter,
+      channels: docChannels,
+      propertyValidators: {
+        stringProp: {
+          type: 'string'
+        }
+      },
+      immutable: true,
+      allowAttachments: true
+    },
+    dynamicImmutableDoc: {
+      typeFilter: docTypeFilter,
+      channels: docChannels,
+      propertyValidators: {
+        integerProp: {
+          type: 'integer'
+        },
+        applyImmutability: {
+          type: 'boolean'
+        }
+      },
+      immutable: isImmutable
+    },
+    staticCannotReplaceDoc: {
+      typeFilter: docTypeFilter,
+      channels: docChannels,
+      propertyValidators: {
+        stringProp: {
+          type: 'string'
+        }
+      },
+      cannotReplace: true,
+      allowAttachments: true
+    },
+    dynamicCannotReplaceDoc: {
+      typeFilter: docTypeFilter,
+      channels: docChannels,
+      propertyValidators: {
+        integerProp: {
+          type: 'integer'
+        },
+        applyImmutability: {
+          type: 'boolean'
+        }
+      },
+      cannotReplace: isImmutable
+    },
+    staticCannotDeleteDoc: {
+      typeFilter: docTypeFilter,
+      channels: docChannels,
+      propertyValidators: {
+        stringProp: {
+          type: 'string'
+        }
+      },
+      cannotDelete: true,
+      allowAttachments: true
+    },
+    dynamicCannotDeleteDoc: {
+      typeFilter: docTypeFilter,
+      channels: docChannels,
+      propertyValidators: {
+        integerProp: {
+          type: 'integer'
+        },
+        applyImmutability: {
+          type: 'boolean'
+        }
+      },
+      cannotDelete: isImmutable
+    }
+  };
 }

--- a/test/resources/property-validators-doc-definitions.js
+++ b/test/resources/property-validators-doc-definitions.js
@@ -38,7 +38,27 @@ function() {
         }
       }
     },
-    dynamicValidationDoc: {
+    dynamicPropertiesValidationDoc: {
+      typeFilter: simpleTypeFilter,
+      channels: docChannels,
+      allowUnknownProperties: function(doc, oldDoc, value, oldValue) {
+        return doc.unknownPropertiesAllowed;
+      },
+      propertyValidators: function(doc, oldDoc, value, oldValue) {
+        var props = {
+          unknownPropertiesAllowed: { type: 'boolean' }
+        };
+
+        if (doc._id === 'foobar') {
+          props.extraProperty = { type: 'float' };
+        } else {
+          props.extraProperty = { type: 'string' };
+        }
+
+        return props;
+      }
+    },
+    dynamicObjectValidationDoc: {
       typeFilter: simpleTypeFilter,
       channels: docChannels,
       propertyValidators: {

--- a/test/resources/property-validators-doc-definitions.js
+++ b/test/resources/property-validators-doc-definitions.js
@@ -6,7 +6,7 @@ function() {
   var docChannels = { write: 'write' };
 
   return {
-    allowUnknownDoc: {
+    staticAllowUnknownDoc: {
       typeFilter: docTypeFilter,
       channels: docChannels,
       allowUnknownProperties: true,
@@ -22,7 +22,7 @@ function() {
         }
       }
     },
-    preventUnknownDoc: {
+    staticPreventUnknownDoc: {
       typeFilter: docTypeFilter,
       channels: docChannels,
       allowUnknownProperties: false,


### PR DESCRIPTION
Constraints that are specified at the document level (e.g. `allowAttachments`, `immutable`, `propertyValidators`) may now be specified dynamically as a function. This initial pull request includes test cases for `allowUnknownProperties`, `propertyValidators`, `immutable`, `cannotReplace` and `cannotDelete`.

The first of two pull requests to address issue #97.