### PR TITLE
Issue 43: Validation of document definition property validator types

### DIFF
--- a/src/document-definition-properties-validator.js
+++ b/src/document-definition-properties-validator.js
@@ -1,10 +1,10 @@
 /**
-* Validates that the given document definition's property validator definitions conform to specifications.
-*
-* @param {Object} docDefinition The document type definition
-* @param {Object} docPropertyValidatorDefinitions The document type's property validator definitions
-*
-* @returns {string[]} An array of all problems that were identified in the property validators
+ * Validates that the given document definition's property validator definitions conform to specifications.
+ *
+ * @param {Object} docDefinition The document type definition
+ * @param {Object} docPropertyValidatorDefinitions The document type's property validator definitions
+ *
+ * @returns {string[]} An array of all problems that were identified in the property validators
  */
 exports.validate = validate;
 

--- a/src/document-definition-properties-validator.js
+++ b/src/document-definition-properties-validator.js
@@ -1,0 +1,76 @@
+/**
+* Validates that the given document definition's property validator definitions conform to specifications.
+*
+* @param {Object} docDefinition The document type definition
+* @param {Object} docPropertyValidatorDefinitions The document type's property validator definitions
+*
+* @returns {string[]} An array of all problems that were identified in the property validators
+ */
+exports.validate = validate;
+
+function validate(docDefinition, docPropertyValidatorDefinitions) {
+  var validationErrors = [ ];
+
+  validatePropertyDefinitions(docPropertyValidatorDefinitions);
+
+  function validatePropertyDefinitions(propertyDefinitions) {
+    for (var propertyName in propertyDefinitions) {
+      var propertyDefinition = propertyDefinitions[propertyName];
+      if (isAnObject(propertyDefinition)) {
+        validatePropertyDefinition(propertyName, propertyDefinition);
+      } else {
+        validationErrors.push('the "propertyValidators" entry "' + propertyName + '" is not an object');
+      }
+    }
+  }
+
+  function validatePropertyDefinition(propertyName, propertyDefinition) {
+    var type = propertyDefinition.type;
+    if (typeof(type) === 'undefined') {
+      validationErrors.push('the "propertyValidators" entry "' + propertyName + '" does not declare a "type"');
+
+      return;
+    } else if (typeof(type) === 'function') {
+      // Properties with a type that is determined dynamically cannot be validated at this point
+      return;
+    } else if (typeof(type) !== 'string') {
+      validationErrors.push('the "propertyValidators" entry "' + propertyName + '" declares a "type" that is neither a string nor a function');
+
+      return;
+    }
+
+    switch (type) {
+      case 'string':
+        break;
+      case 'integer':
+        break;
+      case 'float':
+        break;
+      case 'boolean':
+        break;
+      case 'datetime':
+        break;
+      case 'date':
+        break;
+      case 'enum':
+        break;
+      case 'attachmentReference':
+        break;
+      case 'array':
+        break;
+      case 'object':
+        break;
+      case 'hashtable':
+        break;
+      default:
+        validationErrors.push('the "propertyValidators" entry "' + propertyName + '" declares an invalid "type": "' + type + '"');
+        break;
+    }
+  }
+
+  return validationErrors;
+}
+
+function isAnObject(value) {
+  return value !== null && typeof(value) === 'object' && !(value instanceof Array);
+}

--- a/src/document-definitions-validator.js
+++ b/src/document-definitions-validator.js
@@ -9,6 +9,8 @@
  */
 exports.validate = validate;
 
+var propertiesValidator = require('./document-definition-properties-validator.js');
+
 function validate(rawDocDefinitions) {
   var docDefinitions;
   try {
@@ -29,7 +31,7 @@ function validate(rawDocDefinitions) {
     if (!isAnObject(docDefinition)) {
       allValidationErrors[docType] = [ 'not specified as an object' ];
     } else {
-      allValidationErrors[docType] = validateDocDefinition(docType, docDefinition);
+      allValidationErrors[docType] = validateDocDefinition(docDefinition);
     }
   }
 
@@ -47,7 +49,7 @@ var supportedCustomActionEvents = {
 var supportedRoleAssignmentProperties = { type: true, roles: true, users: true };
 var supportedChannelAssignmentProperties = { type: true, roles: true, users: true, channels: true };
 
-function validateDocDefinition(docType, docDefinition) {
+function validateDocDefinition(docDefinition) {
   var validationErrors = [ ];
   var hasTypeFilter = false;
   var hasPermissionGrant = false;
@@ -93,7 +95,10 @@ function validateDocDefinition(docType, docDefinition) {
         break;
       case 'propertyValidators':
         hasPropertyValidators = true;
-        if (!isAnObject(propertyValue) && typeof(propertyValue) !== 'function') {
+        if (isAnObject(propertyValue)) {
+          var propertiesValidationErrors = propertiesValidator.validate(docDefinition, propertyValue);
+          validationErrors = validationErrors.concat(propertiesValidationErrors);
+        } else if (typeof(propertyValue) !== 'function') {
           validationErrors.push('the "propertyValidators" property is not an object or a function');
         }
         break;
@@ -215,7 +220,7 @@ function validateDocDefinition(docType, docDefinition) {
           validateAttachmentListConstraint('supportedContentTypes', attachmentConstraintPropertyValue);
           break;
         case 'requireAttachmentReferences':
-          if (!isUndefined(attachmentConstraintPropertyValue) && typeof(attachmentConstraintPropertyValue) !== 'boolean') {
+          if (typeof(attachmentConstraintPropertyValue) !== 'boolean') {
             validationErrors.push('the "attachmentConstraints" specifies a "requireAttachmentReferences" property that is not a boolean');
           }
           break;

--- a/src/templates/document-definitions-shell-template.js
+++ b/src/templates/document-definitions-shell-template.js
@@ -3,7 +3,7 @@ function(require) {
 
   var doc = { };
   var oldDoc = { };
-  var typeIdValidator = { };
+  var typeIdValidator = { type: 'string' };
   var simpleTypeFilter = simple.stub();
   var isDocumentMissingOrDeleted = simple.stub();
   var isValueNullOrUndefined = simple.stub();

--- a/test/document-definition-properties-validator-spec.js
+++ b/test/document-definition-properties-validator-spec.js
@@ -1,0 +1,79 @@
+var expect = require('expect.js');
+var docDefinitionPropertiesValidator = require('../src/document-definition-properties-validator.js');
+
+describe('Document definition properties validator', function() {
+  var testPropertyValidators, testDocDefinition;
+
+  beforeEach(function() {
+    testPropertyValidators = {
+      stringTypeProp: {
+        type: 'string'
+      },
+      integerTypeProp: {
+        type: 'integer'
+      },
+      floatTypeProp: {
+        type: 'float'
+      },
+      booleanTypeProp: {
+        type: 'boolean'
+      },
+      datetimeTypeProp: {
+        type: 'datetime'
+      },
+      dateTypeProp: {
+        type: 'date'
+      },
+      enumTypeProp: {
+        type: 'enum'
+      },
+      attachmentReferenceTypeProp: {
+        type: 'attachmentReference'
+      },
+      arrayTypeProp: {
+        type: 'array'
+      },
+      objectTypeProp: {
+        type: 'object'
+      },
+      hashtableTypeProp: {
+        type: 'hashtable'
+      },
+      functionTypeProp: {
+        type: function() { }
+      }
+    };
+
+    testDocDefinition = { propertyValidators: testPropertyValidators };
+  });
+
+  it('approves valid property validators', function() {
+    var result = docDefinitionPropertiesValidator.validate(testDocDefinition, testPropertyValidators);
+
+    expect(result).to.eql([ ]);
+  });
+
+  it('rejects a property validator with an unrecognized validation type', function() {
+    testPropertyValidators.invalidTypeProp = { type: 'invalid' };
+
+    var result = docDefinitionPropertiesValidator.validate(testDocDefinition, testPropertyValidators);
+
+    expect(result).to.eql([ 'the "propertyValidators" entry "invalidTypeProp" declares an invalid "type": "invalid"' ]);
+  });
+
+  it('rejects a property validator that does not declare a validation type', function() {
+    testPropertyValidators.invalidTypeProp = { };
+
+    var result = docDefinitionPropertiesValidator.validate(testDocDefinition, testPropertyValidators);
+
+    expect(result).to.eql([ 'the "propertyValidators" entry "invalidTypeProp" does not declare a "type"' ]);
+  });
+
+  it('rejects a property validator whose type is neither a string nor a function', function() {
+    testPropertyValidators.invalidTypeProp = { type: 1 };
+
+    var result = docDefinitionPropertiesValidator.validate(testDocDefinition, testPropertyValidators);
+
+    expect(result).to.eql([ 'the "propertyValidators" entry "invalidTypeProp" declares a "type" that is neither a string nor a function' ]);
+  });
+});

--- a/test/document-definitions-validator-advanced-spec.js
+++ b/test/document-definitions-validator-advanced-spec.js
@@ -1,8 +1,9 @@
 var expect = require('expect.js');
-var docDefinitionsValidator = require('../src/document-definitions-validator.js');
+var simpleMock = require('simple-mock');
+var mockRequire = require('mock-require');
 
-describe('Document definitions validator:', function() {
-  var testDocDefinitions;
+describe('Document definitions advanced validator:', function() {
+  var docDefinitionsValidator, propertiesValidatorMock, testDocDefinitions;
 
   beforeEach(function() {
     // By default these document definitions are valid
@@ -40,6 +41,16 @@ describe('Document definitions validator:', function() {
             channels: 'channel1',
             roles: 'role2',
             users: 'user2'
+          },
+          {
+            type: 'role',
+            roles: [ 'role3' ],
+            users: [ 'user3' ]
+          },
+          {
+            channels: 'channel2',
+            roles: [ 'role4' ],
+            users: [ 'user4' ]
           }
         ],
         customActions: {
@@ -83,6 +94,17 @@ describe('Document definitions validator:', function() {
         cannotDelete: true
       }
     };
+
+    propertiesValidatorMock = { validate: simpleMock.stub() };
+    propertiesValidatorMock.validate.returnWith([ ]);
+    mockRequire('../src/document-definition-properties-validator.js', propertiesValidatorMock);
+
+    docDefinitionsValidator = mockRequire.reRequire('../src/document-definitions-validator.js');
+  });
+
+  afterEach(function() {
+    // Restore "require" calls to their original behaviour after each test case
+    mockRequire.stopAll();
   });
 
   it('approves valid document definitions as an object', function() {


### PR DESCRIPTION
Introduces a new module that will perform validation on property validator definitions. The initial implementation simply wires it into the document-definitions-validator module and performs simple validation of each property's validation type.

Additional pull requests to come to address issue #43.