### PR TITLE
Issue 230: Fix file path resolution for test and validation environment templates

### DIFF
--- a/src/testing/test-environment-maker.js
+++ b/src/testing/test-environment-maker.js
@@ -9,6 +9,7 @@
 exports.init = init;
 
 var fs = require('fs');
+var path = require('path');
 var vm = require('vm');
 var underscore = require('../../lib/underscore/underscore-min');
 var simpleMock = require('../../lib/simple-mock/index');
@@ -19,7 +20,8 @@ function init(rawSyncFunction, syncFunctionFile) {
     displayErrors: true
   };
 
-  var environmentTemplate = fs.readFileSync('templates/test-environment-template.js', 'utf8').trim();
+  var filePath = path.resolve(__dirname, '../../templates/test-environment-template.js');
+  var environmentTemplate = fs.readFileSync(filePath, 'utf8').trim();
 
   // The test environment includes a placeholder string called "%SYNC_FUNC_PLACEHOLDER%" that is to be replaced with the contents of
   // the sync function

--- a/src/testing/test-environment-maker.spec.js
+++ b/src/testing/test-environment-maker.spec.js
@@ -1,4 +1,5 @@
 var expect = require('chai').expect;
+var path = require('path');
 var simpleMock = require('../../lib/simple-mock/index.js');
 var mockRequire = require('mock-require');
 
@@ -48,7 +49,10 @@ describe('Test environment maker', function() {
     expect(result).to.eql(expectedResult);
 
     expect(fsMock.readFileSync.callCount).to.equal(1);
-    expect(fsMock.readFileSync.calls[0].args).to.eql([ 'templates/test-environment-template.js', 'utf8' ]);
+    expect(fsMock.readFileSync.calls[0].args).to.eql([
+      path.resolve(__dirname, '../../templates/test-environment-template.js'),
+      'utf8'
+    ]);
 
     expect(vmMock.runInThisContext.callCount).to.equal(1);
     expect(vmMock.runInThisContext.calls[0].args).to.eql([

--- a/src/validation/validation-environment-maker.js
+++ b/src/validation/validation-environment-maker.js
@@ -12,6 +12,7 @@
 exports.init = init;
 
 var fs = require('fs');
+var path = require('path');
 var vm = require('vm');
 var underscore = require('../../lib/underscore/underscore-min');
 var simpleMock = require('../../lib/simple-mock/index');
@@ -22,7 +23,8 @@ function init(docDefinitionsString, originalFilename) {
     displayErrors: true
   };
 
-  var envTemplateString = fs.readFileSync('templates/validation-environment-template.js', 'utf8').trim();
+  var filePath = path.resolve(__dirname, '../../templates/validation-environment-template.js');
+  var envTemplateString = fs.readFileSync(filePath, 'utf8').trim();
 
   // The test helper environment includes a placeholder string called "%DOC_DEFINITIONS_PLACEHOLDER%" that is to be replaced with the
   // contents of the document definitions

--- a/src/validation/validation-environment-maker.spec.js
+++ b/src/validation/validation-environment-maker.spec.js
@@ -1,4 +1,5 @@
 var expect = require('chai').expect;
+var path = require('path');
 var simpleMock = require('../../lib/simple-mock/index');
 var mockRequire = require('mock-require');
 
@@ -40,7 +41,10 @@ describe('Validation environment maker', function() {
     expect(result).to.eql(expectedResult);
 
     expect(fsMock.readFileSync.callCount).to.equal(1);
-    expect(fsMock.readFileSync.calls[0].args).to.eql([ 'templates/validation-environment-template.js', 'utf8' ]);
+    expect(fsMock.readFileSync.calls[0].args).to.eql([
+      path.resolve(__dirname, '../../templates/validation-environment-template.js'),
+      'utf8'
+    ]);
 
     expect(vmMock.runInThisContext.callCount).to.equal(1);
     expect(vmMock.runInThisContext.calls[0].args).to.eql([


### PR DESCRIPTION
Previously the `test-environment-maker` and `validation-environment-maker` modules used a relative file path to reference their respective template files. However, this is invalid when the module is run from a dependent project since the current working directory will be the root of _that_ project rather than the root of synctos. Now it uses Node.js' built in `path` module to resolve the template file paths correctly.

Required for issue #230.