### PR TITLE
Issue #116: Avoid character sequences used as special replacement patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-Nothing yet
+### Fixed
+- [#116](https://github.com/Kashoo/synctos/issues/116): Syntax error when the Sync Gateway admin UI loads a generated sync function
 
 ## [1.9.0] - 2017-04-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ typeFilter: function(doc, oldDoc, currentDocType) {
     return true;
   } else {
     // The type property did not match - fall back to matching the document ID pattern
-    var docIdRegex = new RegExp('^message\\.[A-Za-z0-9_-]+$');
+    var docIdRegex = /^message\.[A-Za-z0-9_-]+$/;
 
     return docIdRegex.test(doc._id);
   }

--- a/etc/sync-function-validation-module.js
+++ b/etc/sync-function-validation-module.js
@@ -6,21 +6,22 @@ function() {
 
   // Check that a given value is a valid ISO 8601 format date string with optional time and time zone components
   function isIso8601DateTimeString(value) {
-    var regex = new RegExp('^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))([T ]([01][0-9]|2[0-4])(:[0-5][0-9])?(:[0-5][0-9])?([\\.,][0-9]{1,3})?)?([zZ]|([\\+-])([01][0-9]|2[0-3]):?([0-5][0-9])?)?$');
+    var regex = /^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))([T ]([01][0-9]|2[0-4])(:[0-5][0-9])?(:[0-5][0-9])?([\.,][0-9]{1,3})?)?([zZ]|([\+-])([01][0-9]|2[0-3]):?([0-5][0-9])?)?$/;
 
     return regex.test(value);
   }
 
   // Check that a given value is a valid ISO 8601 date string without time and time zone components
   function isIso8601DateString(value) {
-    var regex = new RegExp('^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$');
+    var regex = /^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$/;
 
     return regex.test(value);
   }
 
   // A regular expression that matches one of the given file extensions
   function buildSupportedExtensionsRegex(extensions) {
-    return new RegExp('\\.(' + extensions.join('|') + ')$', 'i');
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return new RegExp("\\.(" + extensions.join("|") + ")$", "i");
   }
 
   // Constructs the fully qualified path of the item at the top of the given stack

--- a/samples/fragment-business.js
+++ b/samples/fragment-business.js
@@ -14,7 +14,7 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return new RegExp('^biz\\.[A-Za-z0-9_-]+$').test(doc._id);
+    return /^biz\.[A-Za-z0-9_-]+$/.test(doc._id);
   },
   allowAttachments: true,
   attachmentConstraints: {

--- a/samples/fragment-notification-transport-processing-summary.js
+++ b/samples/fragment-notification-transport-processing-summary.js
@@ -5,7 +5,8 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return createBusinessEntityRegex('notification\\.[A-Za-z0-9_-]+\\.processedTransport\\.[A-Za-z0-9_-]+$').test(doc._id);
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return createBusinessEntityRegex("notification\\.[A-Za-z0-9_-]+\\.processedTransport\\.[A-Za-z0-9_-]+$").test(doc._id);
   },
   cannotDelete: true,
   propertyValidators: {

--- a/samples/fragment-notification-transport.js
+++ b/samples/fragment-notification-transport.js
@@ -3,7 +3,8 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return createBusinessEntityRegex('notificationTransport\\.[A-Za-z0-9_-]+$').test(doc._id);
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return createBusinessEntityRegex("notificationTransport\\.[A-Za-z0-9_-]+$").test(doc._id);
   },
   propertyValidators: {
     type: {

--- a/samples/fragment-notification.js
+++ b/samples/fragment-notification.js
@@ -13,7 +13,8 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return createBusinessEntityRegex('notification\\.[A-Za-z0-9_-]+$').test(doc._id);
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return createBusinessEntityRegex("notification\\.[A-Za-z0-9_-]+$").test(doc._id);
   },
   accessAssignments: [
     {

--- a/samples/fragment-notifications-config.js
+++ b/samples/fragment-notifications-config.js
@@ -3,7 +3,8 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return createBusinessEntityRegex('notificationsConfig$').test(doc._id);
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return createBusinessEntityRegex("notificationsConfig$").test(doc._id);
   },
   propertyValidators: {
     notificationTypes: {
@@ -12,7 +13,7 @@
       hashtableKeysValidator: {
         type: 'string',
         mustNotBeEmpty: true,
-        regexPattern: new RegExp('^[a-zA-Z]+$')
+        regexPattern: /^[a-zA-Z]+$/
       },
       hashtableValuesValidator: {
         type: 'object',

--- a/samples/fragment-notifications-reference.js
+++ b/samples/fragment-notifications-reference.js
@@ -3,7 +3,8 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return createBusinessEntityRegex('notifications$').test(doc._id);
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return createBusinessEntityRegex("notifications$").test(doc._id);
   },
   propertyValidators: {
     allNotificationIds: {

--- a/samples/fragment-payment-attempt.js
+++ b/samples/fragment-payment-attempt.js
@@ -11,7 +11,7 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return new RegExp('^paymentAttempt\\.[A-Za-z0-9_-]+$').test(doc._id);
+    return /^paymentAttempt\.[A-Za-z0-9_-]+$/.test(doc._id);
   },
   immutable: true,
   propertyValidators: {

--- a/samples/fragment-payment-processor-definition.js
+++ b/samples/fragment-payment-processor-definition.js
@@ -3,7 +3,8 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return createBusinessEntityRegex('paymentProcessor\\.[A-Za-z0-9_-]+$').test(doc._id);
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return createBusinessEntityRegex("paymentProcessor\\.[A-Za-z0-9_-]+$").test(doc._id);
   },
   propertyValidators: {
     provider: {

--- a/samples/fragment-payment-processor-settlement.js
+++ b/samples/fragment-payment-processor-settlement.js
@@ -45,7 +45,8 @@ function() {
         regexPattern: function(doc, oldDoc, value, oldValue) {
           var expectedSettlementId = typeRegexMatchGroups[SETTLEMENT_ID_MATCH_GROUP];
 
-          return new RegExp('^' + expectedSettlementId + '$');
+          // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+          return new RegExp("^" + expectedSettlementId + "$");
         }
       },
       processorId: {
@@ -57,7 +58,8 @@ function() {
         regexPattern: function(doc, oldDoc, value, oldValue) {
           var expectedProcessorId = typeRegexMatchGroups[PROCESSOR_ID_MATCH_GROUP];
 
-          return new RegExp('^' + expectedProcessorId + '$');
+          // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+          return new RegExp("^" + expectedProcessorId + "$");
         }
       },
       capturedAt: {

--- a/samples/fragment-payment-requisition.js
+++ b/samples/fragment-payment-requisition.js
@@ -3,7 +3,7 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return new RegExp('^paymentRequisition\\.[A-Za-z0-9_-]+$').test(doc._id);
+    return /^paymentRequisition\.[A-Za-z0-9_-]+$/.test(doc._id);
   },
   cannotReplace: true,
   propertyValidators: {

--- a/samples/fragment-payment-requisitions-reference.js
+++ b/samples/fragment-payment-requisitions-reference.js
@@ -3,7 +3,8 @@
   authorizedRoles: defaultAuthorizedRoles,
   authorizedUsers: defaultAuthorizedUsers,
   typeFilter: function(doc, oldDoc) {
-    return createBusinessEntityRegex('invoice\\.[A-Za-z0-9_-]+.paymentRequisitions$').test(doc._id);
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return createBusinessEntityRegex("invoice\\.[A-Za-z0-9_-]+.paymentRequisitions$").test(doc._id);
   },
   propertyValidators: {
     paymentProcessorId: {

--- a/samples/sample-sync-doc-definitions.js
+++ b/samples/sample-sync-doc-definitions.js
@@ -6,11 +6,12 @@ function() {
   var adminUser = 'ADMIN';
 
   // Matches values that look like three-letter ISO 4217 currency codes. It is not comprehensive.
-  var iso4217CurrencyCodeRegex = new RegExp('^[A-Z]{3}$');
+  var iso4217CurrencyCodeRegex = /^[A-Z]{3}$/;
 
   // Creates a RegExp to match the ID of an entity that belongs to a business
   function createBusinessEntityRegex(suffixPattern) {
-    return new RegExp('^biz\\.\\d+\\.' + suffixPattern + '$');
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return new RegExp("^biz\\.\\d+\\." + suffixPattern + "$");
   }
 
   // Checks that a business ID is valid (an integer greater than 0) and is not changed from the old version of the document
@@ -31,7 +32,7 @@ function() {
 
   // Retrieves the ID of the business to which the document belongs
   function getBusinessId(doc, oldDoc) {
-    var regex = new RegExp('^biz\\.([A-Za-z0-9_-]+)(?:\\..+)?$');
+    var regex = /^biz\.([A-Za-z0-9_-]+)(?:\..+)?$/;
     var matchGroups = regex.exec(doc._id);
     if (matchGroups) {
       return matchGroups[1];

--- a/test/sample-notifications-config-spec.js
+++ b/test/sample-notifications-config-spec.js
@@ -53,9 +53,9 @@ describe('Sample business notifications config doc definition', function() {
         errorFormatter.unsupportedProperty('notificationTypes[invoicePayments].enabledTransports[0].invalid-property'),
         errorFormatter.requiredValueViolation('notificationTypes[invoicePayments].enabledTransports[0].transportId'),
         errorFormatter.mustNotBeEmptyViolation('notificationTypes[invoicePayments].enabledTransports[1].transportId'),
-        errorFormatter.regexPatternHashtableKeyViolation('notificationTypes[Invalid-Type]', new RegExp('^[a-zA-Z]+$')),
+        errorFormatter.regexPatternHashtableKeyViolation('notificationTypes[Invalid-Type]', /^[a-zA-Z]+$/),
         errorFormatter.hashtableKeyEmpty('notificationTypes'),
-        errorFormatter.regexPatternHashtableKeyViolation('notificationTypes[]', new RegExp('^[a-zA-Z]+$')),
+        errorFormatter.regexPatternHashtableKeyViolation('notificationTypes[]', /^[a-zA-Z]+$/),
         errorFormatter.requiredValueViolation('notificationTypes[]'),
         errorFormatter.unsupportedProperty('unknownprop')
       ]);

--- a/test/sample-payment-processor-definition-spec.js
+++ b/test/sample-payment-processor-definition-spec.js
@@ -78,7 +78,7 @@ describe('Sample payment processor definition doc definition', function() {
       oldDoc,
       expectedDocType,
       [
-        errorFormatter.regexPatternItemViolation('supportedCurrencyCodes[0]', new RegExp('^[A-Z]{3}$')),
+        errorFormatter.regexPatternItemViolation('supportedCurrencyCodes[0]', /^[A-Z]{3}$/),
         errorFormatter.typeConstraintViolation('accountId', 'integer'),
         errorFormatter.typeConstraintViolation('displayName', 'string'),
         errorFormatter.requiredValueViolation('provider'),


### PR DESCRIPTION
Previously, sync functions generated by synctos could not be loaded by the [Sync Gateway admin UI](https://github.com/couchbaselabs/sync_gateway_admin_ui)'s editor view due to a [defect](https://github.com/couchbaselabs/sync_gateway_admin_ui/issues/47) in the way that project injects a sync function's contents into the page. Specifically, the admin UI uses the version of the JavaScript `String.replace` function that allows special replacement patterns in the replacement value, one of which (`$'`) appears frequently at the end of a number of regular expressions in synctos' templates. A proper fix requires the underlying issue to be resolved in that project; however, as an immediate workaround to the problem, double quotes are now used instead of single quotes when constructing such regular expression strings. In addition, where possible, I have replaced the use of RegExp objects (e.g. `new RegExp('[a-zA-Z]+')`) with the literal regex equivalent (e.g. `/[a-zA-Z]+/`).

Addresses issue #116.