### PR TITLE
Issue 185: Set minimum supported Node.js version

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,7 @@
   "bitwise": true,
   "curly": true,
   "eqeqeq": true,
+  "esversion": 6,
   "freeze": true,
   "futurehostile": true,
   "latedef": "nofunc",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "node"
-  - "lts/*"
+  - "node" # Latest version
+  - "8.9.0" # Minimum supported version
 
 # Enable Greenkeeper's support for npm 5+ lockfiles: https://github.com/greenkeeperio/greenkeeper-lockfile
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 
 ### Changed
 - [#212](https://github.com/Kashoo/synctos/issues/212): Improve document validation error messages
+- [#185](https://github.com/Kashoo/synctos/issues/185): Upgrade minimum supported Node.js version to latest Long Term Support release
 
 ### Fixed
 - [#190](https://github.com/Kashoo/synctos/issues/190): JavaScript error when mustEqual constraint is violated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ Files in the project are organized into the following directories:
 * `etc`: Any development script or other type of file that is not part of the package's public interface (e.g. build scripts).
 * `lib`: Reserved for external packages (i.e. libraries) to be embedded as static dependencies in the project.
 * `samples`: A collection of document definitions that are purely for example purposes. Specifications for these document definitions are stored in the top level `test` directory. Code must be written to the **ECMAScript 3** specification for compatibility with Sync Gateway.
-* `src`: JavaScript code that is executable by Node.js. Specifications should be stored in files alongside the code under test in this directory. Code must be written to the **ECMAScript 5** specification for backward compatibility with previous versions of Node.js.
+* `src`: JavaScript code that is executable by Node.js. Specifications should be stored in files alongside the code under test in this directory. Code may be written to the subset of the **ECMAScript 2015** and later specifications that is supported by Node.js v8.9.0.
 * `templates`: JavaScript templates for sync functions/document definitions. Notably, the code in this directory is _not_ intended to be executable by Node.js. Specifications are stored in the top level `test` directory. Code must be written to the **ECMAScript 3** specification for compatibility with Sync Gateway.
-* `test`: Test cases for document definition configuration elements from the top level `templates` directory and example document definitions from the top level `samples` directory. Code must be written to the **ECMAScript 5** specification for backward compatibility with previous versions of Node.js.
+* `test`: Test cases for document definition configuration elements from the top level `templates` directory and example document definitions from the top level `samples` directory. Code may be written to the subset of the **ECMAScript 2015** and later specifications that is supported by Node.js v8.9.0.
 
 ### Commits
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To learn more about Sync Gateway, check out [Couchbase](http://www.couchbase.com
 
 # Installation
 
-Synctos is distributed as an [npm](https://www.npmjs.com/) package and has several npm development dependencies. As such, it requires that [Node.js](https://nodejs.org/) is installed in order to run. For best results use, at a minimum, the most recent Long Term Support (LTS) release.
+Synctos is distributed as an [npm](https://www.npmjs.com/) package and it requires that [Node.js](https://nodejs.org/) is installed in order to run. NOTE: The minimum officially supported version of Node.js is v8.9.0.
 
 To add synctos to your project, run `npm install synctos` from the project's root directory to install the package locally. Or, better yet, if you define a package.json file in your project, you can run `npm install synctos --savedev` to automatically install locally and insert the package into your package.json's developer dependencies.
 

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "bin": {
     "synctos": "./make-sync-function",
     "synctos-validate": "./validate-document-definitions"
+  },
+  "engines": {
+    "node": ">=8.9.0"
   }
 }


### PR DESCRIPTION
WARNING: Breaking change.

Updated the project's package configuration to indicate that only Node.js versions 8.9.0 or higher may be used. Technically earlier versions may work now and in the future, but they are not supported. Also increased the version of the ECMAScript specification that Node.js code supports from ES5 to ES2015/ES6.

Addresses issue #185 for the upcoming 2.0.0 release.