### PR TITLE
Issue 235: Minimum and maximum value constraint tests for strings

### DIFF
--- a/test/resources/string-doc-definitions.js
+++ b/test/resources/string-doc-definitions.js
@@ -19,6 +19,14 @@ function() {
     return doc.dynamicMustBeTrimmedState;
   }
 
+  function dynamicMinimumValue(doc, oldDoc, value, oldValue) {
+    return doc.dynamicMinimumValue;
+  }
+
+  function dynamicMaximumValue(doc, oldDoc, value, oldValue) {
+    return doc.dynamicMaximumValue;
+  }
+
   return {
     stringDoc: {
       channels: { write: 'write' },
@@ -71,6 +79,32 @@ function() {
         dynamicMustBeTrimmedValidationProp: {
           type: 'string',
           mustBeTrimmed: dynamicMustBeTrimmed
+        },
+        staticInclusiveRangeValidationProp: {
+          type: 'string',
+          minimumValue: 'A',
+          maximumValue: 'Z'
+        },
+        staticExclusiveRangeValidationProp: {
+          type: 'string',
+          minimumValueExclusive: 'aa',
+          maximumValueExclusive: 'c'
+        },
+        dynamicMinimumValue: {
+          type: 'string'
+        },
+        dynamicMaximumValue: {
+          type: 'string'
+        },
+        dynamicInclusiveRangeValidationProp: {
+          type: 'string',
+          minimumValue: dynamicMinimumValue,
+          maximumValue: dynamicMaximumValue
+        },
+        dynamicExclusiveRangeValidationProp: {
+          type: 'string',
+          minimumValueExclusive: dynamicMinimumValue,
+          maximumValueExclusive: dynamicMaximumValue
         }
       }
     }

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -252,4 +252,202 @@ describe('String validation type', function() {
       });
     });
   });
+
+  describe('inclusive range constraints', () => {
+    describe('with static validation', () => {
+      it('allows a value that falls between the minimum and maximum values', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticInclusiveRangeValidationProp: 'Right'
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a value that matches the minimum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticInclusiveRangeValidationProp: 'A'
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('allows a value that matches the maximum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticInclusiveRangeValidationProp: 'Z'
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('rejects a value that is less than the minimum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticInclusiveRangeValidationProp: '9'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.minimumValueViolation('staticInclusiveRangeValidationProp', 'A') ]);
+      });
+
+      it('rejects a value that is greater than the maximum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticInclusiveRangeValidationProp: 'wrong'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.maximumValueViolation('staticInclusiveRangeValidationProp', 'Z') ]);
+      });
+    });
+
+    describe('with dynamic validation', () => {
+      it('allows a value that falls between the minimum and maximum values', () => {
+        const doc = {
+          _id: 'stringDoc',
+          dynamicMinimumValue: '5',
+          dynamicMaximumValue: '5999',
+          dynamicInclusiveRangeValidationProp: '54'
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('rejects a value that is less than the minimum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          dynamicMinimumValue: '3',
+          dynamicMaximumValue: '4',
+          dynamicInclusiveRangeValidationProp: '2.99999'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.minimumValueViolation('dynamicInclusiveRangeValidationProp', '3') ]);
+      });
+
+      it('rejects a value that is greater than the maximum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          dynamicMinimumValue: 'a',
+          dynamicMaximumValue: 'z',
+          dynamicInclusiveRangeValidationProp: '{'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.maximumValueViolation('dynamicInclusiveRangeValidationProp', 'z') ]);
+      });
+    });
+  });
+
+  describe('exclusive range constraints', () => {
+    describe('with static validation', () => {
+      it('allows a value that falls between the minimum and maximum values', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticExclusiveRangeValidationProp: 'aaa'
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('rejects a value that matches the minimum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticExclusiveRangeValidationProp: 'aa'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.minimumValueExclusiveViolation('staticExclusiveRangeValidationProp', 'aa') ]);
+      });
+
+      it('rejects a value that matches the maximum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticExclusiveRangeValidationProp: 'c'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.maximumValueExclusiveViolation('staticExclusiveRangeValidationProp', 'c') ]);
+      });
+
+      it('rejects a value that is less than the minimum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticExclusiveRangeValidationProp: 'a'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.minimumValueExclusiveViolation('staticExclusiveRangeValidationProp', 'aa') ]);
+      });
+
+      it('rejects a value that is greater than the maximum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          staticExclusiveRangeValidationProp: 'cc'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.maximumValueExclusiveViolation('staticExclusiveRangeValidationProp', 'c') ]);
+      });
+    });
+
+    describe('with dynamic validation', () => {
+      it('allows a value that falls between the minimum and maximum values', () => {
+        const doc = {
+          _id: 'stringDoc',
+          dynamicMinimumValue: '@',
+          dynamicMaximumValue: '[',
+          dynamicExclusiveRangeValidationProp: 'Good'
+        };
+
+        testHelper.verifyDocumentCreated(doc);
+      });
+
+      it('rejects a value that matches the minimum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          dynamicMinimumValue: 'F',
+          dynamicMaximumValue: 'f',
+          dynamicExclusiveRangeValidationProp: 'F'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.minimumValueExclusiveViolation('dynamicExclusiveRangeValidationProp', 'F') ]);
+      });
+
+      it('rejects a value that matches the maximum value', () => {
+        const doc = {
+          _id: 'stringDoc',
+          dynamicMinimumValue: '{',
+          dynamicMaximumValue: '}',
+          dynamicExclusiveRangeValidationProp: '}'
+        };
+
+        testHelper.verifyDocumentNotCreated(
+          doc,
+          'stringDoc',
+          [ errorFormatter.maximumValueExclusiveViolation('dynamicExclusiveRangeValidationProp', '}') ]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Verifies that the inclusive and exclusive range constraints work as expected for the `string` validation type.

Addresses issue #235.