### PR TITLE
Issue 113: Escape backticks in generated sync functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#97](https://github.com/Kashoo/synctos/issues/97): Support dynamic document constraints
 - [#100](https://github.com/Kashoo/synctos/issues/100): Option to initialize test helper module with document definition file
 
+### Fixed
+- [#113](https://github.com/Kashoo/synctos/issues/113): Backticks in document definitions cause syntax errors
+
 ## [1.8.0] - 2017-03-21
 ### Added
 - [#90](https://github.com/Kashoo/synctos/issues/90): Document-wide constraints on file attachments

--- a/etc/sync-function-loader.js
+++ b/etc/sync-function-loader.js
@@ -44,8 +44,10 @@ exports.load = function(docDefinitionFilename, baseDir) {
   syncDocDefn = syncDocDefn.replace(/importDocumentDefinitionFragment\s*\(\s*"((?:\\"|[^"])+)"\s*\)/g, readDocDefinitionFragment)
     .replace(/importDocumentDefinitionFragment\s*\(\s*'((?:\\'|[^'])+)'\s*\)/g, readDocDefinitionFragment);
 
-  // Load the document definitions into the sync function template
-  var syncFunc = syncFuncTemplate.replace('%SYNC_DOCUMENT_DEFINITIONS%', function() { return syncDocDefn; });
+  // Load the document definitions into the sync function template and then escape any occurrence of the backtick character so the sync
+  // function can be used in a Sync Gateway configuration file multiline string
+  var syncFunc = syncFuncTemplate.replace('%SYNC_DOCUMENT_DEFINITIONS%', function() { return syncDocDefn; })
+    .replace(/`/g, function() { return '\\`'; });
 
   // Normalize code block indentation, normalize line endings and replace blank lines with empty lines
   syncFunc = indent.indentJS(syncFunc, '  ')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "expect.js": "^0.3.1",
     "jshint": "^2.9.4",
-    "mocha": "^3.2.0",
+    "mocha": "^3.3.0",
     "simple-mock": "^0.7.3"
   },
   "scripts": {

--- a/test/hashtable-spec.js
+++ b/test/hashtable-spec.js
@@ -145,7 +145,7 @@ describe('Hashtable validation type', function() {
         var doc = {
           _id: 'hashtableDoc',
           staticKeyRegexPatternValidationProp: {
-            'Foobar': 'baz',
+            'Foo`bar': 'baz',
             'Baz': 'qux'
           }
         };
@@ -165,7 +165,7 @@ describe('Hashtable validation type', function() {
         testHelper.verifyDocumentNotCreated(
           doc,
           'hashtableDoc',
-          errorFormatter.regexPatternHashtableKeyViolation('staticKeyRegexPatternValidationProp[123]', /^[a-zA-Z]+$/));
+          errorFormatter.regexPatternHashtableKeyViolation('staticKeyRegexPatternValidationProp[123]', /^[a-zA-Z]+(`[a-zA-Z]+)?$/));
       });
     });
 

--- a/test/resources/hashtable-doc-definitions.js
+++ b/test/resources/hashtable-doc-definitions.js
@@ -49,7 +49,7 @@ function() {
         staticKeyRegexPatternValidationProp: {
           type: 'hashtable',
           hashtableKeysValidator: {
-            regexPattern: /^[a-zA-Z]+$/
+            regexPattern: /^[a-zA-Z]+(`[a-zA-Z]+)?$/
           }
         },
         dynamicKeyRegex: {

--- a/test/resources/string-doc-definitions.js
+++ b/test/resources/string-doc-definitions.js
@@ -48,7 +48,7 @@ function() {
         },
         staticRegexPatternValidationProp: {
           type: 'string',
-          regexPattern: /^\d+$/
+          regexPattern: /^\d+`[a-z]+$/
         },
         dynamicRegex: {
           type: 'string'

--- a/test/string-spec.js
+++ b/test/string-spec.js
@@ -124,7 +124,7 @@ describe('String validation type', function() {
       it('allows a doc with a string that matches the expected pattern', function() {
         var doc = {
           _id: 'stringDoc',
-          staticRegexPatternValidationProp: '0472'
+          staticRegexPatternValidationProp: '0472`foo'
         };
 
         testHelper.verifyDocumentCreated(doc);
@@ -136,7 +136,10 @@ describe('String validation type', function() {
           staticRegexPatternValidationProp: 'foobar'
         };
 
-        testHelper.verifyDocumentNotCreated(doc, 'stringDoc', errorFormatter.regexPatternItemViolation('staticRegexPatternValidationProp', /^\d+$/));
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          errorFormatter.regexPatternItemViolation('staticRegexPatternValidationProp', /^\d+`[a-z]+$/));
       });
     });
 


### PR DESCRIPTION
To avoid syntax errors when a generated sync function is inserted as a multiline string in a Sync Gateway configuration file, all backtick characters that appear in the sync function are now automatically escaped.

I also manually verified that, with this fix, Sync Gateway accepts a sync function generated from document definitions that contain backtick characters.

Addresses issue #113.