### PR TITLE
Issue 212: Update various document validation error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 - [#43](https://github.com/Kashoo/synctos/issues/43): Tool to validate structure and semantics of a document definitions file
 - [#189](https://github.com/Kashoo/synctos/issues/189): Automatically create the output sync function file directory if it does not exist
 
+### Changed
+- [#212](https://github.com/Kashoo/synctos/issues/212): Improve document validation error messages
+
 ### Fixed
 - [#190](https://github.com/Kashoo/synctos/issues/190): JavaScript error when mustEqual constraint is violated
 - [#196](https://github.com/Kashoo/synctos/issues/196): Date-time validation type supports invalid time components

--- a/src/testing/validation-error-formatter.js
+++ b/src/testing/validation-error-formatter.js
@@ -355,7 +355,7 @@ exports.unsupportedProperty = function(propertyPath) {
  * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "objectProp.arrayProp[10].uuidProp")
  */
 exports.uuidFormatInvalid = function(itemPath) {
-  return 'item "' + itemPath + '" is not a valid UUID';
+  return 'item "' + itemPath + '" must be ' + getTypeDescription('uuid');
 };
 
 function getTypeDescription(type) {
@@ -383,7 +383,7 @@ function getTypeDescription(type) {
     case 'string':
       return 'a string';
     case 'uuid':
-      return 'a string';
+      return 'a UUID string';
     default:
       throw new Error('Unrecognized validation type: ' + type);
   }

--- a/src/testing/validation-error-formatter.js
+++ b/src/testing/validation-error-formatter.js
@@ -92,7 +92,7 @@ exports.immutableDocViolation = function() {
  *                          (e.g. "arrayProp[1].hashtableProp[my-key].integerProp")
  */
 exports.immutableItemViolation = function(itemPath) {
-  return 'value of item "' + itemPath + '" cannot be modified';
+  return 'item "' + itemPath + '" cannot be modified';
 };
 
 /**

--- a/src/testing/validation-error-formatter.js
+++ b/src/testing/validation-error-formatter.js
@@ -46,7 +46,7 @@ exports.datetimeFormatInvalid = function(itemPath) {
  * @param {(string[]|integer[])} expectedPredefinedValues A list of predefined values that are allowed for the item in question
  */
 exports.enumPredefinedValueViolation = function(itemPath, expectedPredefinedValues) {
-  return 'item "' + itemPath + '" must be one of the predefined values: ' + expectedPredefinedValues.toString();
+  return 'item "' + itemPath + '" must be one of the predefined values: ' + expectedPredefinedValues.join(',');
 };
 
 /**
@@ -55,7 +55,7 @@ exports.enumPredefinedValueViolation = function(itemPath, expectedPredefinedValu
  * @param {string} hashtablePath The full path of the hashtable in which the error occurs (e.g. "objectProp.arrayProp[2].hashtableProp")
  */
 exports.hashtableKeyEmpty = function(hashtablePath) {
-  return 'empty hashtable key in item "' + hashtablePath + '" is not allowed';
+  return 'hashtable "' + hashtablePath + '" must not have an empty key';
 };
 
 /**
@@ -92,7 +92,7 @@ exports.immutableDocViolation = function() {
  *                          (e.g. "arrayProp[1].hashtableProp[my-key].integerProp")
  */
 exports.immutableItemViolation = function(itemPath) {
-  return 'value of item "' + itemPath + '" may not be modified';
+  return 'value of item "' + itemPath + '" cannot be modified';
 };
 
 /**
@@ -101,7 +101,7 @@ exports.immutableItemViolation = function(itemPath) {
  * @param {integer} maxCount The maximum number of attachments that are allowed
  */
 exports.maximumAttachmentCountViolation = function(maxCount) {
-  return 'the total number of attachments must not exceed ' + maxCount;
+  return 'documents of this type must not have more than ' + maxCount + ' attachments';
 };
 
 /**
@@ -141,7 +141,7 @@ exports.maximumSizeAttachmentViolation = function(itemPath, maxSize) {
  * @param {integer} maxSize The maximum size, in bytes, that is allowed
  */
 exports.maximumTotalAttachmentSizeViolation = function(maxSize) {
-  return 'the total size of all attachments must not exceed ' + maxSize + ' bytes';
+  return 'documents of this type must not have a combined attachment size greater than ' + maxSize + ' bytes';
 };
 
 /**
@@ -240,7 +240,7 @@ exports.mustNotBeNullValueViolation = function(itemPath) {
  * @param {RegExp} expectedRegex The regular expression pattern that is expected
  */
 exports.regexPatternHashtableKeyViolation = function(hashtableKeyPath, expectedRegex) {
-  return 'hashtable key "' + hashtableKeyPath + '" does not conform to expected format ' + expectedRegex;
+  return 'hashtable key "' + hashtableKeyPath + '" must conform to expected format ' + expectedRegex;
 };
 
 /**
@@ -269,7 +269,7 @@ exports.requireAttachmentReferencesViolation = function(attachmentName) {
  * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "objectProp.arrayProp[2].booleanProp")
  */
 exports.requiredValueViolation = function(itemPath) {
-  return 'required item "' + itemPath + '" is missing';
+  return 'item "' + itemPath + '" must not be null or missing';
 };
 
 /**
@@ -293,7 +293,9 @@ exports.supportedContentTypesAttachmentReferenceViolation = function(itemPath, e
  *                                        Element order must match that set in the validator in the document definition.
  */
 exports.supportedContentTypesRawAttachmentViolation = function(attachmentName, expectedContentTypes) {
-  return 'attachment "' + attachmentName + '" must have a supported content type (' + expectedContentTypes + ')';
+  var contentTypesString = expectedContentTypes.join(',');
+
+  return 'attachment "' + attachmentName + '" must have a supported content type (' + contentTypesString + ')';
 };
 
 /**
@@ -304,7 +306,9 @@ exports.supportedContentTypesRawAttachmentViolation = function(attachmentName, e
  *                                          Element order must match that set in the validator in the document definition.
  */
 exports.supportedExtensionsAttachmentReferenceViolation = function(itemPath, expectedFileExtensions) {
-  return 'attachment reference "' + itemPath + '" must have a supported file extension (' + expectedFileExtensions + ')';
+  var extensionsString = expectedFileExtensions.join(',');
+
+  return 'attachment reference "' + itemPath + '" must have a supported file extension (' + extensionsString + ')';
 };
 
 /**

--- a/src/testing/validation-error-formatter.js
+++ b/src/testing/validation-error-formatter.js
@@ -328,13 +328,7 @@ exports.supportedExtensionsRawAttachmentViolation = function(attachmentName, exp
  *                              "float", "hashtable", "integer", "object", "string"). Throws an exception if the type is not recognized.
  */
 exports.typeConstraintViolation = function(itemPath, expectedType) {
-  var typeDescription = getTypeDescription(expectedType);
-  if (expectedType === 'attachmentReference') {
-    // Attachment references have a slightly different error message format
-    return 'attachment reference "' + itemPath + '" must be ' + typeDescription;
-  } else {
-    return 'item "' + itemPath + '" must be ' + typeDescription;
-  }
+  return 'item "' + itemPath + '" must be ' + getTypeDescription(expectedType);
 };
 
 /**
@@ -369,7 +363,7 @@ function getTypeDescription(type) {
     case 'array':
       return 'an array';
     case 'attachmentReference':
-      return 'a string';
+      return 'an attachment reference string';
     case 'boolean':
       return 'a boolean';
     case 'date':

--- a/src/testing/validation-error-formatter.spec.js
+++ b/src/testing/validation-error-formatter.spec.js
@@ -203,6 +203,7 @@ describe('Validation error formatter', function() {
       it('formats messages for general types', function() {
         var typeDescriptions = {
           'array': 'an array',
+          'attachmentReference': 'an attachment reference string',
           'boolean': 'a boolean',
           'date': 'an ISO 8601 date string with no time or time zone components',
           'datetime': 'an ISO 8601 date string with optional time and time zone components',
@@ -219,12 +220,6 @@ describe('Validation error formatter', function() {
           expect(errorFormatter.typeConstraintViolation(fakeItemPath, typeName))
             .to.equal('item "' + fakeItemPath + '" must be ' + typeDescriptions[typeName]);
         }
-      });
-
-      it('formats messages for attachment references', function() {
-        // Attachment reference type violations have a custom format
-        expect(errorFormatter.typeConstraintViolation(fakeItemPath, 'attachmentReference'))
-          .to.equal('attachment reference "' + fakeItemPath + '" must be a string');
       });
 
       it('throws an error if an unrecognized type is encountered', function() {

--- a/src/testing/validation-error-formatter.spec.js
+++ b/src/testing/validation-error-formatter.spec.js
@@ -196,7 +196,7 @@ describe('Validation error formatter', function() {
     });
 
     it('produces invalid UUID format messages', function() {
-      expect(errorFormatter.uuidFormatInvalid(fakeItemPath)).to.equal('item "' + fakeItemPath + '" is not a valid UUID');
+      expect(errorFormatter.uuidFormatInvalid(fakeItemPath)).to.equal('item "' + fakeItemPath + '" must be a UUID string');
     });
 
     describe('type constraint violations', function() {
@@ -213,7 +213,7 @@ describe('Validation error formatter', function() {
           'integer': 'an integer',
           'object': 'an object',
           'string': 'a string',
-          'uuid': 'a string'
+          'uuid': 'a UUID string'
         };
 
         for (var typeName in typeDescriptions) {

--- a/src/testing/validation-error-formatter.spec.js
+++ b/src/testing/validation-error-formatter.spec.js
@@ -100,7 +100,7 @@ describe('Validation error formatter', function() {
     });
 
     it('produces immutable value violation messages', function() {
-      expect(errorFormatter.immutableItemViolation(fakeItemPath)).to.equal('value of item "' + fakeItemPath + '" cannot be modified');
+      expect(errorFormatter.immutableItemViolation(fakeItemPath)).to.equal('item "' + fakeItemPath + '" cannot be modified');
     });
 
     it('produces maximumLength violation messages', function() {

--- a/src/testing/validation-error-formatter.spec.js
+++ b/src/testing/validation-error-formatter.spec.js
@@ -22,7 +22,7 @@ describe('Validation error formatter', function() {
     it('produces maximumAttachmentCount violation messages', function() {
       var maximumAttachmentCount = 2;
       expect(errorFormatter.maximumAttachmentCountViolation(maximumAttachmentCount))
-        .to.equal('the total number of attachments must not exceed ' + maximumAttachmentCount);
+        .to.equal('documents of this type must not have more than ' + maximumAttachmentCount + ' attachments');
     });
 
     it('produces attachments maximumIndividualSize violation messages', function() {
@@ -35,7 +35,7 @@ describe('Validation error formatter', function() {
     it('produces attachments maximumTotalSize violation messages', function() {
       var maximumSize = 2;
       expect(errorFormatter.maximumTotalAttachmentSizeViolation(maximumSize))
-        .to.equal('the total size of all attachments must not exceed ' + maximumSize + ' bytes');
+        .to.equal('documents of this type must not have a combined attachment size greater than ' + maximumSize + ' bytes');
     });
 
     it('produces requireAttachmentReferences violation messages', function() {
@@ -79,12 +79,12 @@ describe('Validation error formatter', function() {
     it('produces invalid enum value messages', function() {
       var fakeEnumValues = [ 'foo', 'bar', -5 ];
       expect(errorFormatter.enumPredefinedValueViolation(fakeItemPath, fakeEnumValues))
-        .to.equal('item "' + fakeItemPath + '" must be one of the predefined values: ' + fakeEnumValues.join(','));
+        .to.equal('item "' + fakeItemPath + '" must be one of the predefined values: ' + fakeEnumValues);
     });
 
     it('produces empty hashtable key violation messages', function() {
       expect(errorFormatter.hashtableKeyEmpty(fakeItemPath))
-        .to.equal('empty hashtable key in item "' + fakeItemPath + '" is not allowed');
+        .to.equal('hashtable "' + fakeItemPath + '" must not have an empty key');
     });
 
     it('produces hashtable maximumSize violation messages', function() {
@@ -100,7 +100,7 @@ describe('Validation error formatter', function() {
     });
 
     it('produces immutable value violation messages', function() {
-      expect(errorFormatter.immutableItemViolation(fakeItemPath)).to.equal('value of item "' + fakeItemPath + '" may not be modified');
+      expect(errorFormatter.immutableItemViolation(fakeItemPath)).to.equal('value of item "' + fakeItemPath + '" cannot be modified');
     });
 
     it('produces maximumLength violation messages', function() {
@@ -166,7 +166,7 @@ describe('Validation error formatter', function() {
     it('produces hashtable key regexPattern violation messages', function() {
       var regex = /^foo-bar$/;
       expect(errorFormatter.regexPatternHashtableKeyViolation(fakeItemPath, regex))
-        .to.equal('hashtable key "' + fakeItemPath + '" does not conform to expected format ' + regex);
+        .to.equal('hashtable key "' + fakeItemPath + '" must conform to expected format ' + regex);
     });
 
     it('produces regexPattern violation messages', function() {
@@ -176,7 +176,7 @@ describe('Validation error formatter', function() {
     });
 
     it('produces required value violation messages', function() {
-      expect(errorFormatter.requiredValueViolation(fakeItemPath)).to.equal('required item "' + fakeItemPath + '" is missing');
+      expect(errorFormatter.requiredValueViolation(fakeItemPath)).to.equal('item "' + fakeItemPath + '" must not be null or missing');
     });
 
     it('produces attachment reference supportedContentTypes violation messages', function() {

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -307,7 +307,7 @@ function validationModule() {
             break;
           case 'uuid':
             if (!isUuid(itemValue)) {
-              validationErrors.push('item "' + buildItemPath(itemStack) + '" is not a valid UUID');
+              validationErrors.push('item "' + buildItemPath(itemStack) + '" must be a UUID string');
             }
             break;
           case 'object':

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -302,7 +302,7 @@ function validationModule() {
             if (!(enumPredefinedValues instanceof Array)) {
               validationErrors.push('item "' + buildItemPath(itemStack) + '" belongs to an enum that has no predefined values');
             } else if (enumPredefinedValues.indexOf(itemValue) < 0) {
-              validationErrors.push('item "' + buildItemPath(itemStack) + '" must be one of the predefined values: ' + enumPredefinedValues.toString());
+              validationErrors.push('item "' + buildItemPath(itemStack) + '" must be one of the predefined values: ' + enumPredefinedValues.join(','));
             }
             break;
           case 'uuid':
@@ -333,7 +333,7 @@ function validationModule() {
         }
       } else if (resolveValidationConstraint(validator.required)) {
         // The item has no value (either it's null or undefined), but the validator indicates it is required
-        validationErrors.push('required item "' + buildItemPath(itemStack) + '" is missing');
+        validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be null or missing');
       } else if (resolveValidationConstraint(validator.mustNotBeMissing) && typeof itemValue === 'undefined') {
         // The item is missing (i.e. it's undefined), but the validator indicates it must not be
         validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be missing');
@@ -370,7 +370,7 @@ function validationModule() {
         }
 
         if (!constraintSatisfied) {
-          validationErrors.push('value of item "' + buildItemPath(itemStack) + '" may not be modified');
+          validationErrors.push('value of item "' + buildItemPath(itemStack) + '" cannot be modified');
         }
       }
     }
@@ -528,11 +528,11 @@ function validationModule() {
               validationErrors.push('hashtable key "' + fullKeyPath + '" is not a string');
             } else {
               if (resolveValidationConstraint(keyValidator.mustNotBeEmpty) && elementKey.length < 1) {
-                validationErrors.push('empty hashtable key in item "' + buildItemPath(itemStack) + '" is not allowed');
+                validationErrors.push('hashtable "' + buildItemPath(itemStack) + '" must not have an empty key');
               }
               var regexPattern = resolveValidationConstraint(keyValidator.regexPattern);
               if (regexPattern && !regexPattern.test(elementKey)) {
-                validationErrors.push('hashtable key "' + fullKeyPath + '" does not conform to expected format ' + regexPattern);
+                validationErrors.push('hashtable key "' + fullKeyPath + '" must conform to expected format ' + regexPattern);
               }
             }
           }
@@ -665,11 +665,11 @@ function validationModule() {
       }
 
       if (isInteger(maximumTotalAttachmentSize) && totalSize > maximumTotalAttachmentSize) {
-        validationErrors.push('the total size of all attachments must not exceed ' + maximumTotalAttachmentSize + ' bytes');
+        validationErrors.push('documents of this type must not have a combined attachment size greater than ' + maximumTotalAttachmentSize + ' bytes');
       }
 
       if (isInteger(maximumAttachmentCount) && attachmentCount > maximumAttachmentCount) {
-        validationErrors.push('the total number of attachments must not exceed ' + maximumAttachmentCount);
+        validationErrors.push('documents of this type must not have more than ' + maximumAttachmentCount + ' attachments');
       }
 
       if (!resolveDocConstraint(doc, oldDoc, docDefinition.allowAttachments) && attachmentCount > 0) {

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -572,7 +572,7 @@ function validationModule() {
       var itemValue = currentItemEntry.itemValue;
 
       if (typeof itemValue !== 'string') {
-        validationErrors.push('attachment reference "' + buildItemPath(itemStack) + '" must be a string');
+        validationErrors.push('item "' + buildItemPath(itemStack) + '" must be an attachment reference string');
       } else {
         attachmentReferenceValidators[itemValue] = validator;
 

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -370,7 +370,7 @@ function validationModule() {
         }
 
         if (!constraintSatisfied) {
-          validationErrors.push('value of item "' + buildItemPath(itemStack) + '" cannot be modified');
+          validationErrors.push('item "' + buildItemPath(itemStack) + '" cannot be modified');
         }
       }
     }


### PR DESCRIPTION
Brings some consistency to some of the outlier error messages (e.g. for attachment references, UUIDs, immutable items, required items, etc.).

Addresses issue #212.