### PR TITLE
Issue 197: Month and day are now optional components of date-only strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 - [#207](https://github.com/Kashoo/synctos/issues/207): Ignore all top-level document properties that start with an underscore
 - [#204](https://github.com/Kashoo/synctos/issues/204): Constraint that requires string values to be trimmed
 - [#215](https://github.com/Kashoo/synctos/issues/215): Allow document definition fragments to be nested
+- [#197](https://github.com/Kashoo/synctos/issues/197): Make month and day components of date validation type optional
 
 ### Changed
 - [#212](https://github.com/Kashoo/synctos/issues/212): Improve document validation error messages

--- a/src/validation/document-definitions-validator.spec.js
+++ b/src/validation/document-definitions-validator.spec.js
@@ -208,7 +208,7 @@ describe('Document definitions validator:', function() {
         'myDoc1.propertyValidators.nestedObject.unrecognizedConstraint: "unrecognizedConstraint" is not allowed',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.dateProperty.immutableWhenSet: \"immutableWhenSet\" conflict with forbidden peer \"immutable\"',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.dateProperty.immutable: \"immutable\" conflict with forbidden peer \"immutableWhenSet\"',
-        'myDoc1.propertyValidators.nestedObject.propertyValidators.dateProperty.maximumValue: "maximumValue" with value "2018-01-31T17:31:27.283-08:00" fails to match the required pattern: /^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$/',
+        'myDoc1.propertyValidators.nestedObject.propertyValidators.dateProperty.maximumValue: "maximumValue" with value "2018-01-31T17:31:27.283-08:00" fails to match the required pattern: /^([0-9]{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12][0-9]|3[01]))?)?$/',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.dateProperty.maximumValue: \"maximumValue\" conflict with forbidden peer \"mustEqualStrict\"',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.dateProperty.mustEqualStrict: \"mustEqualStrict\" must be a string',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.dateProperty.customValidation: \"customValidation\" must have an arity lesser or equal to 4',

--- a/src/validation/property-validator-schema.js
+++ b/src/validation/property-validator-schema.js
@@ -17,7 +17,7 @@ var datetimeSchema = joi.any().when(
     then: datetimeStringSchema,
     otherwise: joi.date().options({ convert: false })
   });
-var dateOnlyStringSchema = joi.string().regex(/^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$/);
+var dateOnlyStringSchema = joi.string().regex(/^([0-9]{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12][0-9]|3[01]))?)?$/);
 var dateOnlySchema = joi.any().when(
   joi.string(),
   {

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -14,7 +14,7 @@ function validationModule() {
 
   // Check that a given value is a valid ISO 8601 date string without time and time zone components
   function isIso8601DateString(value) {
-    var regex = /^(([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))$/;
+    var regex = /^([0-9]{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12][0-9]|3[01]))?)?$/;
 
     // Verify that it's in ISO 8601 format (via the regex) and that it represents a valid day (via Date.parse)
     return regex.test(value) && !isNaN(Date.parse(value));

--- a/test/resources/date-doc-definitions.js
+++ b/test/resources/date-doc-definitions.js
@@ -7,7 +7,7 @@
     propertyValidators: {
       inclusiveRangeValidationProp: {
         type: 'date',
-        minimumValue: '2015-12-31T23:59:59.999Z',
+        minimumValue: new Date(Date.UTC(2015, 11, 31, 23, 59, 59, 999)),
         maximumValue: new Date(Date.UTC(2016, 0, 1, 23, 59, 59, 999))
       },
       exclusiveRangeValidationProp: {

--- a/test/resources/date-doc-definitions.js
+++ b/test/resources/date-doc-definitions.js
@@ -5,10 +5,15 @@
       return doc._id === 'dateDoc';
     },
     propertyValidators: {
-      rangeValidationProp: {
+      inclusiveRangeValidationProp: {
         type: 'date',
-        minimumValue: '2016-06-23',
-        maximumValue: new Date(Date.UTC(2016, 5, 23, 23, 59, 59, 999))
+        minimumValue: '2015-12-31T23:59:59.999Z',
+        maximumValue: new Date(Date.UTC(2016, 0, 1, 23, 59, 59, 999))
+      },
+      exclusiveRangeValidationProp: {
+        type: 'date',
+        minimumValueExclusive: '2018',
+        maximumValueExclusive: '2018-02-02'
       },
       formatValidationProp: {
         type: 'date'


### PR DESCRIPTION
Date strings now have the option to omit their month and day components. If a component is absent, its value is assumed to be "01" by convention (e.g. "2018-01" and "2018" are both the same date as "2018-01-01").

Addresses issue #197.