### PR TITLE
Issue 203: Manually parse ISO 8601 date strings for range validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 - [#207](https://github.com/Kashoo/synctos/issues/207): Ignore all top-level document properties that start with an underscore
 - [#204](https://github.com/Kashoo/synctos/issues/204): Constraint that requires string values to be trimmed
 - [#180](https://github.com/Kashoo/synctos/issues/180): Data validation type for time of day
+- [#203](https://github.com/Kashoo/synctos/issues/203): Date range validation fails for values far in the past or future
 - [#215](https://github.com/Kashoo/synctos/issues/215): Allow document definition fragments to be nested
 
 ### Changed

--- a/templates/sync-function-validation-module.js
+++ b/templates/sync-function-validation-module.js
@@ -29,14 +29,17 @@ function validationModule() {
 
   // Converts an ISO 8601 time into an array of its component pieces
   function extractIso8601TimePieces(value) {
-    var timePieces = value.split(/[:.,]/);
+    var timePieces = /^(\d{2}):(\d{2})(?:\:(\d{2}))?(?:\.(\d{1,3}))?$/.exec(value);
+    if (timePieces === null) {
+      return null;
+    }
 
-    var hour = timePieces[0] ? parseInt(timePieces[0], 10) : 0;
-    var minute = timePieces[1] ? parseInt(timePieces[1], 10) : 0;
-    var second = timePieces[2] ? parseInt(timePieces[2], 10) : 0;
+    var hour = timePieces[1] ? parseInt(timePieces[1], 10) : 0;
+    var minute = timePieces[2] ? parseInt(timePieces[2], 10) : 0;
+    var second = timePieces[3] ? parseInt(timePieces[3], 10) : 0;
 
     // The millisecond component has a variable length; normalize the length by padding it with zeros
-    var millisecond = timePieces[3] ? parseInt(padRight(timePieces[3], 3, '0'), 10) : 0;
+    var millisecond = timePieces[4] ? parseInt(padRight(timePieces[4], 3, '0'), 10) : 0;
 
     return [ hour, minute, second, millisecond ];
   }
@@ -51,6 +54,10 @@ function validationModule() {
     var aTimePieces = extractIso8601TimePieces(a);
     var bTimePieces = extractIso8601TimePieces(b);
 
+    if (aTimePieces === null || bTimePieces === null) {
+      return NaN;
+    }
+
     for (var timePieceIndex = 0; timePieceIndex < aTimePieces.length; timePieceIndex++) {
       if (aTimePieces[timePieceIndex] < bTimePieces[timePieceIndex]) {
         return -1;
@@ -63,12 +70,87 @@ function validationModule() {
     return 0;
   }
 
+  function extractIso8601DateOnlyPieces(value) {
+    var datePieces = /^(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?$/.exec(value);
+    if (datePieces === null) {
+      return null;
+    }
+
+    var year = datePieces[1] ? parseInt(datePieces[1], 10) : 0;
+    var month = datePieces[2] ? parseInt(datePieces[2], 10) : 1;
+    var day = datePieces[3] ? parseInt(datePieces[3], 10) : 1;
+
+    return [ year, month, day ];
+  }
+
+  function extractDateFromPieces(dateAndTimePieces) {
+    var dateString = dateAndTimePieces.length > 0 ? dateAndTimePieces[0] : '';
+    var datePieces = extractIso8601DateOnlyPieces(dateString);
+    if (datePieces === null) {
+      return null;
+    }
+
+    return {
+      year: datePieces[0],
+      month: datePieces[1],
+      day: datePieces[2]
+    };
+  }
+
+  function extractTimeFromPieces(dateAndTimePieces) {
+      // Default to midnight UTC if the candidate value represents a date only
+      var timeAndTimezoneString = dateAndTimePieces.length > 1 ? dateAndTimePieces[1] : '00:00:00.000Z';
+      var timezoneSeparatorIndex =
+        Math.max(timeAndTimezoneString.indexOf('-'), timeAndTimezoneString.indexOf('+'), timeAndTimezoneString.indexOf('Z'));
+
+      var timeString = (timezoneSeparatorIndex >= 0) ? timeAndTimezoneString.substr(0, timezoneSeparatorIndex) : timeAndTimezoneString;
+      var timePieces = extractIso8601TimePieces(timeString);
+      if (timePieces === null)
+      {
+        return null;
+      }
+
+      var timezoneString = (timezoneSeparatorIndex >= 0) ? timeAndTimezoneString.substr(timezoneSeparatorIndex) : null;
+
+      // Default to the server's local time zone offset if time zone is missing from the input
+      var timezoneOffsetMinutes = timezoneString !== null ? normalizeIso8601TimeZone(timezoneString) : -(new Date().getTimezoneOffset());
+
+      return {
+        hour: timePieces[0],
+        minute: timePieces[1],
+        second: timePieces[2],
+        millisecond: timePieces[3],
+        timezoneOffsetMinutes: timezoneOffsetMinutes
+      };
+  }
+
   // Converts the given date representation to a timestamp that represents the number of ms since the Unix epoch
   function convertToTimestamp(value) {
     if (value instanceof Date) {
       return value.getTime();
-    } else if (typeof value === 'string' || typeof value === 'number') {
-      return new Date(value).getTime();
+    } else if (typeof value === 'number') {
+      return Math.floor(value);
+    } else if (typeof value === 'string') {
+      var dateAndTimePieces = value.split('T', 2);
+
+      var date = extractDateFromPieces(dateAndTimePieces);
+      if (date === null) {
+        return NaN;
+      }
+
+      var time = extractTimeFromPieces(dateAndTimePieces);
+      if (time === null) {
+        return NaN;
+      }
+
+      return Date.UTC(
+        date.year,
+        date.month - 1,
+        date.day,
+        time.hour,
+        time.minute - time.timezoneOffsetMinutes,
+        time.second,
+        time.millisecond);
     } else {
       return NaN;
     }
@@ -84,6 +166,25 @@ function validationModule() {
       return NaN;
     } else {
       return aTimestamp - bTimestamp;
+    }
+  }
+
+  // Converts an ISO 8601 time zone into the number of minutes offset from UTC
+  function normalizeIso8601TimeZone(value) {
+    if (value === 'Z') {
+      return 0;
+    }
+
+    var regex = /^([+-])(\d\d):?(\d\d)$/;
+    var matches = regex.exec(value);
+    if (matches === null) {
+      return NaN;
+    } else {
+      var multiplicationFactor = (matches[1] === '+') ? 1 : -1;
+      var hour = parseInt(matches[2], 10);
+      var minute = parseInt(matches[3], 10);
+
+      return multiplicationFactor * ((hour * 60) + minute);
     }
   }
 

--- a/test/datetime.spec.js
+++ b/test/datetime.spec.js
@@ -224,11 +224,11 @@ describe('Date/time validation type', function() {
     });
   });
 
-  describe('range validation for min and max dates with time and time zone components', function() {
+  describe('inclusive range validation for min and max dates with time and time zone components', function() {
     it('can create a doc with a date/time that is within the minimum and maximum values', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatetimesProp: '2016-06-24T08:22:17.123+0230'  // Same date/time as the min and max values, different time zone
+        inclusiveRangeValidationAsDatetimesProp: '2016-06-24T08:22:17.123+0230'  // Same date/time as the min and max values, different time zone
       };
 
       testHelper.verifyDocumentCreated(doc);
@@ -237,67 +237,67 @@ describe('Date/time validation type', function() {
     it('cannot create a doc with a date/time that is less than the minimum value', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatetimesProp: '2016-06-24T05:52:17.122Z'
+        inclusiveRangeValidationAsDatetimesProp: '2016-06-24T05:52:17.122Z'
       };
 
       testHelper.verifyDocumentNotCreated(
         doc,
         'datetimeDoc',
-        errorFormatter.minimumValueViolation('rangeValidationAsDatetimesProp', '2016-06-24T05:52:17.123Z'));
+        errorFormatter.minimumValueViolation('inclusiveRangeValidationAsDatetimesProp', '2016-06-24T05:52:17.123Z'));
     });
 
     it('cannot create a doc with a date without time and time zone components that is less than the minimum value', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatetimesProp: '2016-06-24'  // Treated as UTC when time zone is undefined, making it less than the min value
+        inclusiveRangeValidationAsDatetimesProp: '2016-06-24'  // Treated as midnight UTC when time component is missing, making it less than the min value
       };
 
       testHelper.verifyDocumentNotCreated(
         doc,
         'datetimeDoc',
-        errorFormatter.minimumValueViolation('rangeValidationAsDatetimesProp', '2016-06-24T05:52:17.123Z'));
+        errorFormatter.minimumValueViolation('inclusiveRangeValidationAsDatetimesProp', '2016-06-24T05:52:17.123Z'));
     });
 
     it('cannot create a doc with a date/time that is greater than the maximum value', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatetimesProp: '2016-06-23T21:52:17.124-08:00'
+        inclusiveRangeValidationAsDatetimesProp: '2016-06-23T21:52:17.124-08:00'
       };
 
       testHelper.verifyDocumentNotCreated(
         doc,
         'datetimeDoc',
-        errorFormatter.maximumValueViolation('rangeValidationAsDatetimesProp', '2016-06-24T05:52:17.123Z'));
+        errorFormatter.maximumValueViolation('inclusiveRangeValidationAsDatetimesProp', '2016-06-24T05:52:17.123Z'));
     });
 
     it('cannot create a doc with a date without time and time zone components that is greater than the maximum value', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatetimesProp: '2016-06-25'
+        inclusiveRangeValidationAsDatetimesProp: '2016-06-25'
       };
 
       testHelper.verifyDocumentNotCreated(
         doc,
         'datetimeDoc',
-        errorFormatter.maximumValueViolation('rangeValidationAsDatetimesProp', '2016-06-24T05:52:17.123Z'));
+        errorFormatter.maximumValueViolation('inclusiveRangeValidationAsDatetimesProp', '2016-06-24T05:52:17.123Z'));
     });
 
     it('does not consider an invalid date/time as out of range', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatetimesProp: 'not-a-date'
+        inclusiveRangeValidationAsDatetimesProp: 'not-a-date'
       };
 
       // While the invalid input is not considered out of range, the document is still rejected because the format is invalid
-      testHelper.verifyDocumentNotCreated(doc, 'datetimeDoc', errorFormatter.datetimeFormatInvalid('rangeValidationAsDatetimesProp'));
+      testHelper.verifyDocumentNotCreated(doc, 'datetimeDoc', errorFormatter.datetimeFormatInvalid('inclusiveRangeValidationAsDatetimesProp'));
     });
   });
 
-  describe('range validation for min and max dates without time and time zone components', function() {
+  describe('inclusive range validation for min and max dates without time and time zone components', function() {
     it('can create a doc with a date/time that is within the minimum and maximum values', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatesOnlyProp: '2016-06-23T16:30:00.000-07:30'  // When adjusted to UTC, this matches the min and max dates
+        inclusiveRangeValidationAsDatesOnlyProp: '2016-06-23T16:30:00.000-07:30'  // When adjusted to UTC, this matches the min and max dates
       };
 
       testHelper.verifyDocumentCreated(doc);
@@ -306,7 +306,7 @@ describe('Date/time validation type', function() {
     it('can create a doc with a date without time and time zone components that is within the minimum and maximum values', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatesOnlyProp: '2016-06-24'
+        inclusiveRangeValidationAsDatesOnlyProp: '2016-06-24'
       };
 
       testHelper.verifyDocumentCreated(doc);
@@ -315,59 +315,120 @@ describe('Date/time validation type', function() {
     it('cannot create a doc with a date/time that is less than the minimum value', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatesOnlyProp: '2016-06-23T23:59:59.999Z'
+        inclusiveRangeValidationAsDatesOnlyProp: '2016-06-23T23:59:59.999Z'
       };
 
       testHelper.verifyDocumentNotCreated(
         doc,
         'datetimeDoc',
-        errorFormatter.minimumValueViolation('rangeValidationAsDatesOnlyProp', '2016-06-24T00:00:00.000Z'));
+        errorFormatter.minimumValueViolation('inclusiveRangeValidationAsDatesOnlyProp', '2016-06-24T00:00:00.000Z'));
     });
 
     it('cannot create a doc with a date without time and time zone components that is less than the minimum value', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatesOnlyProp: '2016-06-23'
+        inclusiveRangeValidationAsDatesOnlyProp: '2016-06-23'
       };
 
       testHelper.verifyDocumentNotCreated(
         doc,
         'datetimeDoc',
-        errorFormatter.minimumValueViolation('rangeValidationAsDatesOnlyProp', '2016-06-24T00:00:00.000Z'));
+        errorFormatter.minimumValueViolation('inclusiveRangeValidationAsDatesOnlyProp', '2016-06-24T00:00:00.000Z'));
     });
 
     it('cannot create a doc with a date/time that is greater than the maximum value', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatesOnlyProp: '2016-06-24T00:00:00.001Z'
+        inclusiveRangeValidationAsDatesOnlyProp: '2016-06-24T00:00:00.001Z'
       };
 
       testHelper.verifyDocumentNotCreated(
         doc,
         'datetimeDoc',
-        errorFormatter.maximumValueViolation('rangeValidationAsDatesOnlyProp', '2016-06-24'));
+        errorFormatter.maximumValueViolation('inclusiveRangeValidationAsDatesOnlyProp', '2016-06-24'));
     });
 
     it('cannot create a doc with a date without time and time zone components that is greater than the maximum value', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatesOnlyProp: '2016-06-25'
+        inclusiveRangeValidationAsDatesOnlyProp: '2016-06-25'
       };
 
       testHelper.verifyDocumentNotCreated(
         doc,
         'datetimeDoc',
-        errorFormatter.maximumValueViolation('rangeValidationAsDatesOnlyProp', '2016-06-24'));
+        errorFormatter.maximumValueViolation('inclusiveRangeValidationAsDatesOnlyProp', '2016-06-24'));
     });
 
     it('does not consider an invalid date as out of range', function() {
       var doc = {
         _id: 'datetimeDoc',
-        rangeValidationAsDatesOnlyProp: 'not-a-date'
+        inclusiveRangeValidationAsDatesOnlyProp: 'not-a-date'
       };
 
       // While the invalid input is not considered out of range, the document is still rejected because the format is invalid
-      testHelper.verifyDocumentNotCreated(doc, 'datetimeDoc', errorFormatter.datetimeFormatInvalid('rangeValidationAsDatesOnlyProp'));
+      testHelper.verifyDocumentNotCreated(doc, 'datetimeDoc', errorFormatter.datetimeFormatInvalid('inclusiveRangeValidationAsDatesOnlyProp'));
+    });
+  });
+
+  describe('exclusive range validation', function() {
+    it('allows a date/time that is within the minimum and maximum values', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        exclusiveRangeValidationAsDatetimesProp: new Date('2018-02-08T12:22:38').toISOString() // Output as UTC
+      };
+
+      testHelper.verifyDocumentCreated(doc);
+    });
+
+    it('rejects a date/time that is less than the minimum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        exclusiveRangeValidationAsDatetimesProp: '2018-02-07'
+      };
+
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'datetimeDoc',
+        errorFormatter.minimumValueExclusiveViolation('exclusiveRangeValidationAsDatetimesProp', '2018-02-08T12:22:37.9'));
+    });
+
+    it('rejects a date/time that is equal to the minimum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        exclusiveRangeValidationAsDatetimesProp: new Date('2018-02-08T12:22:37.900').toISOString() // Output as UTC
+      };
+
+      console.log('exclusiveRangeValidationAsDatetimesProp: ' + doc.exclusiveRangeValidationAsDatetimesProp);
+
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'datetimeDoc',
+        errorFormatter.minimumValueExclusiveViolation('exclusiveRangeValidationAsDatetimesProp', '2018-02-08T12:22:37.9'));
+    });
+
+    it('rejects a date/time that is greater than the maximum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        exclusiveRangeValidationAsDatetimesProp: '2018-02-08T19:35'
+      };
+
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'datetimeDoc',
+        errorFormatter.maximumValueExclusiveViolation('exclusiveRangeValidationAsDatetimesProp', '2018-02-08T12:22:38.1'));
+    });
+
+    it('rejects a date/time that is equal to the maximum value', function() {
+      var doc = {
+        _id: 'datetimeDoc',
+        exclusiveRangeValidationAsDatetimesProp: new Date('2018-02-08T12:22:38.10').toISOString() // Output as UTC
+      };
+
+      testHelper.verifyDocumentNotCreated(
+        doc,
+        'datetimeDoc',
+        errorFormatter.maximumValueExclusiveViolation('exclusiveRangeValidationAsDatetimesProp', '2018-02-08T12:22:38.1'));
     });
   });
 });

--- a/test/resources/datetime-doc-definitions.js
+++ b/test/resources/datetime-doc-definitions.js
@@ -5,15 +5,20 @@
       return doc._id === 'datetimeDoc';
     },
     propertyValidators: {
-      rangeValidationAsDatetimesProp: {
+      inclusiveRangeValidationAsDatetimesProp: {
         type: 'datetime',
         minimumValue: new Date('2016-06-23T21:52:17.123-08:00'),
         maximumValue: '2016-06-24T05:52:17.123Z'  // This is the same date and time, just specified as UTC
       },
-      rangeValidationAsDatesOnlyProp: {
+      inclusiveRangeValidationAsDatesOnlyProp: {
         type: 'datetime',
         minimumValue: new Date('2016-06-24'),
         maximumValue: '2016-06-24'
+      },
+      exclusiveRangeValidationAsDatetimesProp: {
+        type: 'datetime',
+        minimumValueExclusive: '2018-02-08T12:22:37.9',
+        maximumValueExclusive: '2018-02-08T12:22:38.1'
       },
       formatValidationProp: {
         type: 'datetime'


### PR DESCRIPTION
Workaround to an issue in which the `date` and `datetime` range constraints mishandle dates after "2262-04-11T23:47:16.854Z" or before "1677-09-21T00:12:43.146Z" due to a bug in the `Date` constructor and `Date.parse`'s parser implementation for ISO 8601 date strings. Dates are now manually parsed from ISO 8601 string form and used to construct timestamps directly when performing range validation checks.

Addresses issue #203.