### PR TITLE
Issue 207: Ignore all internal document properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ### Added
 - [#43](https://github.com/Kashoo/synctos/issues/43): Tool to validate structure and semantics of a document definitions file
 - [#189](https://github.com/Kashoo/synctos/issues/189): Automatically create the output sync function file directory if it does not exist
+- [#207](https://github.com/Kashoo/synctos/issues/207): Ignore all top-level document properties that start with an underscore
 
 ### Fixed
 - [#190](https://github.com/Kashoo/synctos/issues/190): JavaScript error when mustEqual constraint is violated

--- a/src/testing/test-helper.js
+++ b/src/testing/test-helper.js
@@ -304,14 +304,14 @@ function checkAuthorizations(expectedAuthorizations, actualAuthorizations, autho
   for (var expectedAuthIndex = 0; expectedAuthIndex < expectedAuthorizations.length; expectedAuthIndex++) {
     var expectedAuth = expectedAuthorizations[expectedAuthIndex];
     if (actualAuthorizations.indexOf(expectedAuth) < 0) {
-      assert.fail('Expected ' + authorizationType + ' was not encountered: ' + expectedAuth);
+      assert.fail('Expected ' + authorizationType + ' was not encountered: ' + expectedAuth + '. Actual ' + authorizationType + 's: ' + actualAuthorizations);
     }
   }
 
   for (var actualAuthIndex = 0; actualAuthIndex < actualAuthorizations.length; actualAuthIndex++) {
     var actualAuth = actualAuthorizations[actualAuthIndex];
     if (expectedAuthorizations.indexOf(actualAuth) < 0) {
-      assert.fail('Unexpected ' + authorizationType + ' encountered: ' + actualAuth);
+      assert.fail('Unexpected ' + authorizationType + ' encountered: ' + actualAuth + '. Expected ' + authorizationType + 's: ' + expectedAuthorizations);
     }
   }
 }

--- a/src/testing/test-helper.spec.js
+++ b/src/testing/test-helper.spec.js
@@ -97,7 +97,7 @@ describe('Test helper:', function() {
 
       expect(function() {
         testHelper.verifyAccessDenied({ }, void 0, expectedChannels);
-      }).to.throw('Unexpected channel encountered: my-channel-2');
+      }).to.throw('Unexpected channel encountered: my-channel-2. Expected channels: ' + expectedChannels.join(','));
     });
 
     it('fails if it does not encounter a channel that was expected', function() {
@@ -110,7 +110,7 @@ describe('Test helper:', function() {
 
       expect(function() {
         testHelper.verifyAccessDenied({ }, void 0, expectedChannels);
-      }).to.throw('Expected channel was not encountered: my-channel-2');
+      }).to.throw('Expected channel was not encountered: my-channel-2. Actual channels: ' + actualChannels.join(','));
     });
 
     it('fails if the sync function does not throw an error', function() {

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -109,11 +109,11 @@ function validationModule() {
       resolvedPropertyValidators.type = typeIdValidator;
     }
 
-    // Execute each of the document's property validators while ignoring the specified whitelisted properties at the root level
+    // Execute each of the document's property validators while ignoring internal document properties at the root level
     validateProperties(
       resolvedPropertyValidators,
       resolveDocConstraint(doc, oldDoc, docDefinition.allowUnknownProperties),
-      [ '_id', '_rev', '_deleted', '_revisions', '_attachments' ]);
+      true);
 
     if (doc._attachments) {
       validateAttachments();
@@ -131,7 +131,7 @@ function validationModule() {
       }
     }
 
-    function validateProperties(propertyValidators, allowUnknownProperties, whitelistedProperties) {
+    function validateProperties(propertyValidators, allowUnknownProperties, ignoreInternalProperties) {
       var currentItemEntry = itemStack[itemStack.length - 1];
       var objectValue = currentItemEntry.itemValue;
       var oldObjectValue = currentItemEntry.oldItemValue;
@@ -167,7 +167,7 @@ function validationModule() {
       // Verify there are no unsupported properties in the object
       if (!allowUnknownProperties) {
         for (var propertyName in objectValue) {
-          if (whitelistedProperties && whitelistedProperties.indexOf(propertyName) >= 0) {
+          if (ignoreInternalProperties && propertyName.indexOf('_') === 0) {
             // These properties are special cases that should always be allowed - generally only applied at the root level of the document
             continue;
           }

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -212,40 +212,55 @@ describe('Functionality that is common to all documents:', function() {
     });
   });
 
-  it('cannot specify whitelisted properties below the root level of the document', function() {
-    var doc = {
-      _id: 'generalDoc',
-      objectProp: {
-        foo: 'bar',
-        _id: 'my-id',
+  describe('internal document property validation', function() {
+    it('allows internal properties at the root level of the document', function() {
+      var doc = {
+        _id: 'generalDoc',
         _rev: 'my-rev',
-        _deleted: true,
+        _deleted: false,
         _revisions: { },
-        _attachments: { }
-      }
-    };
+        _attachments: { },
+        _someOtherProperty: 'my-value'
+      };
 
-    var syncFuncError = null;
-    expect(function() {
-      try {
-        testHelper.syncFunction(doc);
-      } catch (ex) {
-        syncFuncError = ex;
+      testHelper.verifyDocumentCreated(doc, [ 'add' ]);
+    });
 
-        throw ex;
-      }
-    }).to.throw();
+    it('rejects internal properties below the root level of the document', function() {
+      var doc = {
+        _id: 'generalDoc',
+        objectProp: {
+          foo: 'bar',
+          _id: 'my-id',
+          _rev: 'my-rev',
+          _deleted: true,
+          _revisions: { },
+          _attachments: { }
+        }
+      };
 
-    testHelper.verifyValidationErrors(
-      'generalDoc',
-      [
-        errorFormatter.unsupportedProperty('objectProp._id'),
-        errorFormatter.unsupportedProperty('objectProp._rev'),
-        errorFormatter.unsupportedProperty('objectProp._deleted'),
-        errorFormatter.unsupportedProperty('objectProp._revisions'),
-        errorFormatter.unsupportedProperty('objectProp._attachments')
-      ],
-      syncFuncError);
+      var syncFuncError = null;
+      expect(function() {
+        try {
+          testHelper.syncFunction(doc);
+        } catch (ex) {
+          syncFuncError = ex;
+
+          throw ex;
+        }
+      }).to.throw();
+
+      testHelper.verifyValidationErrors(
+        'generalDoc',
+        [
+          errorFormatter.unsupportedProperty('objectProp._id'),
+          errorFormatter.unsupportedProperty('objectProp._rev'),
+          errorFormatter.unsupportedProperty('objectProp._deleted'),
+          errorFormatter.unsupportedProperty('objectProp._revisions'),
+          errorFormatter.unsupportedProperty('objectProp._attachments')
+        ],
+        syncFuncError);
+    });
   });
 
   it('cannot include attachments in documents that do not explicitly allow them', function() {


### PR DESCRIPTION
During execution of a sync function ignore any document property key that starts with an underscore if it is at the top level of the document. Sync Gateway does not allow top-level document property keys to start with an underscore because it reserves that notation to indicate internal document properties.

Addresses issue #207.