### PR TITLE
Issue 215: Recursively import file fragments that are nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 - [#189](https://github.com/Kashoo/synctos/issues/189): Automatically create the output sync function file directory if it does not exist
 - [#207](https://github.com/Kashoo/synctos/issues/207): Ignore all top-level document properties that start with an underscore
 - [#204](https://github.com/Kashoo/synctos/issues/204): Constraint that requires string values to be trimmed
+- [#215](https://github.com/Kashoo/synctos/issues/215): Allow document definition fragments to be nested
 
 ### Changed
 - [#212](https://github.com/Kashoo/synctos/issues/212): Improve document validation error messages

--- a/src/loading/file-fragment-loader.js
+++ b/src/loading/file-fragment-loader.js
@@ -13,7 +13,12 @@ var fs = require('fs');
 
 function load(baseDir, macroName, rawText) {
   function replacer(fullMatch, fragmentFilename) {
-    return readFileFragment(fragmentFilename, baseDir);
+    var rawFileContents = readFileFragment(fragmentFilename, baseDir);
+
+    // Recursively replace macros nested an arbitrary number of levels deep. Recursion terminates when it encounters a
+    // template file that does not contain the specified macro (i.e. this replacer will not run when `rawText.replace`
+    // is called without an instance of the macro in the file contents).
+    return load(baseDir, macroName, rawFileContents);
   }
 
   return rawText.replace(new RegExp('\\b' + macroName + '\\s*\\(\\s*"((?:\\\\"|[^"])+)"\\s*\\)', 'g'), replacer)

--- a/test/fragment.spec.js
+++ b/test/fragment.spec.js
@@ -22,4 +22,14 @@ describe('Document definition fragments:', function() {
 
     testHelper.verifyDocumentCreated(doc);
   });
+
+  it('can create documents with nested imports', function() {
+    var doc = {
+      _id: 'objectFragmentDoc',
+      type: 'nestedImportDoc',
+      objectProp: { nestedProperty: -58 }
+    };
+
+    testHelper.verifyDocumentCreated(doc);
+  });
 });

--- a/test/resources/fragment-doc-definitions.js
+++ b/test/resources/fragment-doc-definitions.js
@@ -8,6 +8,7 @@ function() {
 
   return {
     singleQuotedFragmentDoc: importDocumentDefinitionFragment( 'fragment-string\'s-doc-definition.js' ),
-    doubleQuotedFragmentDoc: importDocumentDefinitionFragment( "fragment-boolean\'s-doc-definition.js" )
+    doubleQuotedFragmentDoc: importDocumentDefinitionFragment( "fragment-boolean\'s-doc-definition.js" ),
+    nestedImportDoc: importDocumentDefinitionFragment('fragment-object-doc-definition.js')
   };
 }

--- a/test/resources/fragment-nested-property.js
+++ b/test/resources/fragment-nested-property.js
@@ -1,0 +1,1 @@
+{ type: 'integer' }

--- a/test/resources/fragment-object-doc-definition.js
+++ b/test/resources/fragment-object-doc-definition.js
@@ -1,0 +1,13 @@
+{
+  typeFilter: simpleTypeFilter,
+  channels: { write: 'write' },
+  propertyValidators: {
+    objectProp: {
+      type: 'object',
+      required: true,
+      propertyValidators: {
+        nestedProperty: importDocumentDefinitionFragment('fragment-nested-property.js')
+      }
+    }
+  }
+}


### PR DESCRIPTION
The import of file fragments (e.g. using the `importSyncFunctionFragment` or `importDocumentDefinitionFragment` macros) is far more versatile now that they can be nested an arbitrary number of levels deep in the file hierarchy rather than only at the top level.

Addresses issue #215.