### PR TITLE
Issue 43: Test cases for validation of essential document definition properties

### DIFF
--- a/src/document-definitions-shell-maker.js
+++ b/src/document-definitions-shell-maker.js
@@ -31,9 +31,7 @@ function createShell(docDefinitionsString, originalFilename) {
 
   // The test helper environment includes a placeholder string called "%DOC_DEFINITIONS_PLACEHOLDER%" that is to be replaced with the
   // contents of the document definitions
-  var shellString = shellTemplateString.replace(
-    '%DOC_DEFINITIONS_PLACEHOLDER%',
-    function() { return unescapeBackticks(docDefinitionsString); });
+  var shellString = shellTemplateString.replace('%DOC_DEFINITIONS_PLACEHOLDER%', function() { return docDefinitionsString; });
 
   // The code that is compiled must be an expression or a sequence of one or more statements. Surrounding it with parentheses makes it a
   // valid statement.
@@ -44,12 +42,4 @@ function createShell(docDefinitionsString, originalFilename) {
   var shellFunction = vm.runInThisContext(shellStatement, options);
 
   return shellFunction(require);
-}
-
-// Sync Gateway configuration files use the backtick character to denote the beginning and end of a multiline string. The sync function
-// generator script automatically escapes backtick characters with the sequence "\`" so that it produces a valid multiline string.
-// However, when loaded by this module, document definitions are not inserted into a Sync Gateway configuration file so we must "unescape"
-// backtick characters to preserve the original intention.
-function unescapeBackticks(originalString) {
-  return originalString.replace(/\\`/g, function() { return '`'; });
 }

--- a/src/document-definitions-validator.js
+++ b/src/document-definitions-validator.js
@@ -103,7 +103,7 @@ function validateDocDefinition(docType, docDefinition) {
       case 'immutable':
         if (typeof(propertyValue) !== 'boolean' && typeof(propertyValue) !== 'function') {
           validationErrors.push('the "immutable" property is not a boolean or a function');
-        } else if (docDefinition.immutable && (docDefinition.cannotReplace || docDefinition.cannotDelete)) {
+        } else if (docDefinition.immutable === true && (docDefinition.cannotReplace === true || docDefinition.cannotDelete === true)) {
           validationErrors.push('the "immutable" property should not be enabled when either "cannotReplace" or "cannotDelete" are also enabled');
         }
         break;
@@ -123,11 +123,11 @@ function validateDocDefinition(docType, docDefinition) {
         }
         break;
       case 'attachmentConstraints':
-        if (isAnObject(propertyValue)) {
-          if (!docDefinition.allowAttachments) {
-            validationErrors.push('the "attachmentConstraints" property is defined but attachments have not been enabled via the "allowAttachments" property');
-          }
+        if (!docDefinition.allowAttachments) {
+          validationErrors.push('the "attachmentConstraints" property is defined but attachments have not been enabled via the "allowAttachments" property');
+        }
 
+        if (isAnObject(propertyValue)) {
           validateAttachmentConstraints(propertyValue);
         } else if (typeof(propertyValue) !== 'function') {
           validationErrors.push('the "attachmentConstraints" property is not an object or a function');
@@ -175,6 +175,7 @@ function validateDocDefinition(docType, docDefinition) {
         if (permissions.length < 1) {
           validationErrors.push('the "' + permissionsCategory + '" property\'s "' + permissionOperation + '" operation does not contain any elements');
         }
+
         for (var permissionIndex = 0; permissionIndex < permissions.length; permissionIndex++) {
           var permission = permissions[permissionIndex];
           if (typeof(permission) !== 'string') {
@@ -224,17 +225,15 @@ function validateDocDefinition(docType, docDefinition) {
   function validateAttachmentListConstraint(propertyName, propertyValue) {
     if (!isUndefined(propertyValue)) {
       if (propertyValue instanceof Array) {
-        var hasElements = false;
+        if (propertyValue.length < 1) {
+          validationErrors.push('the "attachmentConstraints" specifies a "' + propertyName + '" property that does not contain any elements');
+        }
+
         for (var elementIndex = 0; elementIndex < propertyValue.length; elementIndex++) {
-          hasElements = true;
           var elementValue = propertyValue[elementIndex];
           if (typeof(elementValue) !== 'string') {
             validationErrors.push('the "attachmentConstraints" property\'s "' + propertyName + '" contains an element that is not a string: ' + JSON.stringify(elementValue));
           }
-        }
-
-        if (!hasElements) {
-          validationErrors.push('the "attachmentConstraints" specifies a "' + propertyName + '" property that does not contain any elements');
         }
       } else {
         validationErrors.push('the "attachmentConstraints" specifies a "' + propertyName + '" property that is not an array');

--- a/src/document-definitions-validator.js
+++ b/src/document-definitions-validator.js
@@ -224,11 +224,17 @@ function validateDocDefinition(docType, docDefinition) {
   function validateAttachmentListConstraint(propertyName, propertyValue) {
     if (!isUndefined(propertyValue)) {
       if (propertyValue instanceof Array) {
+        var hasElements = false;
         for (var elementIndex = 0; elementIndex < propertyValue.length; elementIndex++) {
+          hasElements = true;
           var elementValue = propertyValue[elementIndex];
           if (typeof(elementValue) !== 'string') {
             validationErrors.push('the "attachmentConstraints" property\'s "' + propertyName + '" contains an element that is not a string: ' + JSON.stringify(elementValue));
           }
+        }
+
+        if (!hasElements) {
+          validationErrors.push('the "attachmentConstraints" specifies a "' + propertyName + '" property that does not contain any elements');
         }
       } else {
         validationErrors.push('the "attachmentConstraints" specifies a "' + propertyName + '" property that is not an array');

--- a/test/document-definitions-validator-spec.js
+++ b/test/document-definitions-validator-spec.js
@@ -18,7 +18,7 @@ describe('Document definitions validator:', function() {
         },
         propertyValidators: { },
         allowUnknownProperties: false,
-        immutable: function() { return true; },
+        immutable: true,
         cannotReplace: false,
         cannotDelete: false,
         allowAttachments: true,
@@ -57,30 +57,33 @@ describe('Document definitions validator:', function() {
           return { write: 'foo' };
         },
         propertyValidators: function() { return { }; },
-        allowUnknownProperties: function() { return true; },
-        immutable: false,
-        cannotReplace: function() { return true; },
-        cannotDelete: function() { return true; },
-        allowAttachments: function() { return true; },
-        attachmentConstraints: function() { return { }; },
+        allowUnknownProperties: function() { },
+        immutable: function() { },
+        cannotReplace: function() { },
+        cannotDelete: function() { },
+        allowAttachments: function() { },
+        attachmentConstraints: function() { },
         accessAssignments: [
           {
             type: 'role',
-            roles: function() { return [ ]; },
-            users: function() { return [ ]; }
+            roles: function() { },
+            users: function() { }
           },
           {
             // The absence of the "type" property indicates it is the channel assignment type
-            channels: function() { return [ ]; },
-            roles: function() { return [ ]; },
-            users: function() { return [ ]; }
+            channels: function() { },
+            roles: function() { },
+            users: function() { }
           }
         ]
       },
       myDoc3: {
         typeFilter: simpleTypeFilter,
         authorizedUsers: { write: [ 'write' ] },
-        propertyValidators: { }
+        propertyValidators: { },
+        immutable: false,
+        cannotReplace: true,
+        cannotDelete: true
       }
     };
   });

--- a/test/document-definitions-validator-spec.js
+++ b/test/document-definitions-validator-spec.js
@@ -1,0 +1,342 @@
+var expect = require('expect.js');
+var docDefinitionsValidator = require('../src/document-definitions-validator.js');
+
+describe('Document definitions validator:', function() {
+  var testDocDefinitions;
+  var simpleTypeFilter = function(doc, oldDoc, docType) { return true; };
+
+  beforeEach(function() {
+    // By default these document definitions are valid
+    testDocDefinitions = {
+      myDoc1: {
+        typeFilter: simpleTypeFilter,
+        channels: {
+          view: 'view',
+          add: 'add',
+          replace: 'replace',
+          remove: 'remove'
+        },
+        propertyValidators: { },
+        allowUnknownProperties: false,
+        immutable: function() { return true; },
+        cannotReplace: false,
+        cannotDelete: false,
+        allowAttachments: true,
+        attachmentConstraints: {
+          maximumAttachmentCount: 1,
+          maximumIndividualSize: 256,
+          maximumTotalSize: 256,
+          supportedExtensions: [ 'txt' ],
+          supportedContentTypes: [ 'text/plain' ],
+          requireAttachmentReferences: true
+        },
+        accessAssignments: [
+          {
+            type: 'role',
+            roles: [ 'role1' ],
+            users: [ 'user1' ]
+          },
+          {
+            type: 'channel',
+            channels: [ 'channel1' ],
+            roles: [ 'role1', 'role2' ],
+            users: [ 'user1', 'user2' ]
+          }
+        ],
+        customActions: {
+          onTypeIdentificationSucceeded: function() { },
+          onAuthorizationSucceeded: function() { },
+          onValidationSucceeded: function() { },
+          onAccessAssignmentsSucceeded: function() { },
+          onDocumentChannelAssignmentSucceeded: function() { }
+        }
+      },
+      myDoc2: {
+        typeFilter: simpleTypeFilter,
+        authorizedRoles: function() {
+          return { write: 'foo' };
+        },
+        propertyValidators: function() { return { }; },
+        allowUnknownProperties: function() { return true; },
+        immutable: false,
+        cannotReplace: function() { return true; },
+        cannotDelete: function() { return true; },
+        allowAttachments: function() { return true; },
+        attachmentConstraints: function() { return { }; },
+        accessAssignments: [
+          {
+            type: 'role',
+            roles: function() { return [ ]; },
+            users: function() { return [ ]; }
+          },
+          {
+            // The absence of the "type" property indicates it is the channel assignment type
+            channels: function() { return [ ]; },
+            roles: function() { return [ ]; },
+            users: function() { return [ ]; }
+          }
+        ]
+      },
+      myDoc3: {
+        typeFilter: simpleTypeFilter,
+        authorizedUsers: { write: [ 'write' ] },
+        propertyValidators: { }
+      }
+    };
+  });
+
+  it('approves valid document definitions as an object', function() {
+    var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+    expect(results).to.eql({
+      myDoc1: [ ],
+      myDoc2: [ ],
+      myDoc3: [ ]
+    });
+  });
+
+  it('approves valid document definitions as a function', function() {
+    var results = docDefinitionsValidator.validate(function() { return testDocDefinitions; });
+
+    expect(results).to.eql({
+      myDoc1: [ ],
+      myDoc2: [ ],
+      myDoc3: [ ]
+    });
+  });
+
+  it('rejects a value input that is not a plain object', function() {
+    var results = docDefinitionsValidator.validate([ 1, 2, 3 ]);
+
+    expect(results).to.equal('Document definitions are not specified as an object');
+  });
+
+  it('rejects a function input that does not return a plain object', function() {
+    var results = docDefinitionsValidator.validate(function() { return 'not-an-object'; });
+
+    expect(results).to.equal('Document definitions are not specified as an object');
+  });
+
+  it('rejects an input that throws an exception', function() {
+    var exception = new Error('my exception');
+
+    var results = docDefinitionsValidator.validate(function() { throw exception; });
+
+    expect(results).to.equal('Document definitions threw an exception: ' + exception.message);
+  });
+
+  describe('type filter', function() {
+    it('cannot be anything other than a function', function() {
+      testDocDefinitions.myDoc1.typeFilter = true;
+      testDocDefinitions.myDoc2.typeFilter = { foo: 'bar' };
+      testDocDefinitions.myDoc3.typeFilter = 'foobar';
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [ 'the "typeFilter" property is not a function' ],
+        myDoc2: [ 'the "typeFilter" property is not a function' ],
+        myDoc3: [ 'the "typeFilter" property is not a function' ]
+      });
+    });
+
+    it('cannot be left undefined or null', function() {
+      delete testDocDefinitions.myDoc1.typeFilter;
+      testDocDefinitions.myDoc2.typeFilter = null;
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [ 'missing a "typeFilter" property' ],
+        myDoc2: [ 'missing a "typeFilter" property' ],
+        myDoc3: [ ]
+      });
+    });
+  });
+
+  describe('channels', function() {
+    verifyPermissionsCategory('channels');
+
+    it('cannot be left undefined or null if neither authorizedRoles nor authorizedUsers are defined', function() {
+      testDocDefinitions.myDoc1.channels = null;
+      testDocDefinitions.myDoc2.authorizedRoles = null;
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [ 'missing a "channels", "authorizedRoles" or "authorizedUsers" property' ],
+        myDoc2: [ 'missing a "channels", "authorizedRoles" or "authorizedUsers" property' ],
+        myDoc3: [ ]
+      });
+    });
+  });
+
+  describe('authorizedRoles', function() {
+    verifyPermissionsCategory('authorizedRoles');
+  });
+
+  describe('authorizedUsers', function() {
+    verifyPermissionsCategory('authorizedUsers');
+  });
+
+  describe('property validators', function() {
+    it('cannot be anything other than an object or a function', function() {
+      testDocDefinitions.myDoc1.propertyValidators = true;
+      testDocDefinitions.myDoc2.propertyValidators = [ 'prop1', 'prop2' ];
+      testDocDefinitions.myDoc3.propertyValidators = 'foobar';
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [ 'the "propertyValidators" property is not an object or a function' ],
+        myDoc2: [ 'the "propertyValidators" property is not an object or a function' ],
+        myDoc3: [ 'the "propertyValidators" property is not an object or a function' ]
+      });
+    });
+
+    it('cannot be be left undefined or null', function() {
+      delete testDocDefinitions.myDoc1.propertyValidators;
+      testDocDefinitions.myDoc2.propertyValidators = null;
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [ 'missing a "propertyValidators" property' ],
+        myDoc2: [ 'missing a "propertyValidators" property' ],
+        myDoc3: [ ]
+      });
+    });
+  });
+
+  function verifyPermissionsCategory(category) {
+    it('cannot be anything other than an object or a function', function() {
+      testDocDefinitions.myDoc1[category] = [ 'foo', 'bar' ];
+      testDocDefinitions.myDoc2[category] = 'foobar';
+      testDocDefinitions.myDoc3[category] = true;
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [ 'the "' + category + '" property is not an object or a function' ],
+        myDoc2: [ 'the "' + category + '" property is not an object or a function' ],
+        myDoc3: [ 'the "' + category + '" property is not an object or a function' ]
+      });
+    });
+
+    it('cannot contain unknown operations', function() {
+      testDocDefinitions.myDoc1[category] = {
+        write: 'write1',
+        foo: 'bar'
+      };
+      testDocDefinitions.myDoc2[category] = {
+        add: [ 'add1' ],
+        replace: [ 'replace1' ],
+        remove: [ 'remove1' ],
+        bar: [ 'baz' ]
+      };
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [ 'the "' + category + '" property\'s "foo" operation type is not supported' ],
+        myDoc2: [ 'the "' + category + '" property\'s "bar" operation type is not supported' ],
+        myDoc3: [ ]
+      });
+    });
+
+    it('cannot specify no operations', function() {
+      testDocDefinitions.myDoc1[category] = { };
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [ 'the "' + category + '" property does not specify any operation types (e.g. "view", "add", "replace", "remove", "write")' ],
+        myDoc2: [ ],
+        myDoc3: [ ]
+      });
+    });
+
+    it('cannot contain empty operations', function() {
+      testDocDefinitions.myDoc1[category] = {
+        view: [ ],
+        write: [ ]
+      };
+      testDocDefinitions.myDoc2[category] = {
+        add: [ ],
+        replace: [ ],
+        remove: [ ]
+      };
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [
+          'the "' + category + '" property\'s "view" operation does not contain any elements',
+          'the "' + category + '" property\'s "write" operation does not contain any elements'
+        ],
+        myDoc2: [
+          'the "' + category + '" property\'s "add" operation does not contain any elements',
+          'the "' + category + '" property\'s "replace" operation does not contain any elements',
+          'the "' + category + '" property\'s "remove" operation does not contain any elements'
+        ],
+        myDoc3: [ ]
+      });
+    });
+
+    it('cannot contain operations that are not specified as strings or arrays', function() {
+      var myObj = { foo: 'bar' };
+      testDocDefinitions.myDoc1[category] = {
+        view: true,
+        write: null
+      };
+      testDocDefinitions.myDoc2[category] = {
+        add: { bar: 'baz' },
+        replace: -3,
+        remove: 180.33
+      };
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [
+          'the "' + category + '" property\'s "view" operation is not a string or array',
+          'the "' + category + '" property\'s "write" operation is not a string or array'
+        ],
+        myDoc2: [
+          'the "' + category + '" property\'s "add" operation is not a string or array',
+          'the "' + category + '" property\'s "replace" operation is not a string or array',
+          'the "' + category + '" property\'s "remove" operation is not a string or array'
+        ],
+        myDoc3: [ ]
+      });
+    });
+
+    it('cannot contain channels that are not strings', function() {
+      var myObj = { foo: 'bar' };
+      testDocDefinitions.myDoc1[category] = {
+        view: [ 1 ],
+        write: [ true ]
+      };
+      testDocDefinitions.myDoc2[category] = {
+        add: [ myObj ],
+        replace: [ -17.83 ],
+        remove: [ null ]
+      };
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results).to.eql({
+        myDoc1: [
+          'the "' + category + '" property\'s "view" operation contains an element that is not a string: 1',
+          'the "' + category + '" property\'s "write" operation contains an element that is not a string: true'
+        ],
+        myDoc2: [
+          'the "' + category + '" property\'s "add" operation contains an element that is not a string: ' + JSON.stringify(myObj),
+          'the "' + category + '" property\'s "replace" operation contains an element that is not a string: -17.83',
+          'the "' + category + '" property\'s "remove" operation contains an element that is not a string: null'
+        ],
+        myDoc3: [ ]
+      });
+    });
+  }
+});


### PR DESCRIPTION
Defines specifications for validation of the "essential" document definition properties:
* `typeFilter`
* `propertyValidators`
* `channels`
* `authorizedRoles`
* `authorizedUsers`

Also expands the validation that is applied to those and other properties.

This is just one of a number of upcoming pull requests to address issue #43.