### PR TITLE
Issue #157 chai upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- [#157](https://github.com/Kashoo/synctos/issues/157): Swap in Chai as the assertion library used in specs throughout the project
+
 ## [1.9.3] - 2017-10-23
 ### Fixed
 - [#152](https://github.com/Kashoo/synctos/issues/152): Cannot append a new object with immutable properties to an array

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -233,8 +233,7 @@ exports.verifyAccessDenied = verifyAccessDenied;
  */
 exports.verifyUnknownDocumentType = verifyUnknownDocumentType;
 
-
-var expect = require('expect.js');
+var assert = require('assert');
 var simple = require('simple-mock');
 var fs = require('fs');
 var syncFunctionLoader = require('./sync-function-loader.js');
@@ -291,25 +290,25 @@ function init() {
 }
 
 function verifyRequireAccess(expectedChannels) {
-  expect(requireAccess.callCount).to.be.greaterThan(0);
+  assert.ok(requireAccess.callCount > 0, 'Require access not called when expected');
 
   checkAuthorizations(expectedChannels, requireAccess.calls[0].arg, 'channel');
 }
 
 function verifyRequireRole(expectedRoles) {
-  expect(requireRole.callCount).to.be.greaterThan(0);
+  assert.ok(requireRole.callCount > 0, 'Require role not called when expected');
 
   checkAuthorizations(expectedRoles, requireRole.calls[0].arg, 'role');
 }
 
 function verifyRequireUser(expectedUsers) {
-  expect(requireUser.callCount).to.be.greaterThan(0);
+  assert.ok(requireUser.callCount > 0, 'Require user not called when expected');
 
   checkAuthorizations(expectedUsers, requireUser.calls[0].arg, 'user');
 }
 
 function verifyChannelAssignment(expectedChannels) {
-  expect(channel.callCount).to.be(1);
+  assert.equal(channel.callCount, 1, 'Expected channel assignment was not made');
 
   checkAuthorizations(expectedChannels, channel.calls[0].arg, 'channel');
 }
@@ -328,14 +327,14 @@ function checkAuthorizations(expectedAuthorizations, actualAuthorizations, autho
   for (var expectedAuthIndex = 0; expectedAuthIndex < expectedAuthorizations.length; expectedAuthIndex++) {
     var expectedAuth = expectedAuthorizations[expectedAuthIndex];
     if (actualAuthorizations.indexOf(expectedAuth) < 0) {
-      expect().fail('Expected ' + authorizationType + ' was not encountered: ' + expectedAuth);
+      assert.fail('Expected ' + authorizationType + ' was not encountered: ' + expectedAuth);
     }
   }
 
   for (var actualAuthIndex = 0; actualAuthIndex < actualAuthorizations.length; actualAuthIndex++) {
     var actualAuth = actualAuthorizations[actualAuthIndex];
     if (expectedAuthorizations.indexOf(actualAuth) < 0) {
-      expect().fail('Unexpected ' + authorizationType + ' encountered: ' + actualAuth);
+      assert.fail('Unexpected ' + authorizationType + ' encountered: ' + actualAuth);
     }
   }
 }
@@ -409,7 +408,7 @@ function verifyChannelAccessAssignment(expectedAssignment) {
   }
 
   if (!accessAssignmentCallExists(access, expectedUsersAndRoles, expectedChannels)) {
-    expect().fail(
+    assert.fail(
       'Missing expected call to assign channel access (' +
       JSON.stringify(expectedChannels) +
       ') to users and roles (' +
@@ -442,7 +441,7 @@ function verifyRoleAccessAssignment(expectedAssignment) {
   }
 
   if (!accessAssignmentCallExists(role, expectedUsers, expectedRoles)) {
-    expect().fail(
+    assert.fail(
       'Missing expected call to assign role access (' +
       JSON.stringify(expectedRoles) +
       ') to users (' +
@@ -467,26 +466,26 @@ function verifyAccessAssignments(expectedAccessAssignments) {
   }
 
   if (access.callCount !== expectedAccessCalls) {
-    expect().fail('Number of calls to assign channel access (' + access.callCount + ') does not match expected (' + expectedAccessCalls + ')');
+    assert.fail('Number of calls to assign channel access (' + access.callCount + ') does not match expected (' + expectedAccessCalls + ')');
   }
 
   if (role.callCount !== expectedRoleCalls) {
-    expect().fail('Number of calls to assign role access (' + role.callCount + ') does not match expected (' + expectedRoleCalls + ')');
+    assert.fail('Number of calls to assign role access (' + role.callCount + ') does not match expected (' + expectedRoleCalls + ')');
   }
 }
 
 function verifyOperationChannelsAssigned(doc, oldDoc, expectedChannels) {
   if (channel.callCount !== 1) {
-    expect().fail('Document failed authorization and/or validation');
+    assert.fail('Document failed authorization and/or validation');
   }
 
   var actualChannels = channel.calls[0].arg;
   if (expectedChannels instanceof Array) {
     for (var channelIndex = 0; channelIndex < expectedChannels.length; channelIndex++) {
-      expect(actualChannels).to.contain(expectedChannels[channelIndex]);
+      assert.ok(actualChannels.indexOf(expectedChannels[channelIndex]) >= 0, 'Expected channel "' + expectedChannels[channelIndex] + '" was not authorized');
     }
   } else {
-    expect(actualChannels).to.contain(expectedChannels);
+    assert.ok(actualChannels.indexOf(expectedChannels) >= 0, 'Expected assignment channel not found: "' + expectedChannels + '" actual: "' + actualChannels + '"');
   }
 }
 
@@ -497,8 +496,8 @@ function verifyAuthorization(expectedAuthorization) {
     // for authorization
     expectedOperationChannels = expectedAuthorization;
     verifyRequireAccess(expectedAuthorization);
-    expect(requireRole.callCount).to.be(0);
-    expect(requireUser.callCount).to.be(0);
+    assert.equal(requireRole.callCount, 0, 'Require role called unexpectedly: ' + requireRole.calls);
+    assert.equal(requireUser.callCount, 0, 'Require user called unexpectedly: ' + requireUser.calls);
   } else {
     if (expectedAuthorization.expectedChannels) {
       expectedOperationChannels = expectedAuthorization.expectedChannels;
@@ -508,13 +507,13 @@ function verifyAuthorization(expectedAuthorization) {
     if (expectedAuthorization.expectedRoles) {
       verifyRequireRole(expectedAuthorization.expectedRoles);
     } else {
-      expect(requireRole.callCount).to.be(0);
+      assert.equal(requireRole.callCount, 0, 'Require role called unexpectedly: ' + requireRole.calls);
     }
 
     if (expectedAuthorization.expectedUsers) {
       verifyRequireUser(expectedAuthorization.expectedUsers);
     } else {
-      expect(requireUser.callCount).to.be(0);
+      assert.equal(requireUser.callCount, 0, 'Require user called unexpectedly: ' + requireUser.calls);
     }
 
     if (!(expectedAuthorization.expectedChannels) && !(expectedAuthorization.expectedRoles) && !(expectedAuthorization.expectedUsers)) {
@@ -550,13 +549,16 @@ function verifyDocumentDeleted(oldDoc, expectedAuthorization, expectedAccessAssi
 }
 
 function verifyDocumentRejected(doc, oldDoc, docType, expectedErrorMessages, expectedAuthorization) {
-  expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+  try {
+    syncFunction(doc, oldDoc);
+    assert.fail('No errors thrown when some expected');
+  } catch (ex) {
     verifyValidationErrors(docType, expectedErrorMessages, ex);
-  });
+  }
 
   verifyAuthorization(expectedAuthorization);
 
-  expect(channel.callCount).to.equal(0);
+  assert.equal(channel.callCount, 0, 'Channel assignment made unexpectedly: ' + channel.calls);
 }
 
 function verifyDocumentNotCreated(doc, docType, expectedErrorMessages, expectedAuthorization) {
@@ -582,10 +584,10 @@ function verifyValidationErrors(docType, expectedErrorMessages, exception) {
   var exceptionMessageMatches = validationErrorRegex.exec(exception.forbidden);
   var actualErrorMessages;
   if (exceptionMessageMatches) {
-    expect(exceptionMessageMatches.length).to.be(3);
+    assert.equal(exceptionMessageMatches.length, 3);
 
     var invalidDocMessage = exceptionMessageMatches[1].trim();
-    expect(invalidDocMessage).to.equal('Invalid ' + docType + ' document');
+    assert.equal(invalidDocMessage, 'Invalid ' + docType + ' document', 'Expected invalid document type message not reported');
 
     actualErrorMessages = exceptionMessageMatches[2].trim().split(/;\s*/);
   } else {
@@ -593,7 +595,8 @@ function verifyValidationErrors(docType, expectedErrorMessages, exception) {
   }
 
   for (var expectedErrorIndex = 0; expectedErrorIndex < expectedErrorMessages.length; expectedErrorIndex++) {
-    expect(actualErrorMessages).to.contain(expectedErrorMessages[expectedErrorIndex]);
+    var expectedErrorMsg = expectedErrorMessages[expectedErrorIndex];
+    assert.ok(actualErrorMessages.indexOf(expectedErrorMsg) >= 0, 'Expected error message "' + expectedErrorMsg  +'" not reported');
   }
 
   // Rather than compare the sizes of the two lists, which leads to an obtuse error message on failure (e.g. "expected 2 to be 3"), ensure
@@ -601,7 +604,7 @@ function verifyValidationErrors(docType, expectedErrorMessages, exception) {
   for (var actualErrorIndex = 0; actualErrorIndex < actualErrorMessages.length; actualErrorIndex++) {
     var errorMessage = actualErrorMessages[actualErrorIndex];
     if (expectedErrorMessages.indexOf(errorMessage) < 0) {
-      expect().fail('Unexpected validation error: ' + errorMessage);
+      assert.fail('Unexpected validation error: ' + errorMessage);
     }
   }
 }
@@ -631,32 +634,38 @@ function verifyAccessDenied(doc, oldDoc, expectedAuthorization) {
   requireRole = simple.stub().throwWith(roleAccessDenied);
   requireUser = simple.stub().throwWith(userAccessDenied);
 
-  expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+  try {
+    syncFunction(doc, oldDoc);
+    assert.fail('No errors thrown when some expected');
+  } catch (ex) {
     if (typeof(expectedAuthorization) === 'string' || expectedAuthorization instanceof Array) {
-      expect(ex).to.eql(channelAccessDenied);
+      assert.equal(ex, channelAccessDenied);
     } else if (countAuthorizationTypes(expectedAuthorization) === 0) {
       verifyRequireAccess([ ]);
     } else if (countAuthorizationTypes(expectedAuthorization) > 1) {
-      expect(ex.forbidden).to.equal(generalAuthFailedMessage);
+      assert.equal(ex.forbidden, generalAuthFailedMessage, 'Expected authorization exception not met: ' + ex.forbidden);
     } else if (expectedAuthorization.expectedChannels) {
-      expect(ex).to.eql(channelAccessDenied);
+      assert.ok(ex instanceof Error && ex.message === channelAccessDenied.message, 'Expected channel authorization error not triggered');
     } else if (expectedAuthorization.expectedRoles) {
-      expect(ex).to.eql(roleAccessDenied);
+      assert.ok(ex instanceof Error && ex.message === roleAccessDenied.message, 'Expected role authorization error not triggered');
     } else if (expectedAuthorization.expectedUsers) {
-      expect(ex).to.eql(userAccessDenied);
+      assert.ok(ex instanceof Error && ex.message === userAccessDenied.message, 'Expected user authorization error not triggered');
     }
-  });
+  }
 
   verifyAuthorization(expectedAuthorization);
 }
 
 function verifyUnknownDocumentType(doc, oldDoc) {
-  expect(syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
-    expect(ex.forbidden).to.equal('Unknown document type');
-  });
+  try {
+    syncFunction(doc, oldDoc);
+    assert.fail('Expected unknown document type error not thrown');
+  } catch (ex) {
+    assert.equal(ex.forbidden, 'Unknown document type');
+  }
 
-  expect(requireAccess.callCount).to.be(0);
-  expect(channel.callCount).to.be(0);
+  assert.equal(requireAccess.callCount, 0, 'Unexpected require access call');
+  assert.equal(channel.callCount, 0, 'Unexpected channel assignment call');
 }
 
 // Sync Gateway configuration files use the backtick character to denote the beginning and end of a multiline string. The sync function

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "indent.js": "^0.1.4"
   },
   "devDependencies": {
-    "expect.js": "^0.3.1",
+    "chai": "^4.1.2",
     "jshint": "^2.9.4",
     "mocha": "^3.3.0",
     "simple-mock": "^0.7.3"

--- a/test/access-assignment-spec.js
+++ b/test/access-assignment-spec.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var testHelper = require('../etc/test-helper.js');
 
 describe('User and role access assignment:', function() {
@@ -56,9 +56,10 @@ describe('User and role access assignment:', function() {
         invalidProperty: 'foobar'
       };
 
-      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
-        expect(testHelper.access.callCount).to.be(0);
-      });
+      expect(function() {
+        testHelper.syncFunction(doc);
+      }).to.throw();
+      expect(testHelper.access.callCount).to.equal(0);
     });
 
     it('is NOT applied when replacing an invalid document', function() {
@@ -68,9 +69,10 @@ describe('User and role access assignment:', function() {
       };
       var oldDoc = { _id: 'staticAccessDoc' };
 
-      expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
-        expect(testHelper.access.callCount).to.be(0);
-      });
+      expect(function() {
+        testHelper.syncFunction(doc, oldDoc);
+      }).to.throw();
+      expect(testHelper.access.callCount).to.equal(0);
     });
   });
 
@@ -164,9 +166,10 @@ describe('User and role access assignment:', function() {
         invalidProperty: 'foobar'
       };
 
-      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
-        expect(testHelper.access.callCount).to.be(0);
-      });
+      expect(function() {
+        testHelper.syncFunction(doc);
+      }).to.throw();
+      expect(testHelper.access.callCount).to.equal(0);
     });
 
     it('is NOT applied when replacing an invalid document', function() {
@@ -178,9 +181,10 @@ describe('User and role access assignment:', function() {
       };
       var oldDoc = { _id: 'dynamicAccessDoc' };
 
-      expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
-        expect(testHelper.access.callCount).to.be(0);
-      });
+      expect(function() {
+        testHelper.syncFunction(doc, oldDoc);
+      }).to.throw();
+      expect(testHelper.access.callCount).to.equal(0);
     });
   });
 });

--- a/test/attachment-constraints-spec.js
+++ b/test/attachment-constraints-spec.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var testHelper = require('../etc/test-helper.js');
 var errorFormatter = testHelper.validationErrorFormatter;
 
@@ -75,9 +75,12 @@ describe('File attachment constraints:', function() {
             attachmentRefProp: 'bar.html' // The attachmentReference's maximum size of 40 overrides the document's maximum individual size of 25
           };
 
-          expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+          try {
+            testHelper.syncFunction(doc);
+            expect.fail('Expected maximum attachment violation exception not thrown');
+          } catch (ex) {
             testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumTotalAttachmentSizeViolation(40), ex);
-          });
+          }
         });
 
         it('should block replacement when document attachments exceed the limits', function() {
@@ -96,12 +99,15 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+          try {
+            testHelper.syncFunction(doc, oldDoc);
+            expect.fail('Expected maximum attachment violation exception not thrown');
+          } catch (ex) {
             testHelper.verifyValidationErrors(
               'staticRegularAttachmentsDoc',
               [ errorFormatter.maximumTotalAttachmentSizeViolation(40), errorFormatter.maximumIndividualAttachmentSizeViolation('foo.xml', 25) ],
               ex);
-          });
+          }
         });
       });
 
@@ -130,9 +136,12 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+          try {
+            testHelper.syncFunction(doc);
+            expect.fail('Expected maximum attachment count violation exception not thrown');
+          } catch(ex) {
             testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), ex);
-          });
+          }
         });
 
         it('should block replacement when document attachments exceed the limit', function() {
@@ -163,9 +172,12 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+          try {
+            testHelper.syncFunction(doc, oldDoc);
+            expect.fail('Expected maximum attachment count violation exception not thrown');
+          } catch (ex) {
             testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), ex);
-          });
+          }
         });
       });
 
@@ -192,7 +204,10 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+          try {
+            testHelper.syncFunction(doc);
+            expect.fail('Expected file extension constraint violation not thrown');
+          } catch(ex) {
             testHelper.verifyValidationErrors(
               'staticRegularAttachmentsDoc',
               [
@@ -200,7 +215,7 @@ describe('File attachment constraints:', function() {
                 errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions)
               ],
               ex);
-          });
+          }
         });
 
         it('should block replacement when document attachments have unsupported extensions', function() {
@@ -224,12 +239,15 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+          try {
+            testHelper.syncFunction(doc, oldDoc);
+            expect.fail('Expected file attachment constraint violation not thrown');
+          } catch (ex) {
             testHelper.verifyValidationErrors(
               'staticRegularAttachmentsDoc',
               errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions),
               ex);
-          });
+          }
         });
       });
 
@@ -256,7 +274,10 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+          try {
+            testHelper.syncFunction(doc);
+            expect.fail('Expected file extension constraint violation not thrown');
+          } catch(ex) {
             testHelper.verifyValidationErrors(
               'staticRegularAttachmentsDoc',
               [
@@ -264,7 +285,7 @@ describe('File attachment constraints:', function() {
                 errorFormatter.supportedContentTypesRawAttachmentViolation('foo.txt', expectedContentTypes)
               ],
               ex);
-          });
+          }
         });
 
         it('should block replacement when document attachments have unsupported content types', function() {
@@ -288,12 +309,15 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+          try {
+            testHelper.syncFunction(doc, oldDoc);
+            expect.fail('Expected file extension constraint violation not thrown');
+          } catch(ex) {
             testHelper.verifyValidationErrors(
               'staticRegularAttachmentsDoc',
               errorFormatter.supportedContentTypesRawAttachmentViolation('foo.jpg', expectedContentTypes),
               ex);
-          });
+          }
         });
       });
     });
@@ -332,9 +356,12 @@ describe('File attachment constraints:', function() {
           attachmentRefProp: 'foo.pdf'
         };
 
-        expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+        try {
+          testHelper.syncFunction(doc);
+          expect.fail('Expected attachment constraint violation not thrown');
+        } catch(ex) {
           testHelper.verifyValidationErrors('staticAttachmentRefsOnlyDoc', errorFormatter.requireAttachmentReferencesViolation('bar.txt'), ex);
-        });
+        }
       });
 
       it('should allow replacement when document attachments do not violate the constraint', function() {
@@ -378,9 +405,12 @@ describe('File attachment constraints:', function() {
           type: 'staticAttachmentRefsOnlyDoc'
         };
 
-        expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+        try {
+          testHelper.syncFunction(doc, oldDoc);
+          expect.fail('Expected attachment constraint violation not thrown');
+        } catch(ex) {
           testHelper.verifyValidationErrors('staticAttachmentRefsOnlyDoc', errorFormatter.requireAttachmentReferencesViolation('baz.jpg'), ex);
-        });
+        }
       });
     });
   });

--- a/test/custom-actions-spec.js
+++ b/test/custom-actions-spec.js
@@ -1,6 +1,6 @@
 var testHelper = require('../etc/test-helper.js');
 var errorFormatter = testHelper.validationErrorFormatter;
-var expect = require('expect.js');
+var expect = require('chai').expect;
 
 describe('Custom actions:', function() {
   var expectedAuthorization = {
@@ -37,9 +37,12 @@ describe('Custom actions:', function() {
       var unknownDocType = 'foo';
       var doc = { _id: unknownDocType };
 
-      expect(testHelper.syncFunction).withArgs(doc, expectedAuthorization).to.throwException(function(ex) {
+      try {
+        testHelper.syncFunction(doc, expectedAuthorization);
+        expect.fail('Expected error during custom action not thrown');
+      } catch(ex) {
         testHelper.verifyValidationErrors(unknownDocType, errorFormatter.unknownDocumentType(), ex);
-      });
+      }
       verifyCustomActionNotExecuted();
     });
   });
@@ -161,16 +164,19 @@ describe('Custom actions:', function() {
       var expectedError = new Error('bad channels!');
       testHelper.channel.throwWith(expectedError);
 
-      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+      try {
+        testHelper.syncFunction(doc);
+        expect.fail('Expected error during custom action not thrown');
+      } catch(ex) {
         expect(ex).to.equal(expectedError);
-      });
+      }
       verifyCustomActionNotExecuted();
     });
   });
 });
 
 function verifyCustomActionExecuted(doc, oldDoc, expectedActionType) {
-  expect(testHelper.customActionStub.callCount).to.be(1);
+  expect(testHelper.customActionStub.callCount).to.equal(1);
   expect(testHelper.customActionStub.calls[0].args[0]).to.eql(doc);
   expect(testHelper.customActionStub.calls[0].args[1]).to.eql(oldDoc);
 
@@ -178,7 +184,7 @@ function verifyCustomActionExecuted(doc, oldDoc, expectedActionType) {
 }
 
 function verifyCustomActionNotExecuted() {
-  expect(testHelper.customActionStub.callCount).to.be(0);
+  expect(testHelper.customActionStub.callCount).to.equal(0);
 }
 
 function verifyCustomActionMetadata(actualMetadata, docType, expectedActionType) {
@@ -190,8 +196,8 @@ function verifyCustomActionMetadata(actualMetadata, docType, expectedActionType)
 }
 
 function verifyTypeMetadata(actualMetadata, docType) {
-  expect(actualMetadata.documentTypeId).to.be(docType);
-  expect(actualMetadata.documentDefinition.typeFilter({ _id: docType })).to.be(true);
+  expect(actualMetadata.documentTypeId).to.equal(docType);
+  expect(actualMetadata.documentDefinition.typeFilter({ _id: docType })).to.equal(true);
 }
 
 function verifyAuthorizationMetadata(actualMetadata) {
@@ -216,7 +222,7 @@ function verifyAccessAssignmentMetadata(actualMetadata) {
     }
     expect(actualMetadata.accessAssignments).to.eql(expectedAssignments);
   } else {
-    expect(actualMetadata.accessAssignments).to.be(undefined);
+    expect(actualMetadata.accessAssignments).to.equal(undefined);
   }
 }
 
@@ -225,7 +231,7 @@ function verifyDocChannelsMetadata(actualMetadata) {
 }
 
 function verifyCustomActionTypeMetadata(actualMetadata, expectedActionType) {
-  expect(actualMetadata.actionType).to.be(expectedActionType);
+  expect(actualMetadata.actionType).to.equal(expectedActionType);
 }
 
 function getDeletedDoc(docType) {

--- a/test/general-spec.js
+++ b/test/general-spec.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var testHelper = require('../etc/test-helper.js');
 var errorFormatter = testHelper.validationErrorFormatter;
 
@@ -11,26 +11,35 @@ describe('Functionality that is common to all documents:', function() {
     it('rejects document creation with an unrecognized doc type', function() {
       var doc = { _id: 'my-invalid-doc' };
 
-      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+      try {
+        testHelper.syncFunction(doc);
+        expect.fail('Expected unrecognized document type violation not thrown');
+      } catch(ex) {
         expect(ex).to.eql({ forbidden: 'Unknown document type' });
-      });
+      }
     });
 
     it('rejects document replacement with an unrecognized doc type', function() {
       var doc = { _id: 'my-invalid-doc', foo: 'bar' };
       var oldDoc = { _id: 'my-invalid-doc' };
 
-      expect(testHelper.syncFunction).withArgs(doc, oldDoc).to.throwException(function(ex) {
+      try {
+        testHelper.syncFunction(doc, oldDoc);
+        expect.fail('Expected unrecognized document type violation not thrown');
+      } catch(ex) {
         expect(ex).to.eql({ forbidden: 'Unknown document type' });
-      });
+      }
     });
 
     it('rejects document deletion with an unrecognized type', function() {
       var doc = { _id: 'my-invalid-doc', _deleted: true };
 
-      expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+      try {
+        testHelper.syncFunction(doc);
+        expect.fail('Expected unrecognized document violation not thrown');
+      } catch(ex) {
         expect(ex).to.eql({ forbidden: 'Unknown document type' });
-      });
+      }
     });
   });
 
@@ -198,7 +207,10 @@ describe('Functionality that is common to all documents:', function() {
       }
     };
 
-    expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+    try {
+      testHelper.syncFunction(doc);
+      expect.fail('Expected whitelisted property error not thrown');
+    } catch(ex) {
       testHelper.verifyValidationErrors(
         'generalDoc',
         [
@@ -209,7 +221,7 @@ describe('Functionality that is common to all documents:', function() {
           errorFormatter.unsupportedProperty('objectProp._attachments')
         ],
         ex);
-    });
+    }
   });
 
   it('cannot include attachments in documents that do not explicitly allow them', function() {
@@ -223,8 +235,11 @@ describe('Functionality that is common to all documents:', function() {
       }
     };
 
-    expect(testHelper.syncFunction).withArgs(doc).to.throwException(function(ex) {
+    try {
+      testHelper.syncFunction(doc);
+      expect.fail('Expected attachment error not thrown');
+    } catch(ex) {
       testHelper.verifyValidationErrors('generalDoc', errorFormatter.allowAttachmentsViolation(), ex);
-    });
+    }
   });
 });

--- a/test/init-spec.js
+++ b/test/init-spec.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var testHelper = require('../etc/test-helper.js');
 var errorFormatter = testHelper.validationErrorFormatter;
 
@@ -17,9 +17,12 @@ describe('Test helper module initialization', function() {
     });
 
     it('fails to load the sync function for a file that does not exist', function() {
-      expect(testHelper.initSyncFunction).withArgs('build/sync-functions/test-nonexistant-sync-function.js').to.throwException(function(ex) {
-        expect(ex.code).to.eql('ENOENT');
-      });
+      try {
+        testHelper.initSyncFunction('build/sync-functions/test-nonexistant-sync-function.js');
+        expect.fail('Expected exception not thrown');
+      } catch(ex) {
+        expect(ex.code).to.equal('ENOENT');
+      }
     });
   });
 
@@ -37,9 +40,12 @@ describe('Test helper module initialization', function() {
     });
 
     it('fails to load the sync function for a file that does not exist', function() {
-      expect(testHelper.initDocumentDefinitions).withArgs('test/resources/nonexistant-doc-definitions.js').to.throwException(function(ex) {
-        expect(ex.code).to.eql('ENOENT');
-      });
+      try {
+        testHelper.initDocumentDefinitions('test/resources/nonexistant-doc-definitions.js');
+        expect.fail('Expected exception not thrown');
+      } catch (ex) {
+        expect(ex.code).to.equal('ENOENT');
+      }
     });
   });
 });

--- a/test/sample-notification-transport-spec.js
+++ b/test/sample-notification-transport-spec.js
@@ -1,7 +1,7 @@
 var sampleSpecHelper = require('./modules/sample-spec-helper.js');
 var testHelper = require('../etc/test-helper.js');
 var errorFormatter = testHelper.validationErrorFormatter;
-var expect = require('expect.js');
+var expect = require('chai').expect;
 
 describe('Sample business notification transport doc definition', function() {
   beforeEach(function() {
@@ -12,12 +12,12 @@ describe('Sample business notification transport doc definition', function() {
   var expectedBasePrivilege = 'NOTIFICATIONS_CONFIG';
 
   function verifyAuthorizationCustomAction(docId, action) {
-    expect(testHelper.requireAccess.callCount).to.be(2);
+    expect(testHelper.requireAccess.callCount).to.equal(2);
     expect(testHelper.requireAccess.calls[1].arg).to.equal(docId + '-' + action);
   }
 
   function verifyNoAuthorizationCustomAction() {
-    expect(testHelper.requireAccess.callCount).to.be(1);
+    expect(testHelper.requireAccess.callCount).to.equal(1);
   }
 
   it('successfully creates a valid notification transport document', function() {

--- a/test/type-id-validator-spec.js
+++ b/test/type-id-validator-spec.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var testHelper = require('../etc/test-helper.js');
 var errorFormatter = testHelper.validationErrorFormatter;
 


### PR DESCRIPTION
As it turns out, there were a few more API incompatibilities than I initially expected, but it wasn't too bad in the end.  

We gain richer feedback in assertion failures, as both substitute APIs support failure messages on all matchers, but lose elegant and/or flexible handling of `throws` conditions.  
The Node assert API rejects objects thrown that are not `Error`s and Chai simply doesn't support a custom function for asserting the Error.  Trusty old try-fail/catch-assert pattern was used to overcome these weaknesses.  