### PR TITLE
Issue 190: Remove reference to JSON object from generated sync functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
 ## [Unreleased]
-Nothing yet
+### Fixed
+- [#190](https://github.com/Kashoo/synctos/issues/190): JavaScript error when mustEqual constraint is violated
 
 ## [1.10.0] - 2018-01-24
 ### Added

--- a/etc/jshintrc-sync-function-template.json
+++ b/etc/jshintrc-sync-function-template.json
@@ -8,7 +8,6 @@
     "access": false,
     "channel": false,
     "customActionStub": false,
-    "JSON": false,
     "requireAccess": false,
     "requireRole": false,
     "requireUser": false,

--- a/templates/.jshintrc
+++ b/templates/.jshintrc
@@ -11,7 +11,7 @@
     "importSyncFunctionFragment": false,
     "isDocumentMissingOrDeleted": false,
     "isValueNullOrUndefined": false,
-    "JSON": false,
+    "jsonStringify": false,
     "requireAccess": false,
     "requireRole": false,
     "requireUser": false,

--- a/templates/document-definitions-shell-template.js
+++ b/templates/document-definitions-shell-template.js
@@ -9,6 +9,8 @@ function makeDocumentDefinitionsShell(require) {
   var isDocumentMissingOrDeleted = simple.stub();
   var isValueNullOrUndefined = simple.stub();
   var getEffectiveOldDoc = simple.stub();
+  var jsonStringify = simple.stub();
+  var getDocumentType = simple.stub();
   var requireAccess = simple.stub();
   var requireRole = simple.stub();
   var requireUser = simple.stub();
@@ -27,6 +29,8 @@ function makeDocumentDefinitionsShell(require) {
     isDocumentMissingOrDeleted: isDocumentMissingOrDeleted,
     isValueNullOrUndefined: isValueNullOrUndefined,
     getEffectiveOldDoc: getEffectiveOldDoc,
+    jsonStringify: jsonStringify,
+    getDocumentType: getDocumentType,
     requireAccess: requireAccess,
     requireRole: requireRole,
     requireUser: requireUser,

--- a/templates/json-stringify-module.js
+++ b/templates/json-stringify-module.js
@@ -1,0 +1,36 @@
+function jsonStringify(value) {
+  var toString = Object.prototype.toString;
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+  var isArray = Array.isArray || function (a) { return toString.call(a) === '[object Array]'; };
+  var escMap = {'"': '\\"', '\\': '\\\\', '\b': '\\b', '\f': '\\f', '\n': '\\n', '\r': '\\r', '\t': '\\t'};
+  var escFunc = function (m) { return escMap[m] || '\\u' + (m.charCodeAt(0) + 0x10000).toString(16).substr(1); };
+  var escRegex = /[\\"\u0000-\u001F\u2028\u2029]/g;
+  if (isValueNullOrUndefined(value)) {
+    return 'null';
+  } else if (typeof value === 'number') {
+    return isFinite(value) ? value.toString() : 'null';
+  } else if (typeof value === 'boolean') {
+    return value.toString();
+  } else if (typeof value === 'object') {
+    if (typeof value.toJSON === 'function') {
+      return jsonStringify(value.toJSON());
+    } else if (isArray(value)) {
+      var arrayString = '[';
+      for (var arrayIndex = 0; arrayIndex < value.length; arrayIndex++) {
+        arrayString += (arrayIndex ? ',' : '') + jsonStringify(value[arrayIndex]);
+      }
+      return arrayString + ']';
+    } else {
+      var properties = [];
+      for (var k in value) {
+        // in case "hasOwnProperty" has been shadowed
+        if (hasOwnProperty.call(value, k)) {
+          properties.push(jsonStringify(k) + ':' + jsonStringify(value[k]));
+        }
+      }
+      return '{' + properties.join(',') + '}';
+    }
+  } else {
+    return '"' + value.toString().replace(escRegex, escFunc) + '"';
+  }
+}

--- a/templates/sync-function-template.js
+++ b/templates/sync-function-template.js
@@ -38,6 +38,8 @@ function synctos(doc, oldDoc) {
     return !isDocumentMissingOrDeleted(oldDoc) ? oldDoc : null;
   }
 
+  var jsonStringify = importSyncFunctionFragment('json-stringify-module.js');
+
   // Load the document authorization module
   var authorizationModule = importSyncFunctionFragment('sync-function-authorization-module.js')();
 

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -377,7 +377,7 @@ function validationModule() {
       var currentItemEntry = itemStack[itemStack.length - 1];
       var currentItemValue = currentItemEntry.itemValue;
       if (!checkItemEquality(currentItemValue, expectedItemValue, treatNullAsUndefined)) {
-        validationErrors.push('value of item "' + buildItemPath(itemStack) + '" must equal ' + JSON.stringify(expectedItemValue));
+        validationErrors.push('value of item "' + buildItemPath(itemStack) + '" must equal ' + jsonStringify(expectedItemValue));
       }
     }
 


### PR DESCRIPTION
Previously the `mustEqual` and `mustEqualStrict` constraints used `JSON.stringify` when formatting an error message indicating a constraint violation; however, since the JavaScript engine used by Sync Gateway does not support the JSON object, this resulted in JavaScript errors at runtime if a client tried to store a document with a value that violated the constraint. Removed references to the JSON object from the sync function templates and replaced it with a polyfill (`json-stringify-module.js`) that replicates the behaviour of `JSON.stringify`.

Addresses issue #190.