### PR TITLE
Improve handling of expected errors in test cases

### DIFF
--- a/test/attachment-constraints.spec.js
+++ b/test/attachment-constraints.spec.js
@@ -75,15 +75,21 @@ describe('File attachment constraints:', function() {
             attachmentRefProp: 'bar.html' // The attachmentReference's maximum size of 40 overrides the document's maximum individual size of 25
           };
 
+          var syncFuncError = null;
           expect(function() {
             try {
               testHelper.syncFunction(doc);
             } catch (ex) {
-              testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumTotalAttachmentSizeViolation(40), ex);
+              syncFuncError = ex;
 
               throw ex;
             }
           }).to.throw();
+
+          testHelper.verifyValidationErrors(
+            'staticRegularAttachmentsDoc',
+            errorFormatter.maximumTotalAttachmentSizeViolation(40),
+            syncFuncError);
         });
 
         it('should block replacement when document attachments exceed the limits', function() {
@@ -102,18 +108,21 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
+          var syncFuncError = null;
           expect(function() {
             try {
               testHelper.syncFunction(doc, oldDoc);
             } catch (ex) {
-              testHelper.verifyValidationErrors(
-                'staticRegularAttachmentsDoc',
-                [ errorFormatter.maximumTotalAttachmentSizeViolation(40), errorFormatter.maximumIndividualAttachmentSizeViolation('foo.xml', 25) ],
-                ex);
+              syncFuncError = ex;
 
               throw ex;
             }
           }).to.throw();
+
+          testHelper.verifyValidationErrors(
+            'staticRegularAttachmentsDoc',
+            [ errorFormatter.maximumTotalAttachmentSizeViolation(40), errorFormatter.maximumIndividualAttachmentSizeViolation('foo.xml', 25) ],
+            syncFuncError);
         });
       });
 
@@ -142,15 +151,18 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
+          var syncFuncError = null;
           expect(function() {
             try {
               testHelper.syncFunction(doc);
             } catch (ex) {
-              testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), ex);
+              syncFuncError = ex;
 
               throw ex;
             }
           }).to.throw();
+
+          testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), syncFuncError);
         });
 
         it('should block replacement when document attachments exceed the limit', function() {
@@ -181,15 +193,18 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
+          var syncFuncError = null;
           expect(function() {
             try {
               testHelper.syncFunction(doc, oldDoc);
             } catch (ex) {
-              testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), ex);
+              syncFuncError = ex;
 
               throw ex;
             }
           }).to.throw();
+
+          testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), syncFuncError);
         });
       });
 
@@ -216,21 +231,24 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
+          var syncFuncError = null;
           expect(function() {
             try {
               testHelper.syncFunction(doc);
             } catch (ex) {
-              testHelper.verifyValidationErrors(
-                'staticRegularAttachmentsDoc',
-                [
-                  errorFormatter.supportedExtensionsRawAttachmentViolation('baz.unknown', expectedExtensions),
-                  errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions)
-                ],
-                ex);
+              syncFuncError = ex;
 
               throw ex;
             }
           }).to.throw();
+
+          testHelper.verifyValidationErrors(
+            'staticRegularAttachmentsDoc',
+            [
+              errorFormatter.supportedExtensionsRawAttachmentViolation('baz.unknown', expectedExtensions),
+              errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions)
+            ],
+            syncFuncError);
         });
 
         it('should block replacement when document attachments have unsupported extensions', function() {
@@ -254,18 +272,21 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
+          var syncFuncError = null;
           expect(function() {
             try {
               testHelper.syncFunction(doc, oldDoc);
             } catch (ex) {
-              testHelper.verifyValidationErrors(
-                'staticRegularAttachmentsDoc',
-                errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions),
-                ex);
+              syncFuncError = ex;
 
               throw ex;
             }
           }).to.throw();
+
+          testHelper.verifyValidationErrors(
+            'staticRegularAttachmentsDoc',
+            errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions),
+            syncFuncError);
         });
       });
 
@@ -292,21 +313,24 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
+          var syncFuncError = null;
           expect(function() {
             try {
               testHelper.syncFunction(doc);
             } catch (ex) {
-              testHelper.verifyValidationErrors(
-                'staticRegularAttachmentsDoc',
-                [
-                  errorFormatter.supportedContentTypesRawAttachmentViolation('baz.xml', expectedContentTypes),
-                  errorFormatter.supportedContentTypesRawAttachmentViolation('foo.txt', expectedContentTypes)
-                ],
-                ex);
+              syncFuncError = ex;
 
               throw ex;
             }
           }).to.throw();
+
+          testHelper.verifyValidationErrors(
+            'staticRegularAttachmentsDoc',
+            [
+              errorFormatter.supportedContentTypesRawAttachmentViolation('baz.xml', expectedContentTypes),
+              errorFormatter.supportedContentTypesRawAttachmentViolation('foo.txt', expectedContentTypes)
+            ],
+            syncFuncError);
         });
 
         it('should block replacement when document attachments have unsupported content types', function() {
@@ -330,18 +354,21 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
+          var syncFuncError = null;
           expect(function() {
             try {
               testHelper.syncFunction(doc, oldDoc);
             } catch (ex) {
-              testHelper.verifyValidationErrors(
-                'staticRegularAttachmentsDoc',
-                errorFormatter.supportedContentTypesRawAttachmentViolation('foo.jpg', expectedContentTypes),
-                ex);
+              syncFuncError = ex;
 
               throw ex;
             }
           }).to.throw();
+
+          testHelper.verifyValidationErrors(
+            'staticRegularAttachmentsDoc',
+            errorFormatter.supportedContentTypesRawAttachmentViolation('foo.jpg', expectedContentTypes),
+            syncFuncError);
         });
       });
     });
@@ -380,15 +407,21 @@ describe('File attachment constraints:', function() {
           attachmentRefProp: 'foo.pdf'
         };
 
+        var syncFuncError = null;
         expect(function() {
           try {
             testHelper.syncFunction(doc);
           } catch (ex) {
-            testHelper.verifyValidationErrors('staticAttachmentRefsOnlyDoc', errorFormatter.requireAttachmentReferencesViolation('bar.txt'), ex);
+            syncFuncError = ex;
 
             throw ex;
           }
-        });
+        }).to.throw();
+
+        testHelper.verifyValidationErrors(
+          'staticAttachmentRefsOnlyDoc',
+          errorFormatter.requireAttachmentReferencesViolation('bar.txt'),
+          syncFuncError);
       });
 
       it('should allow replacement when document attachments do not violate the constraint', function() {
@@ -432,15 +465,21 @@ describe('File attachment constraints:', function() {
           type: 'staticAttachmentRefsOnlyDoc'
         };
 
+        var syncFuncError = null;
         expect(function() {
           try {
             testHelper.syncFunction(doc, oldDoc);
           } catch (ex) {
-            testHelper.verifyValidationErrors('staticAttachmentRefsOnlyDoc', errorFormatter.requireAttachmentReferencesViolation('baz.jpg'), ex);
+            syncFuncError = ex;
 
             throw ex;
           }
-        });
+        }).to.throw();
+
+        testHelper.verifyValidationErrors(
+          'staticAttachmentRefsOnlyDoc',
+          errorFormatter.requireAttachmentReferencesViolation('baz.jpg'),
+          syncFuncError);
       });
     });
   });

--- a/test/attachment-constraints.spec.js
+++ b/test/attachment-constraints.spec.js
@@ -75,12 +75,15 @@ describe('File attachment constraints:', function() {
             attachmentRefProp: 'bar.html' // The attachmentReference's maximum size of 40 overrides the document's maximum individual size of 25
           };
 
-          try {
-            testHelper.syncFunction(doc);
-            expect.fail('Expected maximum attachment violation exception not thrown');
-          } catch (ex) {
-            testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumTotalAttachmentSizeViolation(40), ex);
-          }
+          expect(function() {
+            try {
+              testHelper.syncFunction(doc);
+            } catch (ex) {
+              testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumTotalAttachmentSizeViolation(40), ex);
+
+              throw ex;
+            }
+          }).to.throw();
         });
 
         it('should block replacement when document attachments exceed the limits', function() {
@@ -99,15 +102,18 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          try {
-            testHelper.syncFunction(doc, oldDoc);
-            expect.fail('Expected maximum attachment violation exception not thrown');
-          } catch (ex) {
-            testHelper.verifyValidationErrors(
-              'staticRegularAttachmentsDoc',
-              [ errorFormatter.maximumTotalAttachmentSizeViolation(40), errorFormatter.maximumIndividualAttachmentSizeViolation('foo.xml', 25) ],
-              ex);
-          }
+          expect(function() {
+            try {
+              testHelper.syncFunction(doc, oldDoc);
+            } catch (ex) {
+              testHelper.verifyValidationErrors(
+                'staticRegularAttachmentsDoc',
+                [ errorFormatter.maximumTotalAttachmentSizeViolation(40), errorFormatter.maximumIndividualAttachmentSizeViolation('foo.xml', 25) ],
+                ex);
+
+              throw ex;
+            }
+          }).to.throw();
         });
       });
 
@@ -136,12 +142,15 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          try {
-            testHelper.syncFunction(doc);
-            expect.fail('Expected maximum attachment count violation exception not thrown');
-          } catch(ex) {
-            testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), ex);
-          }
+          expect(function() {
+            try {
+              testHelper.syncFunction(doc);
+            } catch (ex) {
+              testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), ex);
+
+              throw ex;
+            }
+          }).to.throw();
         });
 
         it('should block replacement when document attachments exceed the limit', function() {
@@ -172,12 +181,15 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          try {
-            testHelper.syncFunction(doc, oldDoc);
-            expect.fail('Expected maximum attachment count violation exception not thrown');
-          } catch (ex) {
-            testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), ex);
-          }
+          expect(function() {
+            try {
+              testHelper.syncFunction(doc, oldDoc);
+            } catch (ex) {
+              testHelper.verifyValidationErrors('staticRegularAttachmentsDoc', errorFormatter.maximumAttachmentCountViolation(3), ex);
+
+              throw ex;
+            }
+          }).to.throw();
         });
       });
 
@@ -204,18 +216,21 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          try {
-            testHelper.syncFunction(doc);
-            expect.fail('Expected file extension constraint violation not thrown');
-          } catch(ex) {
-            testHelper.verifyValidationErrors(
-              'staticRegularAttachmentsDoc',
-              [
-                errorFormatter.supportedExtensionsRawAttachmentViolation('baz.unknown', expectedExtensions),
-                errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions)
-              ],
-              ex);
-          }
+          expect(function() {
+            try {
+              testHelper.syncFunction(doc);
+            } catch (ex) {
+              testHelper.verifyValidationErrors(
+                'staticRegularAttachmentsDoc',
+                [
+                  errorFormatter.supportedExtensionsRawAttachmentViolation('baz.unknown', expectedExtensions),
+                  errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions)
+                ],
+                ex);
+
+              throw ex;
+            }
+          }).to.throw();
         });
 
         it('should block replacement when document attachments have unsupported extensions', function() {
@@ -239,15 +254,18 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          try {
-            testHelper.syncFunction(doc, oldDoc);
-            expect.fail('Expected file attachment constraint violation not thrown');
-          } catch (ex) {
-            testHelper.verifyValidationErrors(
-              'staticRegularAttachmentsDoc',
-              errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions),
-              ex);
-          }
+          expect(function() {
+            try {
+              testHelper.syncFunction(doc, oldDoc);
+            } catch (ex) {
+              testHelper.verifyValidationErrors(
+                'staticRegularAttachmentsDoc',
+                errorFormatter.supportedExtensionsRawAttachmentViolation('foo.invalid', expectedExtensions),
+                ex);
+
+              throw ex;
+            }
+          }).to.throw();
         });
       });
 
@@ -274,18 +292,21 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          try {
-            testHelper.syncFunction(doc);
-            expect.fail('Expected file extension constraint violation not thrown');
-          } catch(ex) {
-            testHelper.verifyValidationErrors(
-              'staticRegularAttachmentsDoc',
-              [
-                errorFormatter.supportedContentTypesRawAttachmentViolation('baz.xml', expectedContentTypes),
-                errorFormatter.supportedContentTypesRawAttachmentViolation('foo.txt', expectedContentTypes)
-              ],
-              ex);
-          }
+          expect(function() {
+            try {
+              testHelper.syncFunction(doc);
+            } catch (ex) {
+              testHelper.verifyValidationErrors(
+                'staticRegularAttachmentsDoc',
+                [
+                  errorFormatter.supportedContentTypesRawAttachmentViolation('baz.xml', expectedContentTypes),
+                  errorFormatter.supportedContentTypesRawAttachmentViolation('foo.txt', expectedContentTypes)
+                ],
+                ex);
+
+              throw ex;
+            }
+          }).to.throw();
         });
 
         it('should block replacement when document attachments have unsupported content types', function() {
@@ -309,15 +330,18 @@ describe('File attachment constraints:', function() {
             type: 'staticRegularAttachmentsDoc'
           };
 
-          try {
-            testHelper.syncFunction(doc, oldDoc);
-            expect.fail('Expected file extension constraint violation not thrown');
-          } catch(ex) {
-            testHelper.verifyValidationErrors(
-              'staticRegularAttachmentsDoc',
-              errorFormatter.supportedContentTypesRawAttachmentViolation('foo.jpg', expectedContentTypes),
-              ex);
-          }
+          expect(function() {
+            try {
+              testHelper.syncFunction(doc, oldDoc);
+            } catch (ex) {
+              testHelper.verifyValidationErrors(
+                'staticRegularAttachmentsDoc',
+                errorFormatter.supportedContentTypesRawAttachmentViolation('foo.jpg', expectedContentTypes),
+                ex);
+
+              throw ex;
+            }
+          }).to.throw();
         });
       });
     });
@@ -356,12 +380,15 @@ describe('File attachment constraints:', function() {
           attachmentRefProp: 'foo.pdf'
         };
 
-        try {
-          testHelper.syncFunction(doc);
-          expect.fail('Expected attachment constraint violation not thrown');
-        } catch(ex) {
-          testHelper.verifyValidationErrors('staticAttachmentRefsOnlyDoc', errorFormatter.requireAttachmentReferencesViolation('bar.txt'), ex);
-        }
+        expect(function() {
+          try {
+            testHelper.syncFunction(doc);
+          } catch (ex) {
+            testHelper.verifyValidationErrors('staticAttachmentRefsOnlyDoc', errorFormatter.requireAttachmentReferencesViolation('bar.txt'), ex);
+
+            throw ex;
+          }
+        });
       });
 
       it('should allow replacement when document attachments do not violate the constraint', function() {
@@ -405,12 +432,15 @@ describe('File attachment constraints:', function() {
           type: 'staticAttachmentRefsOnlyDoc'
         };
 
-        try {
-          testHelper.syncFunction(doc, oldDoc);
-          expect.fail('Expected attachment constraint violation not thrown');
-        } catch(ex) {
-          testHelper.verifyValidationErrors('staticAttachmentRefsOnlyDoc', errorFormatter.requireAttachmentReferencesViolation('baz.jpg'), ex);
-        }
+        expect(function() {
+          try {
+            testHelper.syncFunction(doc, oldDoc);
+          } catch (ex) {
+            testHelper.verifyValidationErrors('staticAttachmentRefsOnlyDoc', errorFormatter.requireAttachmentReferencesViolation('baz.jpg'), ex);
+
+            throw ex;
+          }
+        });
       });
     });
   });

--- a/test/custom-actions.spec.js
+++ b/test/custom-actions.spec.js
@@ -37,16 +37,18 @@ describe('Custom actions:', function() {
       var unknownDocType = 'foo';
       var doc = { _id: unknownDocType };
 
+      var syncFuncError = null;
       expect(function() {
         try {
           testHelper.syncFunction(doc, expectedAuthorization);
         } catch (ex) {
-          testHelper.verifyValidationErrors(unknownDocType, errorFormatter.unknownDocumentType(), ex);
+          syncFuncError = ex;
 
           throw ex;
         }
       }).to.throw();
 
+      testHelper.verifyValidationErrors(unknownDocType, errorFormatter.unknownDocumentType(), syncFuncError);
       verifyCustomActionNotExecuted();
     });
   });
@@ -169,14 +171,8 @@ describe('Custom actions:', function() {
       testHelper.channel.throwWith(expectedError);
 
       expect(function() {
-        try {
-          testHelper.syncFunction(doc);
-        } catch (ex) {
-          expect(ex).to.equal(expectedError);
-
-          throw ex;
-        }
-      }).to.throw();
+        testHelper.syncFunction(doc);
+      }).to.throw(expectedError);
 
       verifyCustomActionNotExecuted();
     });

--- a/test/custom-actions.spec.js
+++ b/test/custom-actions.spec.js
@@ -37,12 +37,16 @@ describe('Custom actions:', function() {
       var unknownDocType = 'foo';
       var doc = { _id: unknownDocType };
 
-      try {
-        testHelper.syncFunction(doc, expectedAuthorization);
-        expect.fail('Expected error during custom action not thrown');
-      } catch(ex) {
-        testHelper.verifyValidationErrors(unknownDocType, errorFormatter.unknownDocumentType(), ex);
-      }
+      expect(function() {
+        try {
+          testHelper.syncFunction(doc, expectedAuthorization);
+        } catch (ex) {
+          testHelper.verifyValidationErrors(unknownDocType, errorFormatter.unknownDocumentType(), ex);
+
+          throw ex;
+        }
+      }).to.throw();
+
       verifyCustomActionNotExecuted();
     });
   });
@@ -164,12 +168,16 @@ describe('Custom actions:', function() {
       var expectedError = new Error('bad channels!');
       testHelper.channel.throwWith(expectedError);
 
-      try {
-        testHelper.syncFunction(doc);
-        expect.fail('Expected error during custom action not thrown');
-      } catch(ex) {
-        expect(ex).to.equal(expectedError);
-      }
+      expect(function() {
+        try {
+          testHelper.syncFunction(doc);
+        } catch (ex) {
+          expect(ex).to.equal(expectedError);
+
+          throw ex;
+        }
+      }).to.throw();
+
       verifyCustomActionNotExecuted();
     });
   });

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -11,24 +11,30 @@ describe('Functionality that is common to all documents:', function() {
     it('rejects document creation with an unrecognized doc type', function() {
       var doc = { _id: 'my-invalid-doc' };
 
-      try {
-        testHelper.syncFunction(doc);
-        expect.fail('Expected unrecognized document type violation not thrown');
-      } catch(ex) {
-        expect(ex).to.eql({ forbidden: 'Unknown document type' });
-      }
+      expect(function() {
+        try {
+          testHelper.syncFunction(doc);
+        } catch (ex) {
+          expect(ex).to.eql({ forbidden: 'Unknown document type' });
+
+          throw ex;
+        }
+      }).to.throw();
     });
 
     it('rejects document replacement with an unrecognized doc type', function() {
       var doc = { _id: 'my-invalid-doc', foo: 'bar' };
       var oldDoc = { _id: 'my-invalid-doc' };
 
-      try {
-        testHelper.syncFunction(doc, oldDoc);
-        expect.fail('Expected unrecognized document type violation not thrown');
-      } catch(ex) {
-        expect(ex).to.eql({ forbidden: 'Unknown document type' });
-      }
+      expect(function() {
+        try {
+          testHelper.syncFunction(doc, oldDoc);
+        } catch (ex) {
+          expect(ex).to.eql({ forbidden: 'Unknown document type' });
+
+          throw ex;
+        }
+      }).to.throw();
     });
 
     it('allows a missing document to be "deleted" even if the type is unrecognized', function() {
@@ -213,21 +219,24 @@ describe('Functionality that is common to all documents:', function() {
       }
     };
 
-    try {
-      testHelper.syncFunction(doc);
-      expect.fail('Expected whitelisted property error not thrown');
-    } catch(ex) {
-      testHelper.verifyValidationErrors(
-        'generalDoc',
-        [
-          errorFormatter.unsupportedProperty('objectProp._id'),
-          errorFormatter.unsupportedProperty('objectProp._rev'),
-          errorFormatter.unsupportedProperty('objectProp._deleted'),
-          errorFormatter.unsupportedProperty('objectProp._revisions'),
-          errorFormatter.unsupportedProperty('objectProp._attachments')
-        ],
-        ex);
-    }
+    expect(function() {
+      try {
+        testHelper.syncFunction(doc);
+      } catch (ex) {
+        testHelper.verifyValidationErrors(
+          'generalDoc',
+          [
+            errorFormatter.unsupportedProperty('objectProp._id'),
+            errorFormatter.unsupportedProperty('objectProp._rev'),
+            errorFormatter.unsupportedProperty('objectProp._deleted'),
+            errorFormatter.unsupportedProperty('objectProp._revisions'),
+            errorFormatter.unsupportedProperty('objectProp._attachments')
+          ],
+          ex);
+
+        throw ex;
+      }
+    }).to.throw();
   });
 
   it('cannot include attachments in documents that do not explicitly allow them', function() {
@@ -241,11 +250,14 @@ describe('Functionality that is common to all documents:', function() {
       }
     };
 
-    try {
-      testHelper.syncFunction(doc);
-      expect.fail('Expected attachment error not thrown');
-    } catch(ex) {
-      testHelper.verifyValidationErrors('generalDoc', errorFormatter.allowAttachmentsViolation(), ex);
-    }
+    expect(function() {
+      try {
+        testHelper.syncFunction(doc);
+      } catch (ex) {
+        testHelper.verifyValidationErrors('generalDoc', errorFormatter.allowAttachmentsViolation(), ex);
+
+        throw ex;
+      }
+    }).to.throw();
   });
 });

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -11,30 +11,36 @@ describe('Functionality that is common to all documents:', function() {
     it('rejects document creation with an unrecognized doc type', function() {
       var doc = { _id: 'my-invalid-doc' };
 
+      var syncFuncError = null;
       expect(function() {
         try {
           testHelper.syncFunction(doc);
         } catch (ex) {
-          expect(ex).to.eql({ forbidden: 'Unknown document type' });
+          syncFuncError = ex;
 
           throw ex;
         }
       }).to.throw();
+
+      expect(syncFuncError).to.eql({ forbidden: 'Unknown document type' });
     });
 
     it('rejects document replacement with an unrecognized doc type', function() {
       var doc = { _id: 'my-invalid-doc', foo: 'bar' };
       var oldDoc = { _id: 'my-invalid-doc' };
 
+      var syncFuncError = null;
       expect(function() {
         try {
           testHelper.syncFunction(doc, oldDoc);
         } catch (ex) {
-          expect(ex).to.eql({ forbidden: 'Unknown document type' });
+          syncFuncError = ex;
 
           throw ex;
         }
       }).to.throw();
+
+      expect(syncFuncError).to.eql({ forbidden: 'Unknown document type' });
     });
 
     it('allows a missing document to be "deleted" even if the type is unrecognized', function() {
@@ -219,24 +225,27 @@ describe('Functionality that is common to all documents:', function() {
       }
     };
 
+    var syncFuncError = null;
     expect(function() {
       try {
         testHelper.syncFunction(doc);
       } catch (ex) {
-        testHelper.verifyValidationErrors(
-          'generalDoc',
-          [
-            errorFormatter.unsupportedProperty('objectProp._id'),
-            errorFormatter.unsupportedProperty('objectProp._rev'),
-            errorFormatter.unsupportedProperty('objectProp._deleted'),
-            errorFormatter.unsupportedProperty('objectProp._revisions'),
-            errorFormatter.unsupportedProperty('objectProp._attachments')
-          ],
-          ex);
+        syncFuncError = ex;
 
         throw ex;
       }
     }).to.throw();
+
+    testHelper.verifyValidationErrors(
+      'generalDoc',
+      [
+        errorFormatter.unsupportedProperty('objectProp._id'),
+        errorFormatter.unsupportedProperty('objectProp._rev'),
+        errorFormatter.unsupportedProperty('objectProp._deleted'),
+        errorFormatter.unsupportedProperty('objectProp._revisions'),
+        errorFormatter.unsupportedProperty('objectProp._attachments')
+      ],
+      syncFuncError);
   });
 
   it('cannot include attachments in documents that do not explicitly allow them', function() {
@@ -250,14 +259,17 @@ describe('Functionality that is common to all documents:', function() {
       }
     };
 
+    var syncFuncError = null;
     expect(function() {
       try {
         testHelper.syncFunction(doc);
       } catch (ex) {
-        testHelper.verifyValidationErrors('generalDoc', errorFormatter.allowAttachmentsViolation(), ex);
+        syncFuncError = ex;
 
         throw ex;
       }
     }).to.throw();
+
+    testHelper.verifyValidationErrors('generalDoc', errorFormatter.allowAttachmentsViolation(), syncFuncError);
   });
 });

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -16,15 +16,18 @@ describe('Test helper module initialization', function() {
     });
 
     it('fails to load the sync function for a file that does not exist', function() {
+      var syncFuncError = null;
       expect(function() {
         try {
           testHelper.initSyncFunction('build/sync-functions/test-nonexistant-sync-function.js');
         } catch (ex) {
-          expect(ex.code).to.equal('ENOENT');
+          syncFuncError = ex;
 
           throw ex;
         }
       }).to.throw();
+
+      expect(syncFuncError.code).to.equal('ENOENT');
     });
   });
 
@@ -42,15 +45,18 @@ describe('Test helper module initialization', function() {
     });
 
     it('fails to load the sync function for a file that does not exist', function() {
+      var syncFuncError = null;
       expect(function() {
         try {
           testHelper.initDocumentDefinitions('test/resources/nonexistant-doc-definitions.js');
         } catch (ex) {
-          expect(ex.code).to.equal('ENOENT');
+          syncFuncError = ex;
 
           throw ex;
         }
       }).to.throw();
+
+      expect(syncFuncError.code).to.equal('ENOENT');
     });
   });
 });

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -16,12 +16,15 @@ describe('Test helper module initialization', function() {
     });
 
     it('fails to load the sync function for a file that does not exist', function() {
-      try {
-        testHelper.initSyncFunction('build/sync-functions/test-nonexistant-sync-function.js');
-        expect.fail('Expected exception not thrown');
-      } catch(ex) {
-        expect(ex.code).to.equal('ENOENT');
-      }
+      expect(function() {
+        try {
+          testHelper.initSyncFunction('build/sync-functions/test-nonexistant-sync-function.js');
+        } catch (ex) {
+          expect(ex.code).to.equal('ENOENT');
+
+          throw ex;
+        }
+      }).to.throw();
     });
   });
 
@@ -39,12 +42,15 @@ describe('Test helper module initialization', function() {
     });
 
     it('fails to load the sync function for a file that does not exist', function() {
-      try {
-        testHelper.initDocumentDefinitions('test/resources/nonexistant-doc-definitions.js');
-        expect.fail('Expected exception not thrown');
-      } catch (ex) {
-        expect(ex.code).to.equal('ENOENT');
-      }
+      expect(function() {
+        try {
+          testHelper.initDocumentDefinitions('test/resources/nonexistant-doc-definitions.js');
+        } catch (ex) {
+          expect(ex.code).to.equal('ENOENT');
+
+          throw ex;
+        }
+      }).to.throw();
     });
   });
 });


### PR DESCRIPTION
Ensure that, when a test case expects that the sync function will throw an error but no error is encountered, the resulting test failure message will be relevant.

It may be helpful to view the diffs with `?w=1`.