### PR TITLE
Issue 43: Load document definitions shells in the current VM context

### DIFF
--- a/etc/prepare-tests.sh
+++ b/etc/prepare-tests.sh
@@ -10,14 +10,21 @@ mkdir -p build/test-reports/
 echo "Linting modules and specs with JSHint\n"
 node_modules/jshint/bin/jshint src/*.js test/*.js
 
-# Create a temporary sync function from the sample document definitions file
-./make-sync-function samples/sample-sync-doc-definitions.js "$outputDir"/test-sample-sync-function.js
+sampleDocDefinitionsPath="samples/sample-sync-doc-definitions.js"
 
-# Automatically create a sync function from each document definitions file in the test resources directory
+# Validate the structure and sematics of the sample document definitions
+./validate-document-definitions "$sampleDocDefinitionsPath"
+
+# Create a temporary sync function from the sample document definitions file
+./make-sync-function "$sampleDocDefinitionsPath" "$outputDir"/test-sample-sync-function.js
+
+# Automatically validate and create a sync function from each document definitions file in the test resources directory
 definitionsDir="test/resources"
 for docDefinitionPath in "$definitionsDir"/*-doc-definitions.js; do
   # Skip entries that are not files
   if [ ! -f "$docDefinitionPath" ]; then continue; fi
+
+  ./validate-document-definitions "$docDefinitionPath"
 
   syncFuncName=$(basename "$docDefinitionPath" "-doc-definitions.js")
 

--- a/src/document-definitions-validator.js
+++ b/src/document-definitions-validator.js
@@ -180,8 +180,8 @@ function validateDocDefinition(docType, docDefinition) {
     validateAttachmentIntegerConstraint('maximumIndividualSize', attachmentConstraintsDefinition.maximumIndividualSize);
     validateAttachmentIntegerConstraint('maximumTotalSize', attachmentConstraintsDefinition.maximumTotalSize);
 
-    if (Number.isInteger(attachmentConstraintsDefinition.maximumIndividualSize) &&
-        Number.isInteger(attachmentConstraintsDefinition.maximumTotalSize) &&
+    if (isInteger(attachmentConstraintsDefinition.maximumIndividualSize) &&
+        isInteger(attachmentConstraintsDefinition.maximumTotalSize) &&
         attachmentConstraintsDefinition.maximumIndividualSize > attachmentConstraintsDefinition.maximumTotalSize) {
       validationErrors.push('the "attachmentConstraints" property\'s "maximumIndividualSize" is greater than "maximumTotalSize"');
     }
@@ -197,7 +197,7 @@ function validateDocDefinition(docType, docDefinition) {
 
   function validateAttachmentIntegerConstraint(propertyName, propertyValue) {
     if (!isUndefined(propertyValue)) {
-      if (!Number.isInteger(propertyValue)) {
+      if (!isInteger(propertyValue)) {
         validationErrors.push('the "attachmentConstraints" specifies a "' + propertyName + '" property that is not an integer');
       } else if (propertyValue <= 0) {
         validationErrors.push('the "attachmentConstraints" specifies a "' + propertyName + '" property that is not a positive number');
@@ -314,4 +314,14 @@ function isAnObject(value) {
 
 function isUndefined(value) {
   return typeof(value) === 'undefined';
+}
+
+// Determine if a given value is an integer. Exists as a failsafe because Number.isInteger does not exist in older versions of Node.js
+// (e.g. 0.10.x).
+function isInteger(value) {
+  if (typeof(Number.isInteger) === 'function') {
+    return Number.isInteger(value);
+  } else {
+    return typeof(value) === 'number' && isFinite(value) && Math.floor(value) === value;
+  }
 }

--- a/src/templates/document-definitions-shell-template.js
+++ b/src/templates/document-definitions-shell-template.js
@@ -1,0 +1,37 @@
+function(require) {
+  var simple = require('simple-mock');
+
+  var doc = { };
+  var oldDoc = { };
+  var typeIdValidator = { };
+  var simpleTypeFilter = simple.stub();
+  var isDocumentMissingOrDeleted = simple.stub();
+  var isValueNullOrUndefined = simple.stub();
+  var getEffectiveOldDoc = simple.stub();
+  var requireAccess = simple.stub();
+  var requireRole = simple.stub();
+  var requireUser = simple.stub();
+  var channel = simple.stub();
+  var access = simple.stub();
+  var role = simple.stub();
+
+  var customActionStub = simple.stub();
+
+  return {
+    doc: doc,
+    oldDoc: oldDoc,
+    typeIdValidator: typeIdValidator,
+    simpleTypeFilter: simpleTypeFilter,
+    isDocumentMissingOrDeleted: isDocumentMissingOrDeleted,
+    isValueNullOrUndefined: isValueNullOrUndefined,
+    getEffectiveOldDoc: getEffectiveOldDoc,
+    requireAccess: requireAccess,
+    requireRole: requireRole,
+    requireUser: requireUser,
+    channel: channel,
+    access: access,
+    role: role,
+    customActionStub: customActionStub,
+    documentDefinitions: %DOC_DEFINITIONS_PLACEHOLDER%
+  };
+}

--- a/test/authorization-spec.js
+++ b/test/authorization-spec.js
@@ -169,39 +169,4 @@ describe('Authorization:', function() {
       testHelper.verifyAccessDenied(doc, oldDoc, { expectedUsers: [ 'remove1', 'remove2' ] });
     });
   });
-
-  describe('for a document that does not define any authorized channels, roles or users', function() {
-    it('rejects document creation', function() {
-      var doc = {
-        _id: 'noAuthorizationsDefinedDoc',
-        stringProp: 'foobar'
-      };
-
-      testHelper.verifyAccessDenied(doc, null, { });
-    });
-
-    it('rejects document replacement', function() {
-      var doc = {
-        _id: 'noAuthorizationsDefinedDoc',
-        stringProp: 'foobar'
-      };
-      var oldDoc = {
-        _id: 'noAuthorizationsDefinedDoc'
-      };
-
-      testHelper.verifyAccessDenied(doc, oldDoc, { });
-    });
-
-    it('rejects document deletion', function() {
-      var doc = {
-        _id: 'noAuthorizationsDefinedDoc',
-        _deleted: true
-      };
-      var oldDoc = {
-        _id: 'noAuthorizationsDefinedDoc'
-      };
-
-      testHelper.verifyAccessDenied(doc, oldDoc, { });
-    });
-  });
 });

--- a/test/document-definitions-shell-maker-spec.js
+++ b/test/document-definitions-shell-maker-spec.js
@@ -1,15 +1,20 @@
+var path = require('path');
 var expect = require('expect.js');
 var simpleMock = require('simple-mock');
 var mockRequire = require('mock-require');
 
 describe('Document definitions shell maker', function() {
-  var docDefinitionsShellMaker, vmMock;
+  var environmentShellMaker, fsMock, vmMock;
 
   beforeEach(function() {
-    vmMock = { runInNewContext: simpleMock.stub() };
+    // Mock out the "require" calls in the module under test
+    fsMock = { readFileSync: simpleMock.stub() };
+    mockRequire('fs', fsMock);
+
+    vmMock = { runInThisContext: simpleMock.stub() };
     mockRequire('vm', vmMock);
 
-    docDefinitionsShellMaker = mockRequire.reRequire('../src/document-definitions-shell-maker.js');
+    environmentShellMaker = mockRequire.reRequire('../src/document-definitions-shell-maker.js');
   });
 
   afterEach(function() {
@@ -17,53 +22,32 @@ describe('Document definitions shell maker', function() {
     mockRequire.stopAll();
   });
 
-  function verifyParse(docDefinitionsString, originalFilename) {
-    var expectedOutput = { foo: 'bar' };
-    vmMock.runInNewContext.returnWith(expectedOutput);
+  function verifyParse(expectedFileContents, originalFilename) {
+    fsMock.readFileSync.returnWith(expectedFileContents);
 
-    var result = docDefinitionsShellMaker.createShell(docDefinitionsString, originalFilename);
+    var expectedResult = { foo: 'bar' };
+    var mockEnvironment = simpleMock.stub();
+    mockEnvironment.returnWith(expectedResult);
 
-    expect(result).to.eql(expectedOutput);
+    vmMock.runInThisContext.returnWith(mockEnvironment);
 
-    expect(vmMock.runInNewContext.callCount).to.be(1);
-    expect(vmMock.runInNewContext.calls[0].args[0]).to.equal('(' + docDefinitionsString + ');');
-    expect(vmMock.runInNewContext.calls[0].args[2]).to.eql({
-      filename: originalFilename,
-      displayErrors: true
-    });
+    var result = environmentShellMaker.createShell(expectedFileContents, originalFilename);
 
-    var sandbox = vmMock.runInNewContext.calls[0].args[1];
-    expect(sandbox).to.only.have.keys([
-      'doc',
-      'oldDoc',
-      'typeIdValidator',
-      'simpleTypeFilter',
-      'isDocumentMissingOrDeleted',
-      'isValueNullOrUndefined',
-      'getEffectiveOldDoc',
-      'requireAccess',
-      'requireRole',
-      'requireUser',
-      'channel',
-      'access',
-      'role'
+    expect(result).to.eql(expectedResult);
+
+    expect(fsMock.readFileSync.callCount).to.be(1);
+    expect(fsMock.readFileSync.calls[0].args).to.eql([ path.resolve(__dirname, '../src/templates/document-definitions-shell-template.js'), 'utf8' ]);
+
+    expect(vmMock.runInThisContext.callCount).to.be(1);
+    expect(vmMock.runInThisContext.calls[0].args).to.eql([
+      '(' + expectedFileContents + ');',
+      {
+        filename: originalFilename,
+        displayErrors: true
+      }
     ]);
-    expect(sandbox.doc).to.be.an('object');
-    expect(sandbox.doc).not.to.be.an(Array);
-    expect(sandbox.oldDoc).to.be.an('object');
-    expect(sandbox.oldDoc).not.to.be.an(Array);
-    expect(sandbox.typeIdValidator).to.be.an('object');
-    expect(sandbox.typeIdValidator).not.to.be.an(Array);
-    expect(sandbox.simpleTypeFilter).to.be.a('function');
-    expect(sandbox.isDocumentMissingOrDeleted).to.be.a('function');
-    expect(sandbox.isValueNullOrUndefined).to.be.a('function');
-    expect(sandbox.getEffectiveOldDoc).to.be.a('function');
-    expect(sandbox.requireAccess).to.be.a('function');
-    expect(sandbox.requireRole).to.be.a('function');
-    expect(sandbox.requireUser).to.be.a('function');
-    expect(sandbox.channel).to.be.a('function');
-    expect(sandbox.access).to.be.a('function');
-    expect(sandbox.role).to.be.a('function');
+
+    expect(mockEnvironment.callCount).to.be(1);
   }
 
   it('creates a shell from the input with a filename for stack traces', function() {

--- a/test/resources/authorization-doc-definitions.js
+++ b/test/resources/authorization-doc-definitions.js
@@ -85,15 +85,5 @@
         type: 'string'
       }
     }
-  },
-  noAuthorizationsDefinedDoc: {
-    typeFilter: function(doc) {
-      return doc._id === 'noAuthorizationsDefinedDoc';
-    },
-    propertyValidators: {
-      stringProp: {
-        type: 'string'
-      }
-    }
   }
 }

--- a/validate-document-definitions
+++ b/validate-document-definitions
@@ -2,7 +2,7 @@
 
 var path = require('path');
 var docDefinitionsLoader = require('./src/document-definitions-loader.js');
-var docDefinitionsShellMaker = require('./src/document-definitions-shell-maker.js');
+var environmentShellMaker = require('./src/document-definitions-shell-maker.js');
 var docDefinitionsValidator = require('./src/document-definitions-validator.js');
 
 var errorStatus = 1;
@@ -18,9 +18,9 @@ var docDefinitionsFilename = process.argv[2];
 
 var rawDocDefinitionsString = docDefinitionsLoader.load(docDefinitionsFilename);
 
-var rawDocDefinitionsShell = docDefinitionsShellMaker.createShell(rawDocDefinitionsString, docDefinitionsFilename);
+var environmentShell = environmentShellMaker.createShell(rawDocDefinitionsString, docDefinitionsFilename);
 
-var validationErrors = docDefinitionsValidator.validate(rawDocDefinitionsShell);
+var validationErrors = docDefinitionsValidator.validate(environmentShell.documentDefinitions);
 
 var exitStatus = 0;
 if (typeof(validationErrors) === 'string') {


### PR DESCRIPTION
To avoid environment mismatches that occur when mixing objects from two different contexts, create document definitions shells in the current Node.js virtual machine context instead of in a new context. Otherwise string comparisons with `===` and use of the `instanceof` keyword do not produce the expected results.

Also took the opportunity to update the `npm test` script to run the document definitions validator utility on each of the sample document definitions and test document definitions to help ensure these examples conform to specification. As a result the `noAuthorizationsDefinedDoc` type was removed from the document definitions for the authorization specifications since it is, by definition, an invalid document definition (i.e. it does not define `channels`, `authorizedRoles` or `authorizedUsers` properties) and thus causes the build to fail. Since it is an edge case and that case is now covered by the validation utility, it seems acceptable to remove it.

Just one more link in the chain to address issue #43.