### PR TITLE
Issue 190: Document the JSON stringify function in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ Custom code (e.g. type filters, custom validation functions, custom actions) wit
 
 * `isDocumentMissingOrDeleted(candidate)`: Determines whether the given `candidate` document is either missing (i.e. `null` or `undefined`) or deleted (i.e. its `_deleted` property is `true`). Useful in cases where, for example, the old document (i.e. `oldDoc` parameter) is non-existant or deleted and you want to treat both cases as equivalent.
 * `isValueNullOrUndefined(value)`: Determines whether the given `value` parameter is either `null` or `undefined`. In many cases, it is useful to treat both states the same.
+* `jsonStringify(value)`: Converts a value into a JSON string. May be useful in a `customValidation` function for formatting a custom error message, for example. Serves as a direct replacement for [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) since Sync Gateway does not support the global `JSON` object.
 
 # Testing
 

--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ Custom code (e.g. type filters, custom validation functions, custom actions) wit
 
 * `isDocumentMissingOrDeleted(candidate)`: Determines whether the given `candidate` document is either missing (i.e. `null` or `undefined`) or deleted (i.e. its `_deleted` property is `true`). Useful in cases where, for example, the old document (i.e. `oldDoc` parameter) is non-existant or deleted and you want to treat both cases as equivalent.
 * `isValueNullOrUndefined(value)`: Determines whether the given `value` parameter is either `null` or `undefined`. In many cases, it is useful to treat both states the same.
-* `jsonStringify(value)`: Converts a value into a JSON string. May be useful in a `customValidation` function for formatting a custom error message, for example. Serves as a direct replacement for [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) since Sync Gateway does not support the global `JSON` object.
+* `jsonStringify(value)`: Converts a value into a JSON string. May be useful in a `customValidation` constraint for formatting a custom error message, for example. Serves as a direct replacement for [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) since Sync Gateway does not support the global `JSON` object.
 
 # Testing
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "synctos",
   "version": "1.10.0",
   "description": "The Syncmaker. A tool to build comprehensive sync functions for Couchbase Sync Gateway.",
-  "keywords": [ "couchbase", "couchbase-sync-gateway", "couchbase-mobile", "sync-gateway", "synchronization", "synctos" ],
+  "keywords": [ "couchbase", "couchbase-sync-gateway", "couchbase-mobile", "sync-gateway", "synchronization", "synctos", "validation" ],
   "main": "src/index.js",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Documented `jsonStringify` in the project's README so that it can be used by, e.g., `customValidation`s. Also added the keyword "validation" to the package configuration.

Final piece of the puzzle for issue #190.