### PR TITLE
Issue 43: Expand validation of document authorization

### DIFF
--- a/src/document-definitions-validator.js
+++ b/src/document-definitions-validator.js
@@ -172,6 +172,12 @@ function validateDocDefinition(docType, docDefinition) {
       hasPermissionOperations = true;
       var permissions = permissionsDefinition[permissionOperation];
 
+      if (permissionOperation === 'replace' && (docDefinition.immutable === true || docDefinition.cannotReplace === true)) {
+        validationErrors.push('the "' + permissionsCategory + '" property\'s "' + permissionOperation + '" operation type is invalid when the document type is immutable');
+      } else if (permissionOperation === 'remove' && (docDefinition.immutable === true || docDefinition.cannotDelete === true)) {
+        validationErrors.push('the "' + permissionsCategory + '" property\'s "' + permissionOperation + '" operation type is invalid when the document type is immutable');
+      }
+
       if (!supportedPermissionOperations[permissionOperation]) {
         validationErrors.push('the "' + permissionsCategory + '" property\'s "' + permissionOperation + '" operation type is not supported');
       } else if (permissions instanceof Array) {

--- a/src/document-definitions-validator.js
+++ b/src/document-definitions-validator.js
@@ -36,7 +36,8 @@ function validate(rawDocDefinitions) {
   return allValidationErrors;
 }
 
-var supportedPermissionOperations = { view: true, add: true, replace: true, remove: true, write: true };
+var supportedChannelOperations = { view: true, add: true, replace: true, remove: true, write: true };
+var supportedRoleOrUserOperations = { add: true, replace: true, remove: true, write: true };
 var supportedCustomActionEvents = {
   onTypeIdentificationSucceeded: true,
   onAuthorizationSucceeded: true,
@@ -70,7 +71,7 @@ function validateDocDefinition(docType, docDefinition) {
       case 'channels':
         hasPermissionGrant = true;
         if (isAnObject(propertyValue)) {
-          validatePermissions('channels', propertyValue);
+          validatePermissions('channels', propertyValue, supportedChannelOperations);
         } else if (typeof(propertyValue) !== 'function') {
           validationErrors.push('the "channels" property is not an object or a function');
         }
@@ -78,7 +79,7 @@ function validateDocDefinition(docType, docDefinition) {
       case 'authorizedRoles':
         hasPermissionGrant = true;
         if (isAnObject(propertyValue)) {
-          validatePermissions('authorizedRoles', propertyValue);
+          validatePermissions('authorizedRoles', propertyValue, supportedRoleOrUserOperations);
         } else if (typeof(propertyValue) !== 'function') {
           validationErrors.push('the "authorizedRoles" property is not an object or a function');
         }
@@ -86,7 +87,7 @@ function validateDocDefinition(docType, docDefinition) {
       case 'authorizedUsers':
         hasPermissionGrant = true;
         if (isAnObject(propertyValue)) {
-          validatePermissions('authorizedUsers', propertyValue);
+          validatePermissions('authorizedUsers', propertyValue, supportedRoleOrUserOperations);
         } else if (typeof(propertyValue) !== 'function') {
           validationErrors.push('the "authorizedUsers" property is not an object or a function');
         }
@@ -165,7 +166,7 @@ function validateDocDefinition(docType, docDefinition) {
     validationErrors.push('missing a "propertyValidators" property');
   }
 
-  function validatePermissions(permissionsCategory, permissionsDefinition) {
+  function validatePermissions(permissionsCategory, permissionsDefinition, supportedPermissionOperations) {
     var hasPermissionOperations = false;
     for (var permissionOperation in permissionsDefinition) {
       hasPermissionOperations = true;
@@ -190,7 +191,7 @@ function validateDocDefinition(docType, docDefinition) {
     }
 
     if (!hasPermissionOperations) {
-      validationErrors.push('the "' + permissionsCategory + '" property does not specify any operation types (e.g. "view", "add", "replace", "remove", "write")');
+      validationErrors.push('the "' + permissionsCategory + '" property does not specify any operation types');
     }
   }
 

--- a/test/document-definitions-validator-advanced-spec.js
+++ b/test/document-definitions-validator-advanced-spec.js
@@ -1,7 +1,7 @@
 var expect = require('expect.js');
 var docDefinitionsValidator = require('../src/document-definitions-validator.js');
 
-describe('Document definitions validator:', function() {
+describe('Document definitions advanced properties validator:', function() {
   var testDocDefinitions;
 
   beforeEach(function() {
@@ -10,10 +10,8 @@ describe('Document definitions validator:', function() {
       myDoc1: {
         typeFilter: function() { },
         channels: {
-          view: 'view',
-          add: 'add',
-          replace: 'replace',
-          remove: 'remove'
+          view: [ 'view' ],
+          write: [ 'user1' ]
         },
         propertyValidators: { },
         allowUnknownProperties: false,
@@ -76,7 +74,16 @@ describe('Document definitions validator:', function() {
       },
       myDoc3: {
         typeFilter: function() { },
-        authorizedUsers: { write: [ 'write' ] },
+        authorizedRoles: {
+          add: 'add-role1',
+          replace: 'replace-role1',
+          remove: 'remove-role1'
+        },
+        authorizedUsers: {
+          add: 'add-role1',
+          replace: 'replace-role1',
+          remove: 'remove-role1'
+        },
         propertyValidators: { },
         immutable: false,
         cannotReplace: true,

--- a/test/document-definitions-validator-advanced-spec.js
+++ b/test/document-definitions-validator-advanced-spec.js
@@ -74,16 +74,8 @@ describe('Document definitions advanced properties validator:', function() {
       },
       myDoc3: {
         typeFilter: function() { },
-        authorizedRoles: {
-          add: 'add-role1',
-          replace: 'replace-role1',
-          remove: 'remove-role1'
-        },
-        authorizedUsers: {
-          add: 'add-role1',
-          replace: 'replace-role1',
-          remove: 'remove-role1'
-        },
+        authorizedRoles: { write: 'role1' },
+        authorizedUsers: { write: 'user1' },
         propertyValidators: { },
         immutable: false,
         cannotReplace: true,
@@ -165,6 +157,54 @@ describe('Document definitions advanced properties validator:', function() {
         myDoc2: [ ],
         myDoc3: [ ]
       });
+    });
+
+    it('cannot be enabled along with channels for replace or remove operations', function() {
+      testDocDefinitions.myDoc1.immutable = true;
+      testDocDefinitions.myDoc1.channels = {
+        replace: [ 'replace' ],
+        remove: [ 'remove' ]
+      };
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results.myDoc1.length).to.be(2);
+      expect(results.myDoc1).to.contain('the "channels" property\'s "replace" operation type is invalid when the document type is immutable');
+      expect(results.myDoc1).to.contain('the "channels" property\'s "remove" operation type is invalid when the document type is immutable');
+      expect(results.myDoc2.length).to.be(0);
+      expect(results.myDoc3.length).to.be(0);
+    });
+
+    it('cannot be enabled along with roles for replace or remove operations', function() {
+      testDocDefinitions.myDoc1.immutable = true;
+      testDocDefinitions.myDoc1.authorizedRoles = {
+        replace: [ 'replace' ],
+        remove: [ 'remove' ]
+      };
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results.myDoc1.length).to.be(2);
+      expect(results.myDoc1).to.contain('the "authorizedRoles" property\'s "replace" operation type is invalid when the document type is immutable');
+      expect(results.myDoc1).to.contain('the "authorizedRoles" property\'s "remove" operation type is invalid when the document type is immutable');
+      expect(results.myDoc2.length).to.be(0);
+      expect(results.myDoc3.length).to.be(0);
+    });
+
+    it('cannot be enabled along with users for replace or remove operations', function() {
+      testDocDefinitions.myDoc1.immutable = true;
+      testDocDefinitions.myDoc1.authorizedUsers = {
+        replace: [ 'replace' ],
+        remove: [ 'remove' ]
+      };
+
+      var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+      expect(results.myDoc1.length).to.be(2);
+      expect(results.myDoc1).to.contain('the "authorizedUsers" property\'s "replace" operation type is invalid when the document type is immutable');
+      expect(results.myDoc1).to.contain('the "authorizedUsers" property\'s "remove" operation type is invalid when the document type is immutable');
+      expect(results.myDoc2.length).to.be(0);
+      expect(results.myDoc3.length).to.be(0);
     });
   });
 

--- a/test/document-definitions-validator-essentials-spec.js
+++ b/test/document-definitions-validator-essentials-spec.js
@@ -1,7 +1,7 @@
 var expect = require('expect.js');
 var docDefinitionsValidator = require('../src/document-definitions-validator.js');
 
-describe('Document definitions validator:', function() {
+describe('Document definitions essential properties validator:', function() {
   var testDocDefinitions;
 
   beforeEach(function() {
@@ -19,12 +19,15 @@ describe('Document definitions validator:', function() {
       },
       myDoc2: {
         typeFilter: function() { },
+        channels: function() { },
         authorizedRoles: function() { },
+        authorizedUsers: function() { },
         propertyValidators: function() { }
       },
       myDoc3: {
         typeFilter: function() { },
-        authorizedUsers: { write: [ 'write' ] },
+        authorizedRoles: { write: [ 'role1' ] },
+        authorizedUsers: { write: [ 'user1' ] },
         propertyValidators: { }
       }
     };
@@ -112,11 +115,14 @@ describe('Document definitions validator:', function() {
   });
 
   describe('channels', function() {
-    verifyPermissionsCategory('channels');
+    verifyPermissionsCategory('channels', true);
 
     it('cannot be left undefined or null if neither authorizedRoles nor authorizedUsers are defined', function() {
-      testDocDefinitions.myDoc1.channels = null;
+      delete testDocDefinitions.myDoc1.channels;
+
+      testDocDefinitions.myDoc2.channels = null;
       testDocDefinitions.myDoc2.authorizedRoles = null;
+      testDocDefinitions.myDoc2.authorizedUsers = null;
 
       var results = docDefinitionsValidator.validate(testDocDefinitions);
 
@@ -129,11 +135,11 @@ describe('Document definitions validator:', function() {
   });
 
   describe('authorizedRoles', function() {
-    verifyPermissionsCategory('authorizedRoles');
+    verifyPermissionsCategory('authorizedRoles', false);
   });
 
   describe('authorizedUsers', function() {
-    verifyPermissionsCategory('authorizedUsers');
+    verifyPermissionsCategory('authorizedUsers', false);
   });
 
   describe('property validators', function() {
@@ -165,7 +171,7 @@ describe('Document definitions validator:', function() {
     });
   });
 
-  function verifyPermissionsCategory(category) {
+  function verifyPermissionsCategory(category, supportsViewOperation) {
     it('cannot be anything other than an object or a function', function() {
       testDocDefinitions.myDoc1[category] = [ 'foo', 'bar' ];
       testDocDefinitions.myDoc2[category] = 'foobar';
@@ -207,17 +213,20 @@ describe('Document definitions validator:', function() {
       var results = docDefinitionsValidator.validate(testDocDefinitions);
 
       expect(results).to.eql({
-        myDoc1: [ 'the "' + category + '" property does not specify any operation types (e.g. "view", "add", "replace", "remove", "write")' ],
+        myDoc1: [ 'the "' + category + '" property does not specify any operation types' ],
         myDoc2: [ ],
         myDoc3: [ ]
       });
     });
 
     it('cannot contain empty operations', function() {
-      testDocDefinitions.myDoc1[category] = {
-        view: [ ],
-        write: [ ]
-      };
+      var expectedDoc1Errors = [ 'the "' + category + '" property\'s "write" operation does not contain any elements' ];
+      testDocDefinitions.myDoc1[category] = { write: [ ] };
+      if (supportsViewOperation) {
+        expectedDoc1Errors.push('the "' + category + '" property\'s "view" operation does not contain any elements');
+        testDocDefinitions.myDoc1[category].view = [ ];
+      }
+
       testDocDefinitions.myDoc2[category] = {
         add: [ ],
         replace: [ ],
@@ -227,10 +236,7 @@ describe('Document definitions validator:', function() {
       var results = docDefinitionsValidator.validate(testDocDefinitions);
 
       expect(results).to.eql({
-        myDoc1: [
-          'the "' + category + '" property\'s "view" operation does not contain any elements',
-          'the "' + category + '" property\'s "write" operation does not contain any elements'
-        ],
+        myDoc1: expectedDoc1Errors,
         myDoc2: [
           'the "' + category + '" property\'s "add" operation does not contain any elements',
           'the "' + category + '" property\'s "replace" operation does not contain any elements',
@@ -241,11 +247,13 @@ describe('Document definitions validator:', function() {
     });
 
     it('cannot contain operations that are not specified as strings or arrays', function() {
-      var myObj = { foo: 'bar' };
-      testDocDefinitions.myDoc1[category] = {
-        view: true,
-        write: null
-      };
+      var expectedDoc1Errors = [ 'the "' + category + '" property\'s "write" operation is not a string or array' ];
+      testDocDefinitions.myDoc1[category] = { write: null };
+      if (supportsViewOperation) {
+        expectedDoc1Errors.push('the "' + category + '" property\'s "view" operation is not a string or array');
+        testDocDefinitions.myDoc1[category].view = true;
+      }
+
       testDocDefinitions.myDoc2[category] = {
         add: { bar: 'baz' },
         replace: -3,
@@ -255,10 +263,7 @@ describe('Document definitions validator:', function() {
       var results = docDefinitionsValidator.validate(testDocDefinitions);
 
       expect(results).to.eql({
-        myDoc1: [
-          'the "' + category + '" property\'s "view" operation is not a string or array',
-          'the "' + category + '" property\'s "write" operation is not a string or array'
-        ],
+        myDoc1: expectedDoc1Errors,
         myDoc2: [
           'the "' + category + '" property\'s "add" operation is not a string or array',
           'the "' + category + '" property\'s "replace" operation is not a string or array',
@@ -269,11 +274,14 @@ describe('Document definitions validator:', function() {
     });
 
     it('cannot contain channels that are not strings', function() {
+      var expectedDoc1Errors = [ 'the "' + category + '" property\'s "write" operation contains an element that is not a string: true' ];
+      testDocDefinitions.myDoc1[category] = { write: [ true ] };
+      if (supportsViewOperation) {
+        expectedDoc1Errors.push('the "' + category + '" property\'s "view" operation contains an element that is not a string: 1');
+        testDocDefinitions.myDoc1[category].view = [ 1 ];
+      }
+
       var myObj = { foo: 'bar' };
-      testDocDefinitions.myDoc1[category] = {
-        view: [ 1 ],
-        write: [ true ]
-      };
       testDocDefinitions.myDoc2[category] = {
         add: [ myObj ],
         replace: [ -17.83 ],
@@ -283,10 +291,7 @@ describe('Document definitions validator:', function() {
       var results = docDefinitionsValidator.validate(testDocDefinitions);
 
       expect(results).to.eql({
-        myDoc1: [
-          'the "' + category + '" property\'s "view" operation contains an element that is not a string: 1',
-          'the "' + category + '" property\'s "write" operation contains an element that is not a string: true'
-        ],
+        myDoc1: expectedDoc1Errors,
         myDoc2: [
           'the "' + category + '" property\'s "add" operation contains an element that is not a string: ' + JSON.stringify(myObj),
           'the "' + category + '" property\'s "replace" operation contains an element that is not a string: -17.83',
@@ -295,5 +300,20 @@ describe('Document definitions validator:', function() {
         myDoc3: [ ]
       });
     });
+
+    if (!supportsViewOperation) {
+      it('cannot include the view operation', function() {
+        testDocDefinitions.myDoc1[category] = { view: [ 'view' ] };
+        testDocDefinitions.myDoc2[category] = { view: 'view' };
+
+        var results = docDefinitionsValidator.validate(testDocDefinitions);
+
+        expect(results).to.eql({
+          myDoc1: [ 'the "' + category + '" property\'s "view" operation type is not supported' ],
+          myDoc2: [ 'the "' + category + '" property\'s "view" operation type is not supported' ],
+          myDoc3: [ ]
+        });
+      });
+    }
   }
 });

--- a/test/document-definitions-validator-essentials-spec.js
+++ b/test/document-definitions-validator-essentials-spec.js
@@ -26,8 +26,16 @@ describe('Document definitions essential properties validator:', function() {
       },
       myDoc3: {
         typeFilter: function() { },
-        authorizedRoles: { write: [ 'role1' ] },
-        authorizedUsers: { write: [ 'user1' ] },
+        authorizedRoles: {
+          add: [ 'add-role1' ],
+          replace: [ 'replace-role1' ],
+          remove: [ 'remove-role1' ]
+        },
+        authorizedUsers: {
+          add: [ 'add-role1' ],
+          replace: [ 'replace-role1' ],
+          remove: [ 'remove-role1' ]
+        },
         propertyValidators: { }
       }
     };


### PR DESCRIPTION
Comprised of two notable changes:
* Validate that the `view` operation is not supported for `authorizedRoles` and `authorizedUsers`
* Check for superfluous channel, role and user authorizations when the document is immutable

Furthers the implementation of issue #43. More work to be done though.