### PR TITLE
Issue 160: Allow Couchbase SDK to delete documents in a shared access bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#156](https://github.com/Kashoo/synctos/issues/156): Fix for an edge case where users assigned a replace role may gain the privilege of removing a document erroneously under certain document definition conditions
 - [#157](https://github.com/Kashoo/synctos/issues/157): Swap in Chai as the assertion library used in specs throughout the project
 
+### Fixed
+- [#160](https://github.com/Kashoo/synctos/issues/160): Unable to import document if it was deleted via Couchbase SDK
+
 ## [1.9.3] - 2017-10-23
 ### Fixed
 - [#152](https://github.com/Kashoo/synctos/issues/152): Cannot append a new object with immutable properties to an array

--- a/etc/sync-function-template.js
+++ b/etc/sync-function-template.js
@@ -76,7 +76,20 @@ function synctos(doc, oldDoc) {
   var theDocType = getDocumentType(doc, oldDoc);
 
   if (isValueNullOrUndefined(theDocType)) {
-    throw({ forbidden: 'Unknown document type' });
+    if (isDocumentMissingOrDeleted(oldDoc) && isDocumentMissingOrDeleted(doc)) {
+      // Attempting to delete a document that does not exist. This may occur when bucket access/sharing
+      // (https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/shared-bucket-access.html)
+      // is enabled and the document was deleted via the Couchbase SDK. Skip everything else and simply assign the
+      // public channel
+      // (https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/channels/index.html#special-channels)
+      // to the document so that it can be replaced in the future.
+      requireAccess('!');
+      channel('!');
+
+      return;
+    } else {
+      throw({ forbidden: 'Unknown document type' });
+    }
   }
 
   var theDocDefinition = docDefinitions[theDocType];

--- a/etc/test-helper.js
+++ b/etc/test-helper.js
@@ -537,7 +537,7 @@ function verifyDocumentAccepted(doc, oldDoc, expectedAuthorization, expectedAcce
 }
 
 function verifyDocumentCreated(doc, expectedAuthorization, expectedAccessAssignments) {
-  verifyDocumentAccepted(doc, undefined, expectedAuthorization || defaultWriteChannel, expectedAccessAssignments);
+  verifyDocumentAccepted(doc, void 0, expectedAuthorization || defaultWriteChannel, expectedAccessAssignments);
 }
 
 function verifyDocumentReplaced(doc, oldDoc, expectedAuthorization, expectedAccessAssignments) {
@@ -562,7 +562,7 @@ function verifyDocumentRejected(doc, oldDoc, docType, expectedErrorMessages, exp
 }
 
 function verifyDocumentNotCreated(doc, docType, expectedErrorMessages, expectedAuthorization) {
-  verifyDocumentRejected(doc, undefined, docType, expectedErrorMessages, expectedAuthorization || defaultWriteChannel);
+  verifyDocumentRejected(doc, void 0, docType, expectedErrorMessages, expectedAuthorization || defaultWriteChannel);
 }
 
 function verifyDocumentNotReplaced(doc, oldDoc, docType, expectedErrorMessages, expectedAuthorization) {

--- a/test/array-spec.js
+++ b/test/array-spec.js
@@ -133,7 +133,7 @@ describe('Array validation type', function() {
       it('blocks a doc when the array elements fail validation', function() {
         var doc = {
           _id: 'arrayDoc',
-          staticArrayElementsValidatorProp: [ 0, null, undefined, 'foo', -1, 3 ]
+          staticArrayElementsValidatorProp: [ 0, null, void 0, 'foo', -1, 3 ]
         };
 
         testHelper.verifyDocumentNotCreated(
@@ -164,7 +164,7 @@ describe('Array validation type', function() {
       it('blocks a doc when the array elements fail validation', function() {
         var doc = {
           _id: 'arrayDoc',
-          dynamicArrayElementsValidatorProp: [ '2017-04-11', null, undefined, 'foo', 47 ],
+          dynamicArrayElementsValidatorProp: [ '2017-04-11', null, void 0, 'foo', 47 ],
           dynamicArrayElementsType: 'date',
           dynamicArrayElementsRequired: true
         };

--- a/test/authorization-spec.js
+++ b/test/authorization-spec.js
@@ -10,7 +10,7 @@ describe('Authorization:', function() {
     it('rejects document creation for a user with no matching channels', function() {
       var doc = { _id: 'explicitChannelsDoc', stringProp: 'foobar' };
 
-      testHelper.verifyAccessDenied(doc, undefined, 'add');
+      testHelper.verifyAccessDenied(doc, void 0, 'add');
     });
 
     it('rejects document replacement for a user with no matching channels', function() {
@@ -23,7 +23,7 @@ describe('Authorization:', function() {
     it('rejects document deletion for a user with no matching channels', function() {
       var doc = { _id: 'explicitChannelsDoc', _deleted: true };
 
-      testHelper.verifyAccessDenied(doc, undefined, [ 'remove', 'delete' ]);
+      testHelper.verifyAccessDenied(doc, void 0, [ 'remove', 'delete' ]);
     });
   });
 
@@ -33,7 +33,7 @@ describe('Authorization:', function() {
     it('rejects document creation for a user with no matching channels', function() {
       var doc = { _id: 'writeOnlyChannelsDoc', stringProp: 'foobar' };
 
-      testHelper.verifyAccessDenied(doc, undefined, writeChannels);
+      testHelper.verifyAccessDenied(doc, void 0, writeChannels);
     });
 
     it('rejects document replacement for a user with no matching channels', function() {
@@ -46,7 +46,7 @@ describe('Authorization:', function() {
     it('rejects document deletion for a user with no matching channels', function() {
       var doc = { _id: 'writeOnlyChannelsDoc', _deleted: true };
 
-      testHelper.verifyAccessDenied(doc, undefined, writeChannels);
+      testHelper.verifyAccessDenied(doc, void 0, writeChannels);
     });
   });
 

--- a/test/custom-actions-spec.js
+++ b/test/custom-actions-spec.js
@@ -20,7 +20,7 @@ describe('Custom actions:', function() {
 
     it('executes a custom action when a document is created', function() {
       testHelper.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, undefined, 'onTypeIdentificationSucceeded');
+      verifyCustomActionExecuted(doc, void 0, 'onTypeIdentificationSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
@@ -54,7 +54,7 @@ describe('Custom actions:', function() {
 
     it('executes a custom action when a document is created', function() {
       testHelper.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, undefined, 'onAuthorizationSucceeded');
+      verifyCustomActionExecuted(doc, void 0, 'onAuthorizationSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
@@ -80,7 +80,7 @@ describe('Custom actions:', function() {
 
     it('executes a custom action when a document is created', function() {
       testHelper.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, undefined, 'onValidationSucceeded');
+      verifyCustomActionExecuted(doc, void 0, 'onValidationSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
@@ -111,7 +111,7 @@ describe('Custom actions:', function() {
 
     it('executes a custom action when a document is created', function() {
       testHelper.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, undefined, 'onAccessAssignmentsSucceeded');
+      verifyCustomActionExecuted(doc, void 0, 'onAccessAssignmentsSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
@@ -146,7 +146,7 @@ describe('Custom actions:', function() {
 
     it('executes a custom action when a document is created', function() {
       testHelper.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, undefined, 'onDocumentChannelAssignmentSucceeded');
+      verifyCustomActionExecuted(doc, void 0, 'onDocumentChannelAssignmentSucceeded');
     });
 
     it('executes a custom action when a document is replaced', function() {
@@ -222,7 +222,7 @@ function verifyAccessAssignmentMetadata(actualMetadata) {
     }
     expect(actualMetadata.accessAssignments).to.eql(expectedAssignments);
   } else {
-    expect(actualMetadata.accessAssignments).to.equal(undefined);
+    expect(actualMetadata.accessAssignments).to.equal(void 0);
   }
 }
 

--- a/test/general-spec.js
+++ b/test/general-spec.js
@@ -31,15 +31,21 @@ describe('Functionality that is common to all documents:', function() {
       }
     });
 
-    it('rejects document deletion with an unrecognized type', function() {
+    it('allows a missing document to be "deleted" even if the type is unrecognized', function() {
       var doc = { _id: 'my-invalid-doc', _deleted: true };
 
-      try {
-        testHelper.syncFunction(doc);
-        expect.fail('Expected unrecognized document violation not thrown');
-      } catch(ex) {
-        expect(ex).to.eql({ forbidden: 'Unknown document type' });
-      }
+      // When deleting a document that does not exist and the document's type cannot be determined, the fallback
+      // behaviour is to allow it to be deleted and assign the public channel to it
+      testHelper.verifyDocumentAccepted(doc, void 0, [ '!' ]);
+    });
+
+    it('allows a deleted document to be deleted again even if the type is unrecognized', function() {
+      var doc = { _id: 'my-invalid-doc', _deleted: true };
+      var oldDoc = { _id: 'my-invalid-doc', _deleted: true };
+
+      // When deleting a document that was already deleted and the document's type cannot be determined, the fallback
+      // behaviour is to allow it to be deleted and assign the public channel to it
+      testHelper.verifyDocumentAccepted(doc, oldDoc, [ '!' ]);
     });
   });
 

--- a/test/hashtable-spec.js
+++ b/test/hashtable-spec.js
@@ -266,7 +266,7 @@ describe('Hashtable validation type', function() {
             '1': 'foo',
             '2': '',
             '3': null,
-            '4': undefined,
+            '4': void 0,
             '5': 13
           }
         };

--- a/test/immutable-docs-spec.js
+++ b/test/immutable-docs-spec.js
@@ -43,7 +43,7 @@ describe('Immutable document validation:', function() {
           _deleted: true
         };
 
-        testHelper.verifyDocumentAccepted(doc, undefined, 'write');
+        testHelper.verifyDocumentAccepted(doc, void 0, 'write');
       });
 
       it('refuses to replace an existing document even if its properties have not been modified', function() {
@@ -201,7 +201,7 @@ describe('Immutable document validation:', function() {
           _deleted: true
         };
 
-        testHelper.verifyDocumentAccepted(doc, undefined, 'write');
+        testHelper.verifyDocumentAccepted(doc, void 0, 'write');
       });
 
       it('refuses to replace an existing document even if its properties have not been modified', function() {
@@ -331,7 +331,7 @@ describe('Immutable document validation:', function() {
           _deleted: true
         };
 
-        testHelper.verifyDocumentAccepted(doc, undefined, 'write');
+        testHelper.verifyDocumentAccepted(doc, void 0, 'write');
       });
 
       it('allows a document to be replaced', function() {

--- a/test/immutable-items-spec.js
+++ b/test/immutable-items-spec.js
@@ -27,7 +27,7 @@ describe('Immutable item validation parameter', function() {
       };
       var oldDoc = {
         _id: 'immutableItemsDoc',
-        staticImmutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], undefined, { foo: 'bar' } ]
+        staticImmutableArrayProp: [ [ 'foobar', 3, false ], [ 45.9 ], [ ], void 0, { foo: 'bar' } ]
       };
 
       testHelper.verifyDocumentReplaced(doc, oldDoc);
@@ -463,7 +463,7 @@ describe('Immutable item validation parameter', function() {
       var doc = {
         _id: 'immutableItemsDoc',
         staticImmutableHashtableProp: {
-          myArrayProp: [ 'foobar', 3, false, 45.9, [ undefined ], { foobar: 18.0 } ],
+          myArrayProp: [ 'foobar', 3, false, 45.9, [ void 0 ], { foobar: 18.0 } ],
           myObjectProp: { foo: 'bar', baz: 73, qux: [ ] }
         }
       };

--- a/test/required-spec.js
+++ b/test/required-spec.js
@@ -89,17 +89,17 @@ describe('Required value constraint', function() {
     it('blocks a doc with top-level values that are undefined', function() {
       var doc = {
         _id: 'staticDoc',
-        stringProp: undefined,
-        integerProp: undefined,
-        floatProp: undefined,
-        booleanProp: undefined,
-        datetimeProp: undefined,
-        dateProp: undefined,
-        enumProp: undefined,
-        attachmentReferenceProp: undefined,
-        arrayProp: undefined,
-        objectProp: undefined,
-        hashtableProp: undefined,
+        stringProp: void 0,
+        integerProp: void 0,
+        floatProp: void 0,
+        booleanProp: void 0,
+        datetimeProp: void 0,
+        dateProp: void 0,
+        enumProp: void 0,
+        attachmentReferenceProp: void 0,
+        arrayProp: void 0,
+        objectProp: void 0,
+        hashtableProp: void 0,
       };
 
       testHelper.verifyDocumentNotCreated(
@@ -131,9 +131,9 @@ describe('Required value constraint', function() {
         dateProp: '2017-04-10',
         enumProp: 2,
         attachmentReferenceProp: 'barfoo.baz',
-        arrayProp: [ undefined ],
-        objectProp: { subProp: undefined },
-        hashtableProp: { 'key': undefined },
+        arrayProp: [ void 0 ],
+        objectProp: { subProp: void 0 },
+        hashtableProp: { 'key': void 0 },
       };
 
       testHelper.verifyDocumentNotCreated(
@@ -213,15 +213,15 @@ describe('Required value constraint', function() {
         _id: 'dynamicDoc',
         dynamicPropsRequired: false,
         stringProp: null,
-        integerProp: undefined,
+        integerProp: void 0,
         floatProp: null,
-        booleanProp: undefined,
+        booleanProp: void 0,
         datetimeProp: null,
-        dateProp: undefined,
+        dateProp: void 0,
         enumProp: null,
-        attachmentReferenceProp: undefined,
+        attachmentReferenceProp: void 0,
         arrayProp: null,
-        objectProp: undefined,
+        objectProp: void 0,
         hashtableProp: null
       };
 
@@ -232,7 +232,7 @@ describe('Required value constraint', function() {
       var doc = {
         _id: 'dynamicDoc',
         arrayProp: [ null ],
-        objectProp: { subProp: undefined },
+        objectProp: { subProp: void 0 },
         hashtableProp: { 'key': null }
       };
 
@@ -305,17 +305,17 @@ describe('Required value constraint', function() {
       var doc = {
         _id: 'dynamicDoc',
         dynamicPropsRequired: true,
-        stringProp: undefined,
-        integerProp: undefined,
-        floatProp: undefined,
-        booleanProp: undefined,
-        datetimeProp: undefined,
-        dateProp: undefined,
-        enumProp: undefined,
-        attachmentReferenceProp: undefined,
-        arrayProp: undefined,
-        objectProp: undefined,
-        hashtableProp: undefined,
+        stringProp: void 0,
+        integerProp: void 0,
+        floatProp: void 0,
+        booleanProp: void 0,
+        datetimeProp: void 0,
+        dateProp: void 0,
+        enumProp: void 0,
+        attachmentReferenceProp: void 0,
+        arrayProp: void 0,
+        objectProp: void 0,
+        hashtableProp: void 0,
       };
 
       testHelper.verifyDocumentNotCreated(
@@ -348,9 +348,9 @@ describe('Required value constraint', function() {
         dateProp: '2017-04-10',
         enumProp: 2,
         attachmentReferenceProp: 'barfoo.baz',
-        arrayProp: [ undefined ],
-        objectProp: { subProp: undefined },
-        hashtableProp: { 'key': undefined },
+        arrayProp: [ void 0 ],
+        objectProp: { subProp: void 0 },
+        hashtableProp: { 'key': void 0 },
       };
 
       testHelper.verifyDocumentNotCreated(

--- a/test/sample-business-spec.js
+++ b/test/sample-business-spec.js
@@ -58,7 +58,7 @@ describe('Sample Business config doc definition', function() {
     verifyBusinessConfigRejected(
       5,
       doc,
-      undefined,
+      void 0,
       [
         errorFormatter.typeConstraintViolation('paymentProcessors', 'array'),
         errorFormatter.typeConstraintViolation('businessLogoAttachment', 'attachmentReference'),

--- a/test/sample-notification-transport-processing-summary-spec.js
+++ b/test/sample-notification-transport-processing-summary-spec.js
@@ -41,7 +41,7 @@ describe('Sample notification transport processing summary doc definition', func
 
     verifyProcessingSummaryNotWritten(
       doc,
-      undefined,
+      void 0,
       [
         errorFormatter.requiredValueViolation('nonce'),
         errorFormatter.typeConstraintViolation('processedBy', 'string'),

--- a/test/sample-payment-attempt-spec.js
+++ b/test/sample-payment-attempt-spec.js
@@ -57,7 +57,7 @@ describe('Sample invoice payment processing attempt doc definition', function() 
     verifyPaymentAttemptNotWritten(
       'my-business',
       doc,
-      undefined,
+      void 0,
       [
         errorFormatter.typeConstraintViolation('businessId', 'integer'),
         errorFormatter.requiredValueViolation('invoiceRecordId'),

--- a/test/sample-payment-processor-settlement-spec.js
+++ b/test/sample-payment-processor-settlement-spec.js
@@ -52,7 +52,7 @@ describe('Sample payment processor settlement doc definition', function() {
     verifySettlementNotWritten(
       'my-business',
       doc,
-      undefined,
+      void 0,
       [
         errorFormatter.maximumValueViolation('businessId', 12345),
         errorFormatter.requiredValueViolation('transferId'),

--- a/test/simple-type-filter-spec.js
+++ b/test/simple-type-filter-spec.js
@@ -1,6 +1,6 @@
 var testHelper = require('../etc/test-helper.js');
 
-describe('Simple type filter', function() {
+describe('Simple type filter:', function() {
   beforeEach(function() {
     testHelper.initSyncFunction('build/sync-functions/test-simple-type-filter-sync-function.js');
   });
@@ -90,7 +90,9 @@ describe('Simple type filter', function() {
         _deleted: true
       };
 
-      testHelper.verifyUnknownDocumentType(doc);
+      // When deleting a document that does not exist and the document's type cannot be determined, the fallback
+      // behaviour is to allow it to be deleted and assign the public channel to it
+      testHelper.verifyDocumentAccepted(doc, void 0, [ '!' ]);
     });
 
     it('cannot identify a deleted document when the old document is also deleted', function() {
@@ -103,7 +105,9 @@ describe('Simple type filter', function() {
         _deleted: true
       };
 
-      testHelper.verifyUnknownDocumentType(doc, oldDoc);
+      // When deleting a document that was already deleted and the document's type cannot be determined, the fallback
+      // behaviour is to allow it to be deleted and assign the public channel to it
+      testHelper.verifyDocumentAccepted(doc, oldDoc, [ '!' ]);
     });
   }
 


### PR DESCRIPTION
To accommodate the special case wherein a Couchbase SDK client deletes a document in a [shared access bucket](https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/shared-bucket-access.html), the sync function now allows documents that do not exist/have already been deleted to be deleted freely, even if the sync function can't determine the document's type. This should be safe since the document that is being deleted does not exist anymore/at all.

Also replaced all uses of the `undefined` global variable with `void 0`. This is the preferred means to get an undefined value in code since the global `undefined` variable can be reassigned ([more info](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void)).

Addresses issue #160.