### PR TITLE
Issue 181: Code coverage configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+/.nyc_output
 /node_modules
 /build

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,21 @@
+{
+  "check-coverage": true,
+  "per-file": true,
+  "statements": 90,
+  "branches": 90,
+  "functions": 90,
+  "lines": 0,
+  "include": [
+    "src/**/*.js"
+  ],
+  "exclude": [
+    "src/**/*.spec.js"
+  ],
+  "reporter": [
+    "text-summary",
+    "lcov"
+  ],
+  "cache": true,
+  "all": true,
+  "report-dir": "build/coverage"
+}

--- a/.nycrc
+++ b/.nycrc
@@ -1,9 +1,9 @@
 {
   "check-coverage": true,
   "per-file": true,
-  "statements": 90,
-  "branches": 90,
-  "functions": 90,
+  "statements": 95,
+  "branches": 95,
+  "functions": 100,
   "lines": 0,
   "include": [
     "src/**/*.js"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,10 @@ Files in the project are organized into the following directories:
 * `/`: Reserved for project configuration files (e.g. `.gitignore`, `.travis.yml`, `package.json`), documentation (e.g. `README.md`, `CHANGELOG.md`, `LICENSE`) and executable command line scripts that are part of the package's public interface (e.g. `make-sync-function`, `validate-document-definitions`).
 * `etc`: Any development script or other type of file that is not part of the package's public interface (e.g. build scripts).
 * `lib`: Reserved for external packages (i.e. libraries) to be embedded as static dependencies in the project.
-* `samples`: A collection of document definitions that are purely for example purposes. Specifications for these document definitions are stored in the top level `test` directory.
-* `src`: JavaScript code that is executable by Node.js. Specifications should be stored in files alongside the code under test in this directory.
-* `templates`: JavaScript templates for sync functions/document definitions. Notably, the code in this directory is _not_ intended to be executable by Node.js. Specifications are stored in the top level `test` directory.
-* `test`: Test cases for document definition configuration elements from the top level `templates` directory and example document definitions from the top level `samples` directory.
+* `samples`: A collection of document definitions that are purely for example purposes. Specifications for these document definitions are stored in the top level `test` directory. Code must be written to the **ECMAScript 3** specification for compatibility with Sync Gateway.
+* `src`: JavaScript code that is executable by Node.js. Specifications should be stored in files alongside the code under test in this directory. Code must be written to the **ECMAScript 5** specification for backward compatibility with previous versions of Node.js.
+* `templates`: JavaScript templates for sync functions/document definitions. Notably, the code in this directory is _not_ intended to be executable by Node.js. Specifications are stored in the top level `test` directory. Code must be written to the **ECMAScript 3** specification for compatibility with Sync Gateway.
+* `test`: Test cases for document definition configuration elements from the top level `templates` directory and example document definitions from the top level `samples` directory. Code must be written to the **ECMAScript 5** specification for backward compatibility with previous versions of Node.js.
 
 ### Commits
 
@@ -51,7 +51,7 @@ Every change should include comprehensive test cases. There are two different ca
 
 In either case, specification files must be denoted by the `.spec.js` filename suffix to be executed by the [Mocha](http://mochajs.org/) test runner. Test cases should use the [Chai](http://chaijs.com/) assertion library's [expect](http://chaijs.com/api/bdd/) assertion style.
 
-To execute the full test suite and lint the project's JS files with JSHint, run `npm test` from the project's root directory.
+To execute the full test suite and lint the project's JS files with JSHint, run `npm test` from the project's root directory. A detailed, human-readable code coverage report is generated at `build/coverage/lcov-report/index.html`.
 
 ### Documentation
 
@@ -59,7 +59,7 @@ The project includes comprehensive end user documentation and, to ensure it stay
 
 Bugs do not generally need to be documented in `README.md` unless there is some caveat that users should be aware of. For example, the need to double-escape backslashes in document definitions for older versions of Sync Gateway (see sync_gateway issue [#1866](https://github.com/couchbase/sync_gateway/issues/1866)).
 
-In either case, include an entry for each change in `CHANGELOG.md`'s "Unreleased" section according to the guidelines at [Keep a CHANGELOG](http://keepachangelog.com).
+In either case, include an entry for each change in `CHANGELOG.md`'s "Unreleased" section according to the guidelines at [Keep a Changelog](http://keepachangelog.com).
 
 ### Example document definitions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,6 +350,1600 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nyc": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
+      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+      "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.1",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.9.1",
+        "istanbul-lib-report": "1.1.2",
+        "istanbul-lib-source-maps": "1.2.2",
+        "istanbul-reports": "1.1.3",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.4",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "4.1.1",
+        "yargs": "10.0.3",
+        "yargs-parser": "8.0.0"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "semver": "5.4.1"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.11"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "which": "1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.0.0"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "8.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "chai": "^4.1.2",
     "jshint": "^2.9.5",
     "mocha": "^5.0.0",
-    "mock-require": "^3.0.1"
+    "mock-require": "^3.0.1",
+    "nyc": "^11.4.1"
   },
   "scripts": {
-    "test": "etc/prepare-tests.sh && node_modules/.bin/mocha **/*.spec.js",
-    "test-report": "etc/prepare-tests.sh && node_modules/.bin/mocha -R xunit **/*.spec.js > build/test-reports/synctos.xml"
+    "test": "etc/prepare-tests.sh && nyc mocha **/*.spec.js",
+    "test-report": "etc/prepare-tests.sh && nyc mocha -R xunit **/*.spec.js > build/test-reports/synctos.xml"
   },
   "license": "MIT",
   "repository": {

--- a/src/document-definition-properties-validator.spec.js
+++ b/src/document-definition-properties-validator.spec.js
@@ -27,6 +27,9 @@ describe('Document definition properties validator', function() {
       enumTypeProp: {
         type: 'enum'
       },
+      uuidTypeProp: {
+        type: 'uuid'
+      },
       attachmentReferenceTypeProp: {
         type: 'attachmentReference'
       },

--- a/src/document-definitions-shell-maker.js
+++ b/src/document-definitions-shell-maker.js
@@ -21,14 +21,7 @@ function createShell(docDefinitionsString, originalFilename) {
     displayErrors: true
   };
 
-  var shellTemplateString;
-  try {
-    shellTemplateString = fs.readFileSync(path.resolve(__dirname, '../templates/document-definitions-shell-template.js'), 'utf8').trim();
-  } catch (ex) {
-    console.log('ERROR: Unable to read the document definitions shell template: ' + ex);
-
-    throw ex;
-  }
+  var shellTemplateString = fs.readFileSync(path.resolve(__dirname, '../templates/document-definitions-shell-template.js'), 'utf8').trim();
 
   // The test helper environment includes a placeholder string called "%DOC_DEFINITIONS_PLACEHOLDER%" that is to be replaced with the
   // contents of the document definitions

--- a/src/document-definitions-shell-maker.spec.js
+++ b/src/document-definitions-shell-maker.spec.js
@@ -22,16 +22,21 @@ describe('Document definitions shell maker', function() {
     mockRequire.stopAll();
   });
 
-  function verifyParse(expectedFileContents, originalFilename) {
-    fsMock.readFileSync.returnWith(expectedFileContents);
+  function verifyParse(rawDocumentDefinitions, originalFilename) {
+    var shellTemplateFileContents = 'template: %DOC_DEFINITIONS_PLACEHOLDER%';
+    fsMock.readFileSync.returnWith(shellTemplateFileContents);
+
+    var expectedShellString = shellTemplateFileContents.replace(
+      '%DOC_DEFINITIONS_PLACEHOLDER%',
+      function() { return rawDocumentDefinitions; });
 
     var expectedResult = { foo: 'bar' };
-    var mockEnvironment = simpleMock.stub();
-    mockEnvironment.returnWith(expectedResult);
+    var mockVmEnvironment = simpleMock.stub();
+    mockVmEnvironment.returnWith(expectedResult);
 
-    vmMock.runInThisContext.returnWith(mockEnvironment);
+    vmMock.runInThisContext.returnWith(mockVmEnvironment);
 
-    var result = environmentShellMaker.createShell(expectedFileContents, originalFilename);
+    var result = environmentShellMaker.createShell(rawDocumentDefinitions, originalFilename);
 
     expect(result).to.eql(expectedResult);
 
@@ -40,21 +45,21 @@ describe('Document definitions shell maker', function() {
 
     expect(vmMock.runInThisContext.callCount).to.equal(1);
     expect(vmMock.runInThisContext.calls[0].args).to.eql([
-      '(' + expectedFileContents + ');',
+      '(' + expectedShellString + ');',
       {
         filename: originalFilename,
         displayErrors: true
       }
     ]);
 
-    expect(mockEnvironment.callCount).to.equal(1);
+    expect(mockVmEnvironment.callCount).to.equal(1);
   }
 
   it('creates a shell from the input with a filename for stack traces', function() {
-    verifyParse('my-doc-definitions1', 'my-original-filename');
+    verifyParse('my-doc-definitions-1', 'my-original-filename');
   });
 
   it('creates a shell from the input but without a filename', function() {
-    verifyParse('my-doc-definitions2');
+    verifyParse('my-doc-definitions-2');
   });
 });

--- a/src/file-fragment-loader.spec.js
+++ b/src/file-fragment-loader.spec.js
@@ -20,7 +20,7 @@ describe('File fragment loader', function() {
   it('should replace instances of the macro with the correct file contents', function() {
     var baseDir = '/my/base/dir';
     var macroName = 'myFileFragmentMacro';
-    var rawText = 'doSomething();\nnotmyFileFragmentMacro("foo.js");myFileFragmentMacro("bar.js");\tmyFileFragmentMacro(\'baz.js\');';
+    var rawText = 'doSomething();\nnotmyFileFragmentMacro("foo.js");myFileFragmentMacro("bar.js");\tmyFileFragmentMacro(\'foo\\ baz.js\');';
 
     var fileFragment1Contents = ' somethingElseGoesHere()\n';
     var fileFragment2Contents = '\nyetAnotherThingHere(\'qux\') ';
@@ -36,8 +36,8 @@ describe('File fragment loader', function() {
 
     expect(fsMock.readFileSync.callCount).to.equal(3);
     expect(fsMock.readFileSync.calls[0].args).to.eql([ baseDir + '/bar.js', 'utf8' ]);
-    expect(fsMock.readFileSync.calls[1].args).to.eql([ baseDir + '/baz.js', 'utf8' ]);
-    expect(fsMock.readFileSync.calls[2].args).to.eql([ 'baz.js', 'utf8' ]);
+    expect(fsMock.readFileSync.calls[1].args).to.eql([ baseDir + '/foo baz.js', 'utf8' ]);
+    expect(fsMock.readFileSync.calls[2].args).to.eql([ 'foo baz.js', 'utf8' ]);
   });
 
   it('should throw an exception if the file fragment cannot be found', function() {

--- a/src/test-environment-maker.js
+++ b/src/test-environment-maker.js
@@ -18,14 +18,7 @@ function init(rawSyncFunction, syncFunctionFile) {
     displayErrors: true
   };
 
-  var environmentTemplate;
-  try {
-    environmentTemplate = fs.readFileSync(path.resolve(__dirname, '../templates/test-environment-template.js'), 'utf8').trim();
-  } catch (ex) {
-    console.log('ERROR: Unable to read the test environment template: ' + ex);
-
-    throw ex;
-  }
+  var environmentTemplate = fs.readFileSync(path.resolve(__dirname, '../templates/test-environment-template.js'), 'utf8').trim();
 
   // The test environment includes a placeholder string called "%SYNC_FUNC_PLACEHOLDER%" that is to be replaced with the contents of
   // the sync function

--- a/src/test-helper.spec.js
+++ b/src/test-helper.spec.js
@@ -1,0 +1,304 @@
+var expect = require('chai').expect;
+var simpleMock = require('../lib/simple-mock/index');
+var mockRequire = require('mock-require');
+
+describe('Test helper:', function() {
+  var testHelper, fsMock, syncFunctionLoaderMock, testEnvironmentMakerMock, fakeTestEnvironment;
+
+  var fakeFilePath = 'my-file-path';
+  var fakeSyncFunctionContents = 'my-sync-function';
+
+  beforeEach(function() {
+    fakeTestEnvironment = {
+      _: simpleMock.stub(),
+      requireAccess: simpleMock.stub(),
+      requireRole: simpleMock.stub(),
+      requireUser: simpleMock.stub(),
+      channel: simpleMock.stub(),
+      access: simpleMock.stub(),
+      role: simpleMock.stub(),
+      customActionStub: simpleMock.stub(),
+      syncFunction: simpleMock.stub()
+    };
+
+    // Stub out the "require" calls in the module under test
+    fsMock = { readFileSync: simpleMock.stub() };
+    fsMock.readFileSync.returnWith(fakeSyncFunctionContents);
+    mockRequire('fs', fsMock);
+
+    syncFunctionLoaderMock = { load: simpleMock.stub() };
+    syncFunctionLoaderMock.load.returnWith(fakeSyncFunctionContents);
+    mockRequire('./sync-function-loader', syncFunctionLoaderMock);
+
+    testEnvironmentMakerMock = { init: simpleMock.stub() };
+    testEnvironmentMakerMock.init.returnWith(fakeTestEnvironment);
+    mockRequire('./test-environment-maker', testEnvironmentMakerMock);
+
+    testHelper = mockRequire.reRequire('./test-helper');
+  });
+
+  afterEach(function() {
+    mockRequire.stopAll();
+  });
+
+  describe('when initializing a test environment', function() {
+    it('can initialize from a sync function', function() {
+      fsMock.readFileSync.returnWith(fakeSyncFunctionContents);
+
+      testHelper.initSyncFunction(fakeFilePath);
+
+      expect(fsMock.readFileSync.callCount).to.equal(1);
+      expect(fsMock.readFileSync.calls[0].args).to.eql([ fakeFilePath, 'utf8' ]);
+
+      expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, fakeFilePath ]);
+
+      verifyTestEnvironment();
+    });
+
+    it('can initialize directly from document definitions', function() {
+      syncFunctionLoaderMock.load.returnWith(fakeSyncFunctionContents);
+
+      testHelper.initDocumentDefinitions(fakeFilePath);
+
+      expect(syncFunctionLoaderMock.load.callCount).to.equal(1);
+      expect(syncFunctionLoaderMock.load.calls[0].args).to.eql([ fakeFilePath ]);
+
+      expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, void 0 ]);
+
+      verifyTestEnvironment();
+    });
+
+    function verifyTestEnvironment() {
+      expect(testHelper.requireAccess).to.equal(fakeTestEnvironment.requireAccess);
+      expect(testHelper.requireRole).to.equal(fakeTestEnvironment.requireRole);
+      expect(testHelper.requireUser).to.equal(fakeTestEnvironment.requireUser);
+      expect(testHelper.channel).to.equal(fakeTestEnvironment.channel);
+      expect(testHelper.access).to.equal(fakeTestEnvironment.access);
+      expect(testHelper.role).to.equal(fakeTestEnvironment.role);
+      expect(testHelper.customActionStub).to.equal(fakeTestEnvironment.customActionStub);
+      expect(testHelper.syncFunction).to.equal(fakeTestEnvironment.syncFunction);
+    }
+  });
+
+  describe('when verifying that document authorization is denied', function() {
+    beforeEach(function() {
+      testHelper.initDocumentDefinitions(fakeFilePath);
+    });
+
+    it('fails if it encounters a required channel that was not expected', function() {
+      var actualChannels = [ 'my-channel-1', 'my-channel-2' ];
+      var expectedChannels = [ 'my-channel-1' ];
+
+      testHelper.syncFunction = function() {
+        testHelper.requireAccess(actualChannels);
+      };
+
+      expect(function() {
+        testHelper.verifyAccessDenied({ }, void 0, expectedChannels);
+      }).to.throw('Unexpected channel encountered: my-channel-2');
+    });
+
+    it('fails if it does not encounter a channel that was expected', function() {
+      var actualChannels = [ 'my-channel-1' ];
+      var expectedChannels = [ 'my-channel-1', 'my-channel-2' ];
+
+      testHelper.syncFunction = function() {
+        testHelper.requireAccess(actualChannels);
+      };
+
+      expect(function() {
+        testHelper.verifyAccessDenied({ }, void 0, expectedChannels);
+      }).to.throw('Expected channel was not encountered: my-channel-2');
+    });
+
+    it('fails if the sync function does not throw an error', function() {
+      testHelper.syncFunction = function() { };
+
+      expect(function() {
+        testHelper.verifyAccessDenied({ }, void 0, [ ]);
+      }).to.throw('Document authorization succeeded when it was expected to fail');
+    });
+
+    it('succeeds if there are no expected channels, roles or users allowed', function() {
+      testHelper.syncFunction = function() {
+        testHelper.requireAccess([ ]);
+      };
+
+      expect(function() {
+        testHelper.verifyAccessDenied({ }, void 0, { });
+      }).not.to.throw();
+    });
+  });
+
+  describe('when verifying that a document type is unknown', function() {
+    beforeEach(function() {
+      testHelper.initDocumentDefinitions(fakeFilePath);
+    });
+
+    it('fails if the document type is recognized', function() {
+      testHelper.syncFunction = function() { };
+
+      expect(function() {
+        testHelper.verifyUnknownDocumentType({ });
+      }).to.throw('Document type was successfully identified when it was expected to be unknown');
+    });
+  });
+
+  describe('when verifying that document contents are invalid', function() {
+    beforeEach(function() {
+      testHelper.initDocumentDefinitions(fakeFilePath);
+    });
+
+    it('fails if the sync function does not throw an error', function() {
+      testHelper.syncFunction = function() { };
+
+      expect(function() {
+        testHelper.verifyDocumentRejected({ }, void 0, 'my-doc-type', [ ], { });
+      }).to.throw('Document validation succeeded when it was expected to fail');
+    });
+
+    it('fails if the validation error message format is invalid', function() {
+      var errorMessage = 'Foo: bar';
+
+      testHelper.syncFunction = function() {
+        throw { forbidden: errorMessage };
+      };
+
+      expect(function() {
+        testHelper.verifyDocumentRejected({ }, void 0, 'my-doc-type', [ ], { });
+      }).to.throw('Unrecognized document validation error message format: "' + errorMessage + '"');
+    });
+
+    it('fails if an expected validation error is missing', function() {
+      var docType = 'my-doc-type';
+      var expectedErrors = [ 'my-error-1', 'my-error-2' ];
+      var errorMessage = 'Invalid ' + docType + ' document: ' + expectedErrors[0];
+
+      testHelper.syncFunction = function() {
+        throw { forbidden: errorMessage };
+      };
+
+      expect(function() {
+        testHelper.verifyDocumentRejected({ }, void 0, docType, expectedErrors, { });
+      }).to.throw('Document validation errors do not include expected error message: "' + expectedErrors[1] + '". Actual error: ' + errorMessage);
+    });
+
+    it('fails if an unexpected validation error is encountered', function() {
+      var docType = 'my-doc-type';
+      var actualErrors = [ 'my-error-1', 'my-error-2' ];
+      var expectedErrors = [ actualErrors[0] ];
+      var errorMessage = 'Invalid ' + docType + ' document: ' + actualErrors[0] + '; ' + actualErrors[1];
+
+      testHelper.syncFunction = function() {
+        throw { forbidden: errorMessage };
+      };
+
+      expect(function() {
+        testHelper.verifyDocumentRejected({ }, void 0, docType, expectedErrors, { });
+      }).to.throw('Unexpected document validation error: "' + actualErrors[1] + '"');
+    });
+  });
+
+  describe('when verifying that document contents are correct', function() {
+    beforeEach(function() {
+      testHelper.initDocumentDefinitions(fakeFilePath);
+    });
+
+    it('fails if the channel assignment function was not called', function() {
+      testHelper.syncFunction = function() {
+        testHelper.requireAccess([ ]);
+      };
+
+      expect(function() {
+        testHelper.verifyDocumentAccepted({ }, void 0, [ ]);
+      }).to.throw('Document channels were not assigned');
+    });
+  });
+
+  describe('when verifying access assignments', function() {
+    beforeEach(function() {
+      testHelper.initDocumentDefinitions(fakeFilePath);
+    });
+
+    it('fails if a different set of channel access is assigned than what was expected', function() {
+      var actualChannels = [ 'my-channel-1' ];
+      var expectedChannelAccessAssignment = {
+        expectedType: 'channel',
+        expectedRoles: [ 'my-role-1' ],
+        foo: [ 'bar' ] // This should be ignored
+      };
+      var expectedEffectiveRoles = expectedChannelAccessAssignment.expectedRoles.map(function(role) { return 'role:' + role; });
+
+      testHelper.syncFunction = function() {
+        testHelper.access(expectedEffectiveRoles, actualChannels);
+      };
+
+      expect(function() {
+        testHelper.verifyDocumentAccepted({ }, void 0, [ ], [ expectedChannelAccessAssignment ]);
+      }).to.throw('Missing expected call to assign channel access (' +
+        JSON.stringify([ ]) +
+        ') to users and roles (' +
+        JSON.stringify(expectedEffectiveRoles) +
+        ')');
+    });
+
+    it('fails if a different set of role access is assigned than what was expected', function() {
+      var expectedRoleAccessAssignment = {
+        expectedType: 'role',
+        expectedRoles: [ 'my-role-1', 'my-role-2' ],
+        expectedUsers: [ 'my-user-1', 'my-user-2', 'my-user-3' ]
+      };
+      var expectedEffectiveRoles = expectedRoleAccessAssignment.expectedRoles.map(function(role) { return 'role:' + role; });
+      var actualUsers = [ 'my-user-1', 'my-user-2', 'my-user-2' ];
+
+      testHelper.syncFunction = function() {
+        testHelper.role(actualUsers, expectedEffectiveRoles);
+      };
+
+      expect(function() {
+        testHelper.verifyDocumentAccepted({ }, void 0, [ ], [ expectedRoleAccessAssignment ]);
+      }).to.throw(
+        'Missing expected call to assign role access (' +
+        JSON.stringify(expectedEffectiveRoles) +
+        ') to users (' +
+        JSON.stringify(expectedRoleAccessAssignment.expectedUsers) +
+        ')');
+    });
+
+    it('fails if there is a call to assign channel access when none is expected', function() {
+      testHelper.syncFunction = function() {
+        testHelper.access();
+      };
+
+      expect(function() {
+        testHelper.verifyDocumentAccepted({ }, void 0, [ ], [ ]);
+      }).to.throw('Number of calls to assign channel access (1) does not match expected (0)');
+    });
+
+    it('fails if there is a call to assign role access when none is expected', function() {
+      testHelper.syncFunction = function() {
+        testHelper.role();
+      };
+
+      expect(function() {
+        testHelper.verifyDocumentAccepted({ }, void 0, [ ], [ ]);
+      }).to.throw('Number of calls to assign role access (1) does not match expected (0)');
+    });
+
+    it('fails if there is an unrecognized access assignment type', function() {
+      var expectedInvalidAccessAssignment = {
+        expectedType: 'invalid-type',
+        expectedRoles: [ 'my-role-1' ],
+        expectedUsers: [ 'my-user-1' ]
+      };
+
+      testHelper.syncFunction = function() { };
+
+      expect(function() {
+        testHelper.verifyDocumentAccepted({ }, void 0, [ ], [ expectedInvalidAccessAssignment ]);
+      }).to.throw('Unrecognized expected access assignment type ("' + expectedInvalidAccessAssignment.expectedType + '")');
+    });
+  });
+});

--- a/src/validation-error-formatter.js
+++ b/src/validation-error-formatter.js
@@ -390,6 +390,8 @@ function getTypeDescription(type) {
       return 'an object';
     case 'string':
       return 'a string';
+
+    /* istanbul ignore next */
     default:
       throw new Error('Unrecognized validation type: ' + type);
   }

--- a/src/validation-error-formatter.js
+++ b/src/validation-error-formatter.js
@@ -293,9 +293,7 @@ exports.supportedContentTypesAttachmentReferenceViolation = function(itemPath, e
  *                                        Element order must match that set in the validator in the document definition.
  */
 exports.supportedContentTypesRawAttachmentViolation = function(attachmentName, expectedContentTypes) {
-  var contentTypesString = expectedContentTypes.join(',');
-
-  return 'attachment "' + attachmentName + '" must have a supported content type (' + contentTypesString + ')';
+  return 'attachment "' + attachmentName + '" must have a supported content type (' + expectedContentTypes + ')';
 };
 
 /**
@@ -306,9 +304,7 @@ exports.supportedContentTypesRawAttachmentViolation = function(attachmentName, e
  *                                          Element order must match that set in the validator in the document definition.
  */
 exports.supportedExtensionsAttachmentReferenceViolation = function(itemPath, expectedFileExtensions) {
-  var extensionsString = expectedFileExtensions.join(',');
-
-  return 'attachment reference "' + itemPath + '" must have a supported file extension (' + extensionsString + ')';
+  return 'attachment reference "' + itemPath + '" must have a supported file extension (' + expectedFileExtensions + ')';
 };
 
 /**
@@ -349,7 +345,7 @@ exports.unknownDocumentType = function() {
 };
 
 /**
- * Formats a message for the error that occurs when an unrecognized property is discovered on at the root level of a document or in an
+ * Formats a message for the error that occurs when an unrecognized property is discovered at the root level of a document or in an
  * object nested in a document.
  *
  * @param {string} propertyPath The full path of the property or element in which the error occurs
@@ -364,8 +360,8 @@ exports.unsupportedProperty = function(propertyPath) {
  *
  * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "objectProp.arrayProp[10].uuidProp")
  */
-exports.uuidFormatInvalid = function(propertyPath) {
-  return 'item "' + propertyPath + '" is not a valid UUID';
+exports.uuidFormatInvalid = function(itemPath) {
+  return 'item "' + itemPath + '" is not a valid UUID';
 };
 
 function getTypeDescription(type) {
@@ -380,6 +376,8 @@ function getTypeDescription(type) {
       return 'an ISO 8601 date string with no time or time zone components';
     case 'datetime':
       return 'an ISO 8601 date string with optional time and time zone components';
+    case 'enum':
+      return 'an integer or a string';
     case 'float':
       return 'a floating point or integer number';
     case 'hashtable':
@@ -390,8 +388,8 @@ function getTypeDescription(type) {
       return 'an object';
     case 'string':
       return 'a string';
-
-    /* istanbul ignore next */
+    case 'uuid':
+      return 'a string';
     default:
       throw new Error('Unrecognized validation type: ' + type);
   }

--- a/src/validation-error-formatter.spec.js
+++ b/src/validation-error-formatter.spec.js
@@ -1,0 +1,238 @@
+var expect = require('chai').expect;
+var errorFormatter = require('./validation-error-formatter');
+
+describe('Validation error formatter', function() {
+  describe('at the document level', function() {
+    it('produces allowAttachments violation messages', function() {
+      expect(errorFormatter.allowAttachmentsViolation()).to.equal('document type does not support attachments');
+    });
+
+    it('produces cannotDelete violation messages', function() {
+      expect(errorFormatter.cannotDeleteDocViolation()).to.equal('documents of this type cannot be deleted');
+    });
+
+    it('produces cannotReplace violation messages', function() {
+      expect(errorFormatter.cannotReplaceDocViolation()).to.equal('documents of this type cannot be replaced');
+    });
+
+    it('produces immutable violation messages', function() {
+      expect(errorFormatter.immutableDocViolation()).to.equal('documents of this type cannot be replaced or deleted');
+    });
+
+    it('produces maximumAttachmentCount violation messages', function() {
+      var maximumAttachmentCount = 2;
+      expect(errorFormatter.maximumAttachmentCountViolation(maximumAttachmentCount))
+        .to.equal('the total number of attachments must not exceed ' + maximumAttachmentCount);
+    });
+
+    it('produces attachments maximumIndividualSize violation messages', function() {
+      var fileName = 'my-attachment-file.jpg';
+      var maximumAttachmentSize = 2;
+      expect(errorFormatter.maximumIndividualAttachmentSizeViolation(fileName, maximumAttachmentSize))
+        .to.equal('attachment ' + fileName + ' must not exceed ' + maximumAttachmentSize + ' bytes');
+    });
+
+    it('produces attachments maximumTotalSize violation messages', function() {
+      var maximumSize = 2;
+      expect(errorFormatter.maximumTotalAttachmentSizeViolation(maximumSize))
+        .to.equal('the total size of all attachments must not exceed ' + maximumSize + ' bytes');
+    });
+
+    it('produces requireAttachmentReferences violation messages', function() {
+      var fileName = 'my-attachment-file.txt';
+      expect(errorFormatter.requireAttachmentReferencesViolation(fileName))
+        .to.equal('attachment ' + fileName + ' must have a corresponding attachment reference property');
+    });
+
+    it('produces attachments supportedContentTypes violation messages', function() {
+      var fileName = 'my-attachment-file.svg';
+      var contentTypes = [ 'image/png' ];
+      expect(errorFormatter.supportedContentTypesRawAttachmentViolation(fileName, contentTypes))
+        .to.equal('attachment "' + fileName + '" must have a supported content type (' + contentTypes + ')');
+    });
+
+    it('produces attachments supportedExtensions violation messages', function() {
+      var fileName = 'my-attachment-file.jpg';
+      var extensions = [ 'png' ];
+      expect(errorFormatter.supportedExtensionsRawAttachmentViolation(fileName, extensions))
+        .to.equal('attachment "' + fileName + '" must have a supported file extension (' + extensions + ')');
+    });
+
+    it('produces an unknown document type message', function() {
+      expect(errorFormatter.unknownDocumentType()).to.equal('Unknown document type');
+    });
+  });
+
+  describe('at the property/element level', function() {
+    var fakeItemPath = 'my.fake[item]';
+
+    it('produces invalid date format messages', function() {
+      expect(errorFormatter.dateFormatInvalid(fakeItemPath))
+        .to.equal('item "' + fakeItemPath + '" must be an ISO 8601 date string with no time or time zone components');
+    });
+
+    it('produces invalid date/time format messages', function() {
+      expect(errorFormatter.datetimeFormatInvalid(fakeItemPath))
+        .to.equal('item "' + fakeItemPath + '" must be an ISO 8601 date string with optional time and time zone components');
+    });
+
+    it('produces invalid enum value messages', function() {
+      var fakeEnumValues = [ 'foo', 'bar', -5 ];
+      expect(errorFormatter.enumPredefinedValueViolation(fakeItemPath, fakeEnumValues))
+        .to.equal('item "' + fakeItemPath + '" must be one of the predefined values: ' + fakeEnumValues.join(','));
+    });
+
+    it('produces empty hashtable key violation messages', function() {
+      expect(errorFormatter.hashtableKeyEmpty(fakeItemPath))
+        .to.equal('empty hashtable key in item "' + fakeItemPath + '" is not allowed');
+    });
+
+    it('produces hashtable maximumSize violation messages', function() {
+      var maximumSize = 8;
+      expect(errorFormatter.hashtableMaximumSizeViolation(fakeItemPath, maximumSize))
+        .to.equal('hashtable "' + fakeItemPath + '" must not be larger than ' + maximumSize + ' elements');
+    });
+
+    it('produces hashtable minimumSize violation messages', function() {
+      var minimumSize = 1;
+      expect(errorFormatter.hashtableMinimumSizeViolation(fakeItemPath, minimumSize))
+        .to.equal('hashtable "' + fakeItemPath + '" must not be smaller than ' + minimumSize + ' elements');
+    });
+
+    it('produces immutable value violation messages', function() {
+      expect(errorFormatter.immutableItemViolation(fakeItemPath)).to.equal('value of item "' + fakeItemPath + '" may not be modified');
+    });
+
+    it('produces maximumLength violation messages', function() {
+      var maximumLength = 1;
+      expect(errorFormatter.maximumLengthViolation(fakeItemPath, maximumLength))
+        .to.equal('length of item "' + fakeItemPath + '" must not be greater than ' + maximumLength);
+    });
+
+    it('produces attachment reference maximumSize violation messages', function() {
+      var maximumSize = 1;
+      expect(errorFormatter.maximumSizeAttachmentViolation(fakeItemPath, maximumSize))
+        .to.equal('attachment reference "' + fakeItemPath + '" must not be larger than ' + maximumSize + ' bytes');
+    });
+
+    it('produces maximumValue violation messages', function() {
+      var maximumValue = 1;
+      expect(errorFormatter.maximumValueViolation(fakeItemPath, maximumValue))
+        .to.equal('item "' + fakeItemPath + '" must not be greater than ' + maximumValue);
+    });
+
+    it('produces maximumValueExclusive violation messages', function() {
+      var maximumValue = 1;
+      expect(errorFormatter.maximumValueExclusiveViolation(fakeItemPath, maximumValue))
+        .to.equal('item "' + fakeItemPath + '" must not be greater than or equal to ' + maximumValue);
+    });
+
+    it('produces minimumLength violation messages', function() {
+      var minimumLength = 1;
+      expect(errorFormatter.minimumLengthViolation(fakeItemPath, minimumLength))
+        .to.equal('length of item "' + fakeItemPath + '" must not be less than ' + minimumLength);
+    });
+
+    it('produces minimumValue violation messages', function() {
+      var minimumValue = 1;
+      expect(errorFormatter.minimumValueViolation(fakeItemPath, minimumValue))
+        .to.equal('item "' + fakeItemPath + '" must not be less than ' + minimumValue);
+    });
+
+    it('produces minimumValueExclusive violation messages', function() {
+      var minimumValue = 1;
+      expect(errorFormatter.minimumValueExclusiveViolation(fakeItemPath, minimumValue))
+        .to.equal('item "' + fakeItemPath + '" must not be less than or equal to ' + minimumValue);
+    });
+
+    it('produces mustEqual violation messages', function() {
+      var value = { foo: [ 'bar' ] };
+      expect(errorFormatter.mustEqualViolation(fakeItemPath, value))
+        .to.equal('value of item "' + fakeItemPath + '" must equal ' + JSON.stringify(value));
+    });
+
+    it('produces mustNotBeEmpty violation messages', function() {
+      expect(errorFormatter.mustNotBeEmptyViolation(fakeItemPath)).to.equal('item "' + fakeItemPath + '" must not be empty');
+    });
+
+    it('produces mustNotBeMissing violation messages', function() {
+      expect(errorFormatter.mustNotBeMissingValueViolation(fakeItemPath)).to.equal('item "' + fakeItemPath + '" must not be missing');
+    });
+
+    it('produces mustNotBeNull violation messages', function() {
+      expect(errorFormatter.mustNotBeNullValueViolation(fakeItemPath)).to.equal('item "' + fakeItemPath + '" must not be null');
+    });
+
+    it('produces hashtable key regexPattern violation messages', function() {
+      var regex = /^foo-bar$/;
+      expect(errorFormatter.regexPatternHashtableKeyViolation(fakeItemPath, regex))
+        .to.equal('hashtable key "' + fakeItemPath + '" does not conform to expected format ' + regex);
+    });
+
+    it('produces regexPattern violation messages', function() {
+      var regex = /^bar-baz$/;
+      expect(errorFormatter.regexPatternItemViolation(fakeItemPath, regex))
+        .to.equal('item "' + fakeItemPath + '" must conform to expected format ' + regex);
+    });
+
+    it('produces required value violation messages', function() {
+      expect(errorFormatter.requiredValueViolation(fakeItemPath)).to.equal('required item "' + fakeItemPath + '" is missing');
+    });
+
+    it('produces attachment reference supportedContentTypes violation messages', function() {
+      var contentTypes = [ 'text/html', 'image/jpeg' ];
+      expect(errorFormatter.supportedContentTypesAttachmentReferenceViolation(fakeItemPath, contentTypes))
+        .to.equal('attachment reference "' + fakeItemPath + '" must have a supported content type (' + contentTypes.join(',') + ')');
+    });
+
+    it('produces attachment reference supportedExtensions violation messages', function() {
+      var extensions = [ 'htm', 'jpg' ];
+      expect(errorFormatter.supportedExtensionsAttachmentReferenceViolation(fakeItemPath, extensions))
+        .to.equal('attachment reference "' + fakeItemPath + '" must have a supported file extension (' + extensions.join(',') + ')');
+    });
+
+    it('produces an unsupported property message', function() {
+      expect(errorFormatter.unsupportedProperty(fakeItemPath)).to.equal('property "' + fakeItemPath + '" is not supported');
+    });
+
+    it('produces invalid UUID format messages', function() {
+      expect(errorFormatter.uuidFormatInvalid(fakeItemPath)).to.equal('item "' + fakeItemPath + '" is not a valid UUID');
+    });
+
+    describe('type constraint violations', function() {
+      it('formats messages for general types', function() {
+        var typeDescriptions = {
+          'array': 'an array',
+          'boolean': 'a boolean',
+          'date': 'an ISO 8601 date string with no time or time zone components',
+          'datetime': 'an ISO 8601 date string with optional time and time zone components',
+          'enum': 'an integer or a string',
+          'float': 'a floating point or integer number',
+          'hashtable': 'an object/hashtable',
+          'integer': 'an integer',
+          'object': 'an object',
+          'string': 'a string',
+          'uuid': 'a string'
+        };
+
+        for (var typeName in typeDescriptions) {
+          expect(errorFormatter.typeConstraintViolation(fakeItemPath, typeName))
+            .to.equal('item "' + fakeItemPath + '" must be ' + typeDescriptions[typeName]);
+        }
+      });
+
+      it('formats messages for attachment references', function() {
+        // Attachment reference type violations have a custom format
+        expect(errorFormatter.typeConstraintViolation(fakeItemPath, 'attachmentReference'))
+          .to.equal('attachment reference "' + fakeItemPath + '" must be a string');
+      });
+
+      it('throws an error if an unrecognized type is encountered', function() {
+        var invalidType = 'foo-type';
+        expect(function() {
+          errorFormatter.typeConstraintViolation(fakeItemPath, invalidType);
+        }).to.throw('Unrecognized validation type: ' + invalidType);
+      });
+    });
+  });
+});

--- a/test/authorization.spec.js
+++ b/test/authorization.spec.js
@@ -23,7 +23,7 @@ describe('Authorization:', function() {
     it('rejects document deletion for a user with no matching channels', function() {
       var doc = { _id: 'explicitChannelsDoc', _deleted: true };
 
-      testHelper.verifyAccessDenied(doc, void 0, [ 'remove', 'delete' ]);
+      testHelper.verifyAccessDenied(doc, void 0, { expectedChannels: [ 'remove', 'delete' ] });
     });
   });
 


### PR DESCRIPTION
The project's `test` process now generates a code coverage report for files in the `src` directory with a minimum of 95% coverage of statements and branches and 100% coverage of functions. As part of this effort, I had to improve test coverage of several modules to meet those thresholds. A future goal is to achieve 100% coverage of statements and branches and to increase the thresholds accordingly (i.e. require 100% coverage across the board).

The diff size may appear very large, but don't let it scare you; ~75% of the changes come from `package-lock.json` due to the addition of the [nyc](https://www.npmjs.com/package/nyc) development dependency for generating code coverage reports. The bulk of the changes that were not automatically generated can be found in the new `test-helper.spec.js` and `validation-error-formatter.spec.js`.

Addresses issue #181.