### PR TITLE
Issue 204: String constraint that prohibits leading or trailing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ### Added
 - [#43](https://github.com/Kashoo/synctos/issues/43): Tool to validate structure and semantics of a document definitions file
 - [#189](https://github.com/Kashoo/synctos/issues/189): Automatically create the output sync function file directory if it does not exist
+- [#204](https://github.com/Kashoo/synctos/issues/204): Constraint that requires string values to be trimmed
 
 ### Fixed
 - [#190](https://github.com/Kashoo/synctos/issues/190): JavaScript error when mustEqual constraint is violated

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Validation for simple data types (e.g. integers, floating point numbers, strings
 
 * `string`: The value is a string of characters. Additional parameters:
   * `mustNotBeEmpty`: If `true`, an empty string is not allowed. Defaults to `false`.
+  * `mustBeTrimmed`: If `true`, a string that has leading or trailing whitespace characters is not allowed. Defaults to `false`.
   * `regexPattern`: A regular expression pattern that must be satisfied for values to be accepted (e.g. `new RegExp('\\d+')` or `/[A-Za-z]+/`). No restriction by default.
   * `minimumLength`: The minimum number of characters (inclusive) allowed in the string. No restriction by default.
   * `maximumLength`: The maximum number of characters (inclusive) allowed in the string. No restriction by default.

--- a/src/testing/validation-error-formatter.js
+++ b/src/testing/validation-error-formatter.js
@@ -195,6 +195,15 @@ exports.minimumValueExclusiveViolation = function(itemPath, minValue) {
 };
 
 /**
+ * Formats a message for the error that occurs when a string has leading or trailing whitespace even though it is forbidden.
+ *
+ * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "hashtableProp[my-key].stringProp")
+ */
+exports.mustBeTrimmedViolation = function(itemPath) {
+  return 'item "' + itemPath + '" must not have any leading or trailing whitespace';
+};
+
+/**
  * Formats a message for the error that occurs when a value does not equal the expected value.
  *
  * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "objectProp.integerProp")

--- a/src/testing/validation-error-formatter.spec.js
+++ b/src/testing/validation-error-formatter.spec.js
@@ -145,6 +145,11 @@ describe('Validation error formatter', function() {
         .to.equal('item "' + fakeItemPath + '" must not be less than or equal to ' + minimumValue);
     });
 
+    it('produces mustBeTrimmed violation messages', function() {
+      expect(errorFormatter.mustBeTrimmedViolation(fakeItemPath))
+        .to.equal('item "' + fakeItemPath + '" must not have any leading or trailing whitespace');
+    });
+
     it('produces mustEqual violation messages', function() {
       var value = { foo: [ 'bar' ] };
       expect(errorFormatter.mustEqualViolation(fakeItemPath, value))

--- a/src/validation/document-definitions-validator.spec.js
+++ b/src/validation/document-definitions-validator.spec.js
@@ -126,6 +126,7 @@ describe('Document definitions validator:', function() {
                       stringProperty: {
                         type: 'string',
                         mustEqual: null, // Must not be defined in conjunction with "regexPattern"
+                        mustBeTrimmed: 0, // Must be a boolean
                         regexPattern: /^[a-z]+$/,
                         minimumLength: function() { return 9; },
                         maximumLength: -1 // Must be at least 0
@@ -223,6 +224,7 @@ describe('Document definitions validator:', function() {
         'myDoc1.propertyValidators.nestedObject.propertyValidators.hashtableProperty.hashtableValuesValidator.mustEqual: \"mustEqual\" must be a string',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.minimumLength: \"minimumLength\" must be an integer',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.maximumLength: \"maximumLength\" must be an integer',
+        'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.stringProperty.mustBeTrimmed: \"mustBeTrimmed\" must be a boolean',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.stringProperty.maximumLength: \"maximumLength\" must be larger than or equal to 0',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.booleanProperty.mustEqual: \"mustEqual\" must be a boolean',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.invalidIntegerProperty.required: \"required\" conflict with forbidden peer \"mustNotBeMissing\"',

--- a/src/validation/property-validator-schema.js
+++ b/src/validation/property-validator-schema.js
@@ -97,6 +97,7 @@ function typeSpecificConstraintSchemas() {
   return {
     string: {
       mustNotBeEmpty: dynamicConstraintSchema(joi.boolean()),
+      mustBeTrimmed: dynamicConstraintSchema(joi.boolean()),
       regexPattern: dynamicConstraintSchema(regexSchema),
       minimumLength: dynamicConstraintSchema(integerSchema.min(0)),
       maximumLength: maximumSizeConstraintSchema('minimumLength'),

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -265,11 +265,10 @@ function validationModule() {
 
         switch (validatorType) {
           case 'string':
-            var regexPattern = resolveValidationConstraint(validator.regexPattern);
             if (typeof itemValue !== 'string') {
               validationErrors.push('item "' + buildItemPath(itemStack) + '" must be a string');
-            } else if (regexPattern && !regexPattern.test(itemValue)) {
-              validationErrors.push('item "' + buildItemPath(itemStack) + '" must conform to expected format ' + regexPattern);
+            } else {
+              validateString(validator);
             }
             break;
           case 'integer':
@@ -345,6 +344,29 @@ function validationModule() {
 
     function hasNoValue(value, treatNullAsUndefined) {
       return treatNullAsUndefined ? isValueNullOrUndefined(value) : typeof value === 'undefined';
+    }
+
+    function validateString(validator) {
+      var currentItemEntry = itemStack[itemStack.length - 1];
+      var itemValue = currentItemEntry.itemValue;
+
+      var regexPattern = resolveValidationConstraint(validator.regexPattern);
+      if (regexPattern && !regexPattern.test(itemValue)) {
+        validationErrors.push('item "' + buildItemPath(itemStack) + '" must conform to expected format ' + regexPattern);
+      }
+
+      var mustBeTrimmed = resolveValidationConstraint(validator.mustBeTrimmed);
+      if (mustBeTrimmed && isStringUntrimmed(itemValue)) {
+        validationErrors.push('item "' + buildItemPath(itemStack) + '" must not have any leading or trailing whitespace');
+      }
+    }
+
+    function isStringUntrimmed(value) {
+      if (isValueNullOrUndefined(value)) {
+        return false;
+      } else {
+        return value !== value.trim();
+      }
     }
 
     function validateImmutable(onlyEnforceIfHasValue, treatNullAsUndefined) {

--- a/test/resources/string-doc-definitions.js
+++ b/test/resources/string-doc-definitions.js
@@ -15,6 +15,10 @@ function() {
     return new RegExp(doc.dynamicRegex);
   }
 
+  function dynamicMustBeTrimmed(doc, oldDoc, value, oldValue) {
+    return doc.dynamicMustBeTrimmedState;
+  }
+
   return {
     stringDoc: {
       channels: { write: 'write' },
@@ -56,6 +60,17 @@ function() {
         dynamicRegexPatternValidationProp: {
           type: 'string',
           regexPattern: dynamicRegexPattern
+        },
+        staticMustBeTrimmedValidationProp: {
+          type: 'string',
+          mustBeTrimmed: true
+        },
+        dynamicMustBeTrimmedState: {
+          type: 'boolean'
+        },
+        dynamicMustBeTrimmedValidationProp: {
+          type: 'string',
+          mustBeTrimmed: dynamicMustBeTrimmed
         }
       }
     }

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -170,4 +170,86 @@ describe('String validation type', function() {
       });
     });
   });
+
+  describe('must be trimmed constraint', function() {
+    describe('with static validation', function() {
+      it('allows an empty string', function() {
+        var doc = {
+          _id: 'stringDoc',
+          staticMustBeTrimmedValidationProp: ''
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a string that has no leading or trailing whitespace', function() {
+        var doc = {
+          _id: 'stringDoc',
+          staticMustBeTrimmedValidationProp: 'foo bar'
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('blocks a string that has leading whitespace', function() {
+        var doc = {
+          _id: 'stringDoc',
+          staticMustBeTrimmedValidationProp: '\tfoo bar'
+        };
+
+        testHelper.verifyDocumentNotCreated(doc, 'stringDoc', errorFormatter.mustBeTrimmedViolation('staticMustBeTrimmedValidationProp'));
+      });
+
+      it('blocks a string that has trailing whitespace', function() {
+        var doc = {
+          _id: 'stringDoc',
+          staticMustBeTrimmedValidationProp: 'foo bar\n'
+        };
+
+        testHelper.verifyDocumentNotCreated(doc, 'stringDoc', errorFormatter.mustBeTrimmedViolation('staticMustBeTrimmedValidationProp'));
+      });
+    });
+
+    describe('with dynamic validation', function() {
+      it('allows a string that has no leading or trailing whitespace', function() {
+        var doc = {
+          _id: 'stringDoc',
+          dynamicMustBeTrimmedValidationProp: 'bar',
+          dynamicMustBeTrimmedState: true
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a string that has leading whitespace if the constraint is disabled', function() {
+        var doc = {
+          _id: 'stringDoc',
+          dynamicMustBeTrimmedValidationProp: ' foobar',
+          dynamicMustBeTrimmedState: false
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a string that has trailing whitespace if the constraint is disabled', function() {
+        var doc = {
+          _id: 'stringDoc',
+          dynamicMustBeTrimmedValidationProp: 'foobar ',
+          dynamicMustBeTrimmedState: false
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('blocks a string that has leading and trailing whitespace if the constraint is enabled', function() {
+        var doc = {
+          _id: 'stringDoc',
+          dynamicMustBeTrimmedValidationProp: ' foobar ',
+          dynamicMustBeTrimmedState: true
+        };
+
+        testHelper.verifyDocumentNotCreated(doc, 'stringDoc', errorFormatter.mustBeTrimmedViolation('dynamicMustBeTrimmedValidationProp'));
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds a new constraint for the `string` validation type that, when enabled, ensures that a candidate value does not begin or end with whitespace.

Addresses issue #204.