### PR TITLE
Issue 43: Use V8 context to parse sync functions in test-helper module

### DIFF
--- a/etc/sync-function-loader.js
+++ b/etc/sync-function-loader.js
@@ -8,13 +8,12 @@
 exports.load = loadFromFile;
 
 var fs = require('fs');
-var path = require('path');
 var indent = require('../lib/indent.js/indent.min.js');
 var docDefinitionsLoader = require('./document-definitions-loader.js');
 var fileFragmentLoader = require('./file-fragment-loader.js');
 
 function loadFromFile(docDefinitionsFile) {
-  var syncFuncTemplateDir = path.dirname(module.filename);
+  var syncFuncTemplateDir = __dirname;
 
   var syncFuncTemplatePath = syncFuncTemplateDir + '/sync-function-template.js';
   var syncFuncTemplate;

--- a/etc/test-helper-environment-template.js
+++ b/etc/test-helper-environment-template.js
@@ -1,4 +1,4 @@
-(function(require) {
+function(require) {
   var simple = require('simple-mock');
 
   var requireAccess = simple.stub();
@@ -20,4 +20,4 @@
     customActionStub: customActionStub,
     syncFunction: %SYNC_FUNC_PLACEHOLDER%
   };
-});
+}

--- a/etc/test-helper-environment-template.js
+++ b/etc/test-helper-environment-template.js
@@ -1,0 +1,23 @@
+(function(require) {
+  var simple = require('simple-mock');
+
+  var requireAccess = simple.stub();
+  var requireRole = simple.stub();
+  var requireUser = simple.stub();
+  var channel = simple.stub();
+  var access = simple.stub();
+  var role = simple.stub();
+
+  var customActionStub = simple.stub();
+
+  return {
+    requireAccess: requireAccess,
+    requireRole: requireRole,
+    requireUser: requireUser,
+    channel: channel,
+    access: access,
+    role: role,
+    customActionStub: customActionStub,
+    syncFunction: %SYNC_FUNC_PLACEHOLDER%
+  };
+});

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -306,7 +306,8 @@ function loadEnvironment(rawSyncFunction, syncFunctionFile) {
   // valid statement.
   var testHelperEnvironmentStatement = '(' + testHelperEnvironmentString + ');';
 
-  // Assign the compiled test helper environment function to a variable
+  // Compile the test helper environment function within the current virtual machine context so it can share access to the "requireAccess",
+  // "channel", "customActionStub", etc. stubs with the test-helper module
   var testHelperEnvironmentFunction = vm.runInThisContext(testHelperEnvironmentStatement, options);
 
   return testHelperEnvironmentFunction(require);

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -296,11 +296,20 @@ function loadEnvironment(rawSyncFunction, syncFunctionFile) {
     throw ex;
   }
 
+  // The test helper environment includes a placeholder string called "%SYNC_FUNC_PLACEHOLDER%" that is to be replaced with the contents of
+  // the sync function
   var testHelperEnvironmentString = testHelperEnvironmentTemplate.replace(
     '%SYNC_FUNC_PLACEHOLDER%',
     function() { return unescapeBackticks(rawSyncFunction); });
 
-  return vm.runInThisContext(testHelperEnvironmentString, options)(require);
+  // The code that is compiled must be an expression or a sequence of one or more statements. Surrounding it with parentheses makes it a
+  // valid statement.
+  var testHelperEnvironmentStatement = '(' + testHelperEnvironmentString + ');';
+
+  // Assign the compiled test helper environment function to a variable
+  var testHelperEnvironmentFunction = vm.runInThisContext(testHelperEnvironmentStatement, options);
+
+  return testHelperEnvironmentFunction(require);
 }
 
 function verifyRequireAccess(expectedChannels) {


### PR DESCRIPTION
The test-helper module now uses Node.js' built in `vm.runInThisContext` to evaluate a sync function's contents in the current V8 virtual machine context as a cleaner and more reliable way to parse JavaScript overall than using `eval` directly.

Also removed the sync-function-loader module's dependency on the built in "path" module since every Node.js module has an implicit `__dirname` variable that makes its use of `path.dirname` superfluous.