### PR TITLE
Issue 152: Allow objects with immutable properties to be added to an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- [#152](https://github.com/Kashoo/synctos/issues/152): Cannot append a new object with immutable properties to an array
+
 ## [1.9.2] - 2017-10-02
 ### Fixed
 - [#149](https://github.com/Kashoo/synctos/issues/149): Permissions for add operations sometimes applied to other operation types

--- a/etc/sync-function-validation-module.js
+++ b/etc/sync-function-validation-module.js
@@ -438,11 +438,8 @@ function() {
         for (var elementIndex = 0; elementIndex < itemValue.length; elementIndex++) {
           var elementName = '[' + elementIndex + ']';
           var elementValue = itemValue[elementIndex];
-
-          var oldElementValue;
-          if (!isValueNullOrUndefined(oldItemValue) && elementIndex < oldItemValue.length) {
-            oldElementValue = oldItemValue[elementIndex];
-          }
+          var oldElementValue =
+            (!isValueNullOrUndefined(oldItemValue) && elementIndex < oldItemValue.length) ? oldItemValue[elementIndex] : null;
 
           itemStack.push({
             itemName: elementName,

--- a/test/immutable-nested-properties-spec.js
+++ b/test/immutable-nested-properties-spec.js
@@ -1,0 +1,322 @@
+var testHelper = require('../etc/test-helper.js');
+var errorFormatter = testHelper.validationErrorFormatter;
+
+describe('Immutable nested properties:', function() {
+  beforeEach(function() {
+    testHelper.initSyncFunction('build/sync-functions/test-immutable-nested-properties-sync-function.js');
+  });
+
+  describe('when an object with an immutable property is nested in an array', function() {
+    it('prevent modification of immutable properties for objects that already exist', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'objectNestedInArrayDoc',
+        elementList: [
+          { id: 'my-element-1', content: 'new-content-1' }, // This element has not changed
+          { id: 'my-element-3', content: 'new-content-3' }, // This element was originally at index 2 of the array
+          { id: 'my-element-2', content: 'new-content-2' }, // This element was originally at index 1 of the array
+          { id: 'new-element-4', content: 'new-content-4' } // Brand new element
+        ]
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'objectNestedInArrayDoc',
+        elementList: [
+          { id: 'my-element-1', content: 'old-content-1' },
+          { id: 'my-element-2', content: 'old-content-2' },
+          { id: 'my-element-3', content: 'old-content-3' }
+        ]
+      };
+
+      testHelper.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'objectNestedInArrayDoc',
+        [ errorFormatter.immutableItemViolation('elementList[1].id'), errorFormatter.immutableItemViolation('elementList[2].id') ]);
+    });
+
+    it('allow modification as long as immutable properties do not change', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'objectNestedInArrayDoc',
+        elementList: [
+          { id: 'my-element-1', content: 'new-content-1' },
+          { id: 'my-element-2', content: 'new-content-2' },
+          { id: 'new-element-3', content: 'new-content-3' } // Brand new element
+        ]
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'objectNestedInArrayDoc',
+        elementList: [
+          { id: 'my-element-1', content: 'old-content-1' },
+          { id: 'my-element-2', content: 'old-content-2' }
+        ]
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+  });
+
+  describe('when an object with an immutable property is nested in a hashtable', function() {
+    it('prevent modification of immutable properties for objects that already exist', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'objectNestedInHashtableDoc',
+        hash: {
+          one: { id: 'my-element-3', content: 'new-content-3' }, // This element was originally for key "three"
+          two: { id: 'my-element-2', content: 'new-content-2' }, // This element has not changed
+          three: { id: 'my-element-1', content: 'new-content-1' }, // This element was originally for key "one"
+          four: { id: 'new-element-4', content: 'new-content-4' } // Brand new element
+        }
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'objectNestedInHashtableDoc',
+        hash: {
+          one: { id: 'my-element-1', content: 'old-content-1' },
+          two: { id: 'my-element-2', content: 'old-content-2' },
+          three: { id: 'my-element-3', content: 'old-content-3' }
+        }
+      };
+
+      testHelper.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'objectNestedInHashtableDoc',
+        [ errorFormatter.immutableItemViolation('hash[one].id'), errorFormatter.immutableItemViolation('hash[three].id') ]);
+    });
+
+    it('allow modification as long as immutable properties do not change', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'objectNestedInHashtableDoc',
+        hash: {
+          one: { id: 'my-element-1', content: 'new-content-1' },
+          two: { id: 'my-element-2', content: 'new-content-2' },
+          three: { id: 'new-element-3', content: 'new-content-3' } // Brand new element
+        }
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'objectNestedInHashtableDoc',
+        hash: {
+          one: { id: 'my-element-1', content: 'old-content-1' },
+          two: { id: 'my-element-2', content: 'old-content-2' }
+        }
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+  });
+
+  describe('when an object with an immutable property is nested in an object', function() {
+    it('prevent modification of immutable properties for objects that already exist', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'objectNestedInObjectDoc',
+        object: {
+          value: { id: 'new-element', content: 'new-content' }
+        }
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'objectNestedInObjectDoc',
+        object: {
+          value: { id: 'old-element', content: 'old-content' }
+        }
+      };
+
+      testHelper.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'objectNestedInObjectDoc',
+        errorFormatter.immutableItemViolation('object.value.id'));
+    });
+
+    it('allow modification as long as immutable properties do not change', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'objectNestedInObjectDoc',
+        object: {
+          value: { id: 'my-element', content: 'new-content' }
+        }
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'objectNestedInObjectDoc',
+        object: {
+          value: { id: 'my-element', content: 'new-content' }
+        }
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+  });
+
+  describe('when a hashtable with immutable values is nested in an array', function() {
+    it('prevent modification of immutable values for hashtables that already exist', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInArrayDoc',
+        elementList: [
+          { value: 2 }, // This element was originally at index 1 of the array
+          { value: 1 }, // This element was originally at index 0 of the array
+          { value: 3 }, // This element has not changed
+          { value: 4 } // Brand new element
+        ]
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInArrayDoc',
+        elementList: [
+          { value: 1 },
+          { value: 2 },
+          { value: 3 }
+        ]
+      };
+
+      testHelper.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'hashtableNestedInArrayDoc',
+        [
+          errorFormatter.immutableItemViolation('elementList[1][value]'),
+          errorFormatter.immutableItemViolation('elementList[0][value]')
+        ]);
+    });
+
+    it('allow modification as long as immutable values do not change', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInArrayDoc',
+        elementList: [
+          { value: 1 },
+          { value: 2 },
+          { value: 3 } // Brand new element
+        ]
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInArrayDoc',
+        elementList: [
+          { value: 1 },
+          { value: 2 }
+        ]
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+  });
+
+  describe('when a hashtable with immutable values is nested in an object', function() {
+    it('prevent modification of immutable values for hashtables that already exist', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInObjectDoc',
+        object: {
+          hash: { value: 2 }
+        }
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInObjectDoc',
+        object: {
+          hash: { value: 1 }
+        }
+      };
+
+      testHelper.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'hashtableNestedInObjectDoc',
+        errorFormatter.immutableItemViolation('object.hash[value]'));
+    });
+
+    it('allow modification as long as immutable values do not change', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInObjectDoc',
+        object: {
+          hash: { value: 1 }
+        }
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInObjectDoc',
+        object: {
+          hash: { value: 1 }
+        }
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+  });
+
+  describe('when a hashtable with immutable values is nested in a hashtable', function() {
+    it('prevent modification of immutable values for hashtables that already exist', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInHashtableDoc',
+        hash: {
+          one: { value: 2 }, // This element was originally for key "two"
+          two: { value: 1 }, // This element was originally for key "one"
+          three: { value: 3 }, // This element has not changed
+          four: { value: 4 } // Brand new element
+        }
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInHashtableDoc',
+        hash: {
+          one: { value: 1 },
+          two: { value: 2 },
+          three: { value: 3 }
+        }
+      };
+
+      testHelper.verifyDocumentNotReplaced(
+        doc,
+        oldDoc,
+        'hashtableNestedInHashtableDoc',
+        [
+          errorFormatter.immutableItemViolation('hash[one][value]'),
+          errorFormatter.immutableItemViolation('hash[two][value]')
+        ]);
+    });
+
+    it('allow modification as long as immutable values do not change', function() {
+      var doc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInHashtableDoc',
+        hash: {
+          one: { value: 1 },
+          two: { value: 2 },
+          three: { value: 3 } // Brand new element
+        }
+      };
+
+      var oldDoc = {
+        _id: 'myDoc',
+        type: 'hashtableNestedInHashtableDoc',
+        hash: {
+          one: { value: 1 },
+          two: { value: 2 }
+        }
+      };
+
+      testHelper.verifyDocumentReplaced(doc, oldDoc);
+    });
+  });
+});

--- a/test/resources/immutable-nested-properties-doc-definitions.js
+++ b/test/resources/immutable-nested-properties-doc-definitions.js
@@ -1,0 +1,117 @@
+{
+  objectNestedInArrayDoc: {
+    typeFilter: simpleTypeFilter,
+    channels: { write: 'write' },
+    propertyValidators: {
+      elementList: {
+        type: 'array',
+        arrayElementsValidator: {
+          type: 'object',
+          propertyValidators: {
+            id: {
+              type: 'string',
+              immutable: true
+            },
+            content: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  },
+  objectNestedInHashtableDoc: {
+    typeFilter: simpleTypeFilter,
+    channels: { write: 'write' },
+    propertyValidators: {
+      hash: {
+        type: 'hashtable',
+        hashtableValuesValidator: {
+          type: 'object',
+          propertyValidators: {
+            id: {
+              type: 'string',
+              immutable: true
+            },
+            content: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  },
+  objectNestedInObjectDoc: {
+    typeFilter: simpleTypeFilter,
+    channels: { write: 'write' },
+    propertyValidators: {
+      object: {
+        type: 'object',
+        propertyValidators: {
+          value: {
+            type: 'object',
+            propertyValidators: {
+              id: {
+                type: 'string',
+                immutable: true
+              },
+              content: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  hashtableNestedInArrayDoc: {
+    typeFilter: simpleTypeFilter,
+    channels: { write: 'write' },
+    propertyValidators: {
+      elementList: {
+        type: 'array',
+        arrayElementsValidator: {
+          type: 'hashtable',
+          hashtableValuesValidator: {
+            type: 'integer',
+            immutable: true
+          }
+        }
+      }
+    }
+  },
+  hashtableNestedInObjectDoc: {
+    typeFilter: simpleTypeFilter,
+    channels: { write: 'write' },
+    propertyValidators: {
+      object: {
+        type: 'object',
+        propertyValidators: {
+          hash: {
+            type: 'hashtable',
+            hashtableValuesValidator: {
+              type: 'integer',
+              immutable: true
+            }
+          }
+        }
+      }
+    }
+  },
+  hashtableNestedInHashtableDoc: {
+    typeFilter: simpleTypeFilter,
+    channels: { write: 'write' },
+    propertyValidators: {
+      hash: {
+        type: 'hashtable',
+        hashtableValuesValidator: {
+          type: 'hashtable',
+          hashtableValuesValidator: {
+            type: 'integer',
+            immutable: true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This bug erroneously rejected cases where a new object could not be added to an array for an existing document if the document definition specifies that one or more properties of the object are immutable. Also applied to hashtables with immutable values nested in an array.

Addresses issue #152.

Note: this pull request does not target the master branch because I intend to issue the update as a patch release without all of the in-progress work on document validation that is currently on the `master` branch. Instead, the release will be cut from the `v1.9.3-dev` branch, which is based off of the `v1.9.2` tag, and then that branch will be merged into `master`.