### PR TITLE
Update mocha to version 4.0.1 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "node"
   - "lts/*"
-  - "0.10"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "expect.js": "^0.3.1",
     "jshint": "^2.9.4",
-    "mocha": "^3.4.2",
+    "mocha": "^4.0.1",
     "mock-require": "^2.0.2",
     "simple-mock": "^0.8.0"
   },


### PR DESCRIPTION
In order to upgrade to the newest version of mocha, support for Node.js 0.10.x has to be removed from the Travis CI build configuration. This should not be a problem since that version of Node.js is positively ancient and there is no need to be able to build the project with it anymore. Furthermore, this is not a breaking change for those packages that depend on synctos because mocha is only a development dependency.

Replaces PR #151.