### PR TITLE
Authorization fix has been done for add operation

### DIFF
--- a/src/templates/sync-function-authorization-module.js
+++ b/src/templates/sync-function-authorization-module.js
@@ -63,7 +63,7 @@ function() {
     } else if (!isDocumentMissingOrDeleted(oldDoc) && authorizationMap.replace) {
       writeAuthorizationFound = true;
       appendToAuthorizationList(requiredAuthorizations, authorizationMap.replace);
-    } else if (authorizationMap.add) {
+    } else if (authorizationMap.add && !oldDoc) {
       writeAuthorizationFound = true;
       appendToAuthorizationList(requiredAuthorizations, authorizationMap.add);
     }


### PR DESCRIPTION
If we provide add operation to a role, there is no check whether the document is really added or changed. I encountered this bug in my application. There were 2 users whose granted roles are same, both can add a document. Depending of a field of the json, replace & delete operation accesses only given to the specific user. However, since this add operation is kind a working wrong, it was possible to make these changes.