### PR TITLE
Issue #43: Reference the validation utility from the testing section of the README and vice versa

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Or as a custom [script](https://docs.npmjs.com/misc/scripts) in your project's `
 
 If the specified document definitions contain any violations, the utility will exit with a non-zero status code and output a list of the violations to standard output. Otherwise, if validation was successful, the utility will exit normally and will not output anything.
 
+See the [Testing](#testing) section for information on writing test cases for custom code in document definitions.
+
 ### Specifications
 
 Document definitions must conform to the following specification. See the `samples/` directory and Kashoo's official [document definitions](https://github.com/Kashoo/kashoo-document-definitions) repository for some examples.
@@ -827,3 +829,5 @@ it('cannot create a myDocType doc when required property foo is missing', functi
 The `testHelper.validationErrorFormatter` object in the preceding example provides a variety of functions that can be used to specify expected validation error messages. See the `src/validation-error-formatter.js` module in this project for documentation.
 
 You will find many more examples in this project's `test/` directory and in the example project [synctos-test-examples](https://github.com/OldSneerJaw/synctos-test-examples).
+
+See the [Validating](#validating) section for information on using the validation utility to verify the structure and semantics of a document definitions file.


### PR DESCRIPTION
Each section references the other to increase the chances that a user will discover the full testing and validation capabilities of the project.