### PR TITLE
Exclude additional directories from JSHint

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,5 @@
-test/resources
+/build/coverage
+/lib
+/node_modules
+/samples
+/test/resources


### PR DESCRIPTION
Prevents JSHint from generating warnings/errors for directories that should not be linted (e.g. `build/coverage`, `lib`, `node_modules`).