### PR TITLE
Issue 149: Ensure add permissions are only valid for add operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "node"
+  - "lts/*"
   - "0.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-Nothing yet
+### Fixed
+- [#149](https://github.com/Kashoo/synctos/issues/149): Permissions for add operations sometimes applied to other operation types
 
 ## [1.9.1] - 2017-05-01
 ### Fixed

--- a/etc/sync-function-authorization-module.js
+++ b/etc/sync-function-authorization-module.js
@@ -63,7 +63,7 @@ function() {
     } else if (!isDocumentMissingOrDeleted(oldDoc) && authorizationMap.replace) {
       writeAuthorizationFound = true;
       appendToAuthorizationList(requiredAuthorizations, authorizationMap.replace);
-    } else if (authorizationMap.add) {
+    } else if (isDocumentMissingOrDeleted(oldDoc) && authorizationMap.add) {
       writeAuthorizationFound = true;
       appendToAuthorizationList(requiredAuthorizations, authorizationMap.add);
     }

--- a/test/authorization-spec.js
+++ b/test/authorization-spec.js
@@ -50,6 +50,34 @@ describe('Authorization:', function() {
     });
   });
 
+  describe('for a document with write channels and an explicit add channel defined', function() {
+    it('allows document addition for a user with only the add channel', function() {
+      var doc = { _id: 'writeAndAddChannelsDoc' };
+
+      testHelper.verifyDocumentCreated(doc, [ 'edit', 'add' ]);
+    });
+
+    it('rejects document replacement for a user with only the add channel', function() {
+      var doc = {
+        _id: 'writeAndAddChannelsDoc',
+        stringProp: 'foobar'
+      };
+      var oldDoc = { _id: 'writeAndAddChannelsDoc' };
+
+      testHelper.verifyAccessDenied(doc, oldDoc, 'edit');
+    });
+
+    it('rejects document deletion for a user with only the add channel', function() {
+      var doc = {
+        _id: 'writeAndAddChannelsDoc',
+        _deleted: true
+      };
+      var oldDoc = { _id: 'writeAndAddChannelsDoc' };
+
+      testHelper.verifyAccessDenied(doc, oldDoc, 'edit');
+    });
+  });
+
   describe('for a document with dynamically-assigned roles, channels and users', function() {
     var expectedWriteChannels = [ 'dynamicChannelsRolesAndUsersDoc-write' ];
     var expectedWriteRoles = [ 'write-role1', 'write-role2' ];

--- a/test/resources/authorization-doc-definitions.js
+++ b/test/resources/authorization-doc-definitions.js
@@ -28,6 +28,20 @@
       }
     }
   },
+  writeAndAddChannelsDoc: {
+    channels: {
+      write: 'edit',
+      add: 'add'
+    },
+    typeFilter: function(doc) {
+      return doc._id === 'writeAndAddChannelsDoc';
+    },
+    propertyValidators: {
+      stringProp: {
+        type: 'string'
+      }
+    }
+  },
   dynamicChannelsRolesAndUsersDoc: {
     typeFilter: function(doc) {
       return doc._id === 'dynamicChannelsRolesAndUsersDoc';


### PR DESCRIPTION
Prevents cases where a user is mistakenly permitted to perform a replace or remove operation when they have the necessary channel, role or username to perform add operations but the document type does not explicitly declare corresponding permissions for replace and/or remove operations.

Addresses issue #149.

Note: this pull request does not target the `master` branch because I intend to issue the update as a patch release without all of the in-progress work on document validation that is currently on the `master` branch. Instead, the release will be cut from the `v1.9.2-dev` branch, which is based off of the `v1.9.1` tag, and then that branch will be merged into `master`.