### PR TITLE
Issue 199: Allow only dates that can be parsed by Date.parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ## [Unreleased]
 ### Fixed
 - [#190](https://github.com/Kashoo/synctos/issues/190): JavaScript error when mustEqual constraint is violated
+- [#199](https://github.com/Kashoo/synctos/issues/199): Date and date-time validation types permit dates that are invalid
 
 ## [1.10.0] - 2018-01-24
 ### Added

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -8,14 +8,16 @@ function validationModule() {
   function isIso8601DateTimeString(value) {
     var regex = /^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))([T ]([01][0-9]|2[0-4])(:[0-5][0-9])?(:[0-5][0-9])?([\.,][0-9]{1,3})?)?([zZ]|([\+-])([01][0-9]|2[0-3]):?([0-5][0-9])?)?$/;
 
-    return regex.test(value);
+    // Verify that it's in ISO 8601 format (via the regex) and that it represents a valid point in time (via Date.parse)
+    return regex.test(value) && !isNaN(Date.parse(value));
   }
 
   // Check that a given value is a valid ISO 8601 date string without time and time zone components
   function isIso8601DateString(value) {
     var regex = /^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$/;
 
-    return regex.test(value);
+    // Verify that it's in ISO 8601 format (via the regex) and that it represents a valid day (via Date.parse)
+    return regex.test(value) && !isNaN(Date.parse(value));
   }
 
   function isUuid(value) {
@@ -286,12 +288,12 @@ function validationModule() {
             }
             break;
           case 'datetime':
-            if (typeof itemValue !== 'string' || !isIso8601DateTimeString(itemValue) || isNaN(Date.parse(itemValue))) {
+            if (typeof itemValue !== 'string' || !isIso8601DateTimeString(itemValue)) {
               validationErrors.push('item "' + buildItemPath(itemStack) + '" must be an ISO 8601 date string with optional time and time zone components');
             }
             break;
           case 'date':
-            if (typeof itemValue !== 'string' || !isIso8601DateString(itemValue) || isNaN(Date.parse(itemValue))) {
+            if (typeof itemValue !== 'string' || !isIso8601DateString(itemValue)) {
               validationErrors.push('item "' + buildItemPath(itemStack) + '" must be an ISO 8601 date string with no time or time zone components');
             }
             break;

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -286,12 +286,12 @@ function validationModule() {
             }
             break;
           case 'datetime':
-            if (typeof itemValue !== 'string' || !isIso8601DateTimeString(itemValue)) {
+            if (typeof itemValue !== 'string' || !isIso8601DateTimeString(itemValue) || isNaN(Date.parse(itemValue))) {
               validationErrors.push('item "' + buildItemPath(itemStack) + '" must be an ISO 8601 date string with optional time and time zone components');
             }
             break;
           case 'date':
-            if (typeof itemValue !== 'string' || !isIso8601DateString(itemValue)) {
+            if (typeof itemValue !== 'string' || !isIso8601DateString(itemValue) || isNaN(Date.parse(itemValue))) {
               validationErrors.push('item "' + buildItemPath(itemStack) + '" must be an ISO 8601 date string with no time or time zone components');
             }
             break;


### PR DESCRIPTION
Use [Date.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) to ensure the sync function will not accept a date or datetime value it cannot represent.

Addresses issue #199.