### PR TITLE
Issue 110: Test that mustEqual constraint applies to array and hashtable elements

### DIFF
--- a/test/must-equal-spec.js
+++ b/test/must-equal-spec.js
@@ -346,6 +346,59 @@ describe('Must equal validation parameter', function() {
     });
   });
 
+  describe('when applied to array elements', function() {
+    it('allows array element values that match', function() {
+      var doc = {
+        _id: 'arrayElementConstraintDoc',
+        arrayProp: [ 'foobar', 'foobar' ]
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('rejects array element values that do not match', function() {
+      var doc = {
+        _id: 'arrayElementConstraintDoc',
+        arrayProp: [ 'foobar', 'foobar', 'fubar' ]
+      };
+
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'arrayElementConstraintDoc',
+        errorFormatter.mustEqualViolation('arrayProp[2]', 'foobar'));
+    });
+  });
+
+  describe('when applied to hashtable element values', function() {
+    it('allows hashtable element values that match', function() {
+      var doc = {
+        _id: 'hashtableElementConstraintDoc',
+        hashtableProp: {
+          a: -15,
+          b: -15
+        }
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('rejects hashtable element values that do not match', function() {
+      var doc = {
+        _id: 'hashtableElementConstraintDoc',
+        hashtableProp: {
+          a: -15,
+          b: -15,
+          c: 15
+        }
+      };
+
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'hashtableElementConstraintDoc',
+        errorFormatter.mustEqualViolation('hashtableProp[c]', -15));
+    });
+  });
+
   describe('with an expected value of null', function() {
     it('allows a document with a value of null', function() {
       var doc = {

--- a/test/resources/must-equal-doc-definitions.js
+++ b/test/resources/must-equal-doc-definitions.js
@@ -93,6 +93,32 @@ function() {
         }
       }
     },
+    arrayElementConstraintDoc: {
+      typeFilter: sharedTypeFilter,
+      channels: docChannels,
+      propertyValidators: {
+        arrayProp: {
+          type: 'array',
+          arrayElementsValidator: {
+            type: 'string',
+            mustEqual: 'foobar'
+          }
+        }
+      }
+    },
+    hashtableElementConstraintDoc: {
+      typeFilter: sharedTypeFilter,
+      channels: docChannels,
+      propertyValidators: {
+        hashtableProp: {
+          type: 'hashtable',
+          hashtableValuesValidator: {
+            type: 'integer',
+            mustEqual: -15
+          }
+        }
+      }
+    },
     nullExpectedValueDoc: {
       typeFilter: sharedTypeFilter,
       channels: docChannels,


### PR DESCRIPTION
Defined some additional test cases to verify that the `mustEqual` constraint is enforced when set via an `arrayElementsValidator` or `hashtableValuesValidator`.

Addresses issue #110.