### PR TITLE
Remove backticks from sync function validation module

### DIFF
--- a/etc/sync-function-validation-module.js
+++ b/etc/sync-function-validation-module.js
@@ -42,7 +42,7 @@ function() {
     return nameComponents.join('');
   }
 
-  // Resolves a constraint defined at the document level (e.g. `propertyValidators`, `allowUnknownProperties`, `immutable`).
+  // Resolves a constraint defined at the document level (e.g. propertyValidators, allowUnknownProperties, immutable).
   function resolveDocConstraint(doc, oldDoc, constraintDefinition) {
     return (typeof(constraintDefinition) === 'function') ? constraintDefinition(doc, getEffectiveOldDoc(oldDoc)) : constraintDefinition;
   }


### PR DESCRIPTION
The backtick (\`) is a reserved character in a Sync Gateway configuration file; it is used to denote the beginning and end of a multiline string as is commonly used for sync functions. Removed the errant backticks from the sync function validation module's comments to prevent the resulting syntax error ("Error reading config file config/synctos-test.json: invalid character 'p' after object key:value pair").

I have also manually verified that Sync Gateway once again launches successfully with sync functions generated by synctos.