### PR TITLE
Issue 217: Extract attachment validation logic into its own module

### DIFF
--- a/templates/.jshintrc
+++ b/templates/.jshintrc
@@ -7,17 +7,10 @@
     "access": false,
     "channel": false,
     "customActionStub": false,
-    "getEffectiveOldDoc": false,
     "importSyncFunctionFragment": false,
-    "isDocumentMissingOrDeleted": false,
-    "isValueNullOrUndefined": false,
-    "jsonStringify": false,
-    "padRight": false,
     "requireAccess": false,
     "requireRole": false,
     "requireUser": false,
-    "role": false,
-    "simpleTypeFilter": false,
-    "typeIdValidator": false
+    "role": false
   }
 }

--- a/templates/sync-function/access-assignment-module.js
+++ b/templates/sync-function/access-assignment-module.js
@@ -1,4 +1,4 @@
-function accessAssignmentModule() {
+function accessAssignmentModule(utils) {
   // Adds a prefix to the specified item if the prefix is defined
   function prefixItem(item, prefix) {
     return prefix ? prefix + item : item.toString();
@@ -6,14 +6,14 @@ function accessAssignmentModule() {
 
   // Transforms the given item or items into a new list of items with the specified prefix (if any) appended to each element
   function resolveCollectionItems(originalItems, itemPrefix) {
-    if (isValueNullOrUndefined(originalItems)) {
+    if (utils.isValueNullOrUndefined(originalItems)) {
       return [ ];
     } else if (originalItems instanceof Array) {
       var resultItems = [ ];
       for (var i = 0; i < originalItems.length; i++) {
         var item = originalItems[i];
 
-        if (isValueNullOrUndefined(item)) {
+        if (utils.isValueNullOrUndefined(item)) {
           continue;
         }
 
@@ -30,7 +30,7 @@ function accessAssignmentModule() {
   // Transforms the given collection definition, which may have been defined as a single item, a list of items or a function that returns a
   // list of items into a simple list, where each item has the specified prefix, if any
   function resolveCollectionDefinition(doc, oldDoc, collectionDefinition, itemPrefix) {
-    if (isValueNullOrUndefined(collectionDefinition)) {
+    if (utils.isValueNullOrUndefined(collectionDefinition)) {
       return [ ];
     } else {
       if (typeof collectionDefinition === 'function') {
@@ -89,7 +89,7 @@ function accessAssignmentModule() {
 
   // Assigns role access to users and/or channel access to users/roles according to the given access assignment definitions
   function assignUserAccess(doc, oldDoc, accessAssignmentDefinitions) {
-    var effectiveOldDoc = getEffectiveOldDoc(oldDoc);
+    var effectiveOldDoc = utils.resolveOldDoc(oldDoc);
 
     var effectiveAssignments = [ ];
     for (var assignmentIndex = 0; assignmentIndex < accessAssignmentDefinitions.length; assignmentIndex++) {
@@ -97,7 +97,7 @@ function accessAssignmentModule() {
 
       if (definition.type === 'role') {
         effectiveAssignments.push(assignRolesToUsers(doc, effectiveOldDoc, definition));
-      } else if (definition.type === 'channel' || isValueNullOrUndefined(definition.type)) {
+      } else if (definition.type === 'channel' || utils.isValueNullOrUndefined(definition.type)) {
         effectiveAssignments.push(assignChannelsToUsersAndRoles(doc, effectiveOldDoc, definition));
       }
     }

--- a/templates/sync-function/attachment-module.js
+++ b/templates/sync-function/attachment-module.js
@@ -1,0 +1,132 @@
+function attachmentModule(utils, buildItemPath, resolveDocConstraint, resolveItemConstraint) {
+  var attachmentReferenceValidators = { };
+
+  return {
+    validateAttachmentReference: validateAttachmentReference,
+    validateAttachments: validateAttachments
+  };
+
+  function validateAttachmentReference(validator, itemStack, docAttachments) {
+    var validationErrors = [ ];
+    var currentItemEntry = itemStack[itemStack.length - 1];
+    var itemValue = currentItemEntry.itemValue;
+
+    if (typeof itemValue !== 'string') {
+      validationErrors.push('item "' + buildItemPath(itemStack) + '" must be an attachment reference string');
+    } else {
+      attachmentReferenceValidators[itemValue] = validator;
+
+      var supportedExtensions = resolveItemConstraint(validator.supportedExtensions);
+      if (supportedExtensions) {
+        var extRegex = buildSupportedExtensionsRegex(supportedExtensions);
+        if (!extRegex.test(itemValue)) {
+          validationErrors.push('attachment reference "' + buildItemPath(itemStack) + '" must have a supported file extension (' + supportedExtensions.join(',') + ')');
+        }
+      }
+
+      // Because the addition of an attachment is typically a separate operation from the creation/update of the associated document, we
+      // can't guarantee that the attachment is present when the attachment reference property is created/updated for it, so only
+      // validate it if it's present. The good news is that, because adding an attachment is a two part operation (create/update the
+      // document and add the attachment), the sync function will be run once for each part, thus ensuring the content is verified once
+      // both parts have been synced.
+      if (docAttachments && docAttachments[itemValue]) {
+        var attachment = docAttachments[itemValue];
+
+        var supportedContentTypes = resolveItemConstraint(validator.supportedContentTypes);
+        if (supportedContentTypes && supportedContentTypes.indexOf(attachment.content_type) < 0) {
+          validationErrors.push('attachment reference "' + buildItemPath(itemStack) + '" must have a supported content type (' + supportedContentTypes.join(',') + ')');
+        }
+
+        var maximumSize = resolveItemConstraint(validator.maximumSize);
+        if (!utils.isValueNullOrUndefined(maximumSize) && attachment.length > maximumSize) {
+          validationErrors.push('attachment reference "' + buildItemPath(itemStack) + '" must not be larger than ' + maximumSize + ' bytes');
+        }
+      }
+    }
+
+    return validationErrors;
+  }
+
+  function validateAttachments(doc, oldDoc, docDefinition) {
+    var validationErrors = [ ];
+    var attachmentConstraints = resolveDocConstraint(doc, oldDoc, docDefinition.attachmentConstraints);
+
+    var maximumAttachmentCount =
+      attachmentConstraints ? resolveDocConstraint(doc, oldDoc, attachmentConstraints.maximumAttachmentCount) : null;
+    var maximumIndividualAttachmentSize =
+      attachmentConstraints ? resolveDocConstraint(doc, oldDoc, attachmentConstraints.maximumIndividualSize) : null;
+    var maximumTotalAttachmentSize =
+      attachmentConstraints ? resolveDocConstraint(doc, oldDoc, attachmentConstraints.maximumTotalSize) : null;
+
+    var supportedExtensions = attachmentConstraints ? resolveDocConstraint(doc, oldDoc, attachmentConstraints.supportedExtensions) : null;
+    var supportedExtensionsRegex = supportedExtensions ? buildSupportedExtensionsRegex(supportedExtensions) : null;
+
+    var supportedContentTypes =
+      attachmentConstraints ? resolveDocConstraint(doc, oldDoc, attachmentConstraints.supportedContentTypes) : null;
+
+    var requireAttachmentReferences =
+      attachmentConstraints ? resolveDocConstraint(doc, oldDoc, attachmentConstraints.requireAttachmentReferences) : false;
+
+    var totalSize = 0;
+    var attachmentCount = 0;
+    for (var attachmentName in doc._attachments) {
+      attachmentCount++;
+
+      var attachment = doc._attachments[attachmentName];
+
+      var attachmentSize = attachment.length;
+      totalSize += attachmentSize;
+
+      var attachmentRefValidator = attachmentReferenceValidators[attachmentName];
+
+      if (requireAttachmentReferences && utils.isValueNullOrUndefined(attachmentRefValidator)) {
+        validationErrors.push('attachment ' + attachmentName + ' must have a corresponding attachment reference property');
+      }
+
+      if (utils.isValueAnInteger(maximumIndividualAttachmentSize) && attachmentSize > maximumIndividualAttachmentSize) {
+        // If this attachment is owned by an attachment reference property, that property's size constraint (if any) takes precedence
+        if (utils.isValueNullOrUndefined(attachmentRefValidator) || !utils.isValueAnInteger(attachmentRefValidator.maximumSize)) {
+          validationErrors.push('attachment ' + attachmentName + ' must not exceed ' + maximumIndividualAttachmentSize + ' bytes');
+        }
+      }
+
+      if (supportedExtensionsRegex && !supportedExtensionsRegex.test(attachmentName)) {
+        // If this attachment is owned by an attachment reference property, that property's extensions constraint (if any) takes
+        // precedence
+        if (utils.isValueNullOrUndefined(attachmentRefValidator) ||
+            utils.isValueNullOrUndefined(attachmentRefValidator.supportedExtensions)) {
+          validationErrors.push('attachment "' + attachmentName + '" must have a supported file extension (' + supportedExtensions.join(',') + ')');
+        }
+      }
+
+      if (supportedContentTypes && supportedContentTypes.indexOf(attachment.content_type) < 0) {
+        // If this attachment is owned by an attachment reference property, that property's content types constraint (if any) takes
+        // precedence
+        if (utils.isValueNullOrUndefined(attachmentRefValidator) ||
+            utils.isValueNullOrUndefined(attachmentRefValidator.supportedContentTypes)) {
+          validationErrors.push('attachment "' + attachmentName + '" must have a supported content type (' + supportedContentTypes.join(',') + ')');
+        }
+      }
+    }
+
+    if (utils.isValueAnInteger(maximumTotalAttachmentSize) && totalSize > maximumTotalAttachmentSize) {
+      validationErrors.push('documents of this type must not have a combined attachment size greater than ' + maximumTotalAttachmentSize + ' bytes');
+    }
+
+    if (utils.isValueAnInteger(maximumAttachmentCount) && attachmentCount > maximumAttachmentCount) {
+      validationErrors.push('documents of this type must not have more than ' + maximumAttachmentCount + ' attachments');
+    }
+
+    if (!resolveDocConstraint(doc, oldDoc, docDefinition.allowAttachments) && attachmentCount > 0) {
+      validationErrors.push('document type does not support attachments');
+    }
+
+    return validationErrors;
+  }
+
+  // A regular expression that matches one of the given file extensions
+  function buildSupportedExtensionsRegex(extensions) {
+    // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
+    return new RegExp("\\.(" + extensions.join("|") + ")$", "i");
+  }
+}

--- a/templates/sync-function/authorization-module.js
+++ b/templates/sync-function/authorization-module.js
@@ -1,8 +1,8 @@
-function authorizationModule() {
+function authorizationModule(utils) {
   // A document definition may define its authorizations (channels, roles or users) for each operation type (view, add, replace, delete or
   // write) as either a string or an array of strings. In either case, add them to the list if they are not already present.
   function appendToAuthorizationList(allAuthorizations, authorizationsToAdd) {
-    if (!isValueNullOrUndefined(authorizationsToAdd)) {
+    if (!utils.isValueNullOrUndefined(authorizationsToAdd)) {
       if (authorizationsToAdd instanceof Array) {
         for (var i = 0; i < authorizationsToAdd.length; i++) {
           var authorization = authorizationsToAdd[i];
@@ -19,7 +19,7 @@ function authorizationModule() {
   // A document definition may define its authorized channels, roles or users as either a function or an object/hashtable
   function getAuthorizationMap(doc, oldDoc, authorizationDefinition) {
     if (typeof authorizationDefinition === 'function') {
-      return authorizationDefinition(doc, getEffectiveOldDoc(oldDoc));
+      return authorizationDefinition(doc, utils.resolveOldDoc(oldDoc));
     } else {
       return authorizationDefinition;
     }
@@ -45,7 +45,7 @@ function authorizationModule() {
   function getRequiredAuthorizations(doc, oldDoc, authorizationDefinition) {
     var authorizationMap = getAuthorizationMap(doc, oldDoc, authorizationDefinition);
 
-    if (isValueNullOrUndefined(authorizationMap)) {
+    if (utils.isValueNullOrUndefined(authorizationMap)) {
       // This document type does not define any authorizations (channels, roles, users) at all
       return null;
     }
@@ -62,10 +62,10 @@ function authorizationModule() {
         writeAuthorizationFound = true;
         appendToAuthorizationList(requiredAuthorizations, authorizationMap.remove);
       }
-    } else if (!isDocumentMissingOrDeleted(oldDoc) && authorizationMap.replace) {
+    } else if (!utils.isDocumentMissingOrDeleted(oldDoc) && authorizationMap.replace) {
       writeAuthorizationFound = true;
       appendToAuthorizationList(requiredAuthorizations, authorizationMap.replace);
-    } else if (isDocumentMissingOrDeleted(oldDoc) && authorizationMap.add) {
+    } else if (utils.isDocumentMissingOrDeleted(oldDoc) && authorizationMap.add) {
       writeAuthorizationFound = true;
       appendToAuthorizationList(requiredAuthorizations, authorizationMap.add);
     }

--- a/templates/sync-function/comparison-module.js
+++ b/templates/sync-function/comparison-module.js
@@ -1,4 +1,4 @@
-function comparisonModule(timeModule, buildItemPath) {
+function comparisonModule(utils, buildItemPath, timeModule) {
   return {
     validateMinValueInclusiveConstraint: validateMinValueInclusiveConstraint,
     validateMaxValueInclusiveConstraint: validateMaxValueInclusiveConstraint,
@@ -47,7 +47,7 @@ function comparisonModule(timeModule, buildItemPath) {
     var itemValue = currentItemEntry.itemValue;
     var oldItemValue = currentItemEntry.oldItemValue;
 
-    if (onlyEnforceIfHasValue && isValueNullOrUndefined(oldItemValue)) {
+    if (onlyEnforceIfHasValue && utils.isValueNullOrUndefined(oldItemValue)) {
       // No need to continue; the constraint only applies if the old document has a value for this item
       return null;
     }
@@ -57,7 +57,7 @@ function comparisonModule(timeModule, buildItemPath) {
     // document, then there is nothing to validate.
     var oldParentItemValue = (itemStack.length >= 2) ? itemStack[itemStack.length - 2].oldItemValue : null;
     var constraintSatisfied;
-    if (isValueNullOrUndefined(oldParentItemValue)) {
+    if (utils.isValueNullOrUndefined(oldParentItemValue)) {
       constraintSatisfied = true;
     } else {
       constraintSatisfied = checkItemEquality(itemValue, oldItemValue, validatorType);
@@ -71,7 +71,7 @@ function comparisonModule(timeModule, buildItemPath) {
     var currentItemValue = currentItemEntry.itemValue;
 
     if (!checkItemEquality(currentItemValue, expectedItemValue, validatorType)) {
-      return 'value of item "' + buildItemPath(itemStack) + '" must equal ' + jsonStringify(expectedItemValue);
+      return 'value of item "' + buildItemPath(itemStack) + '" must equal ' + utils.jsonStringify(expectedItemValue);
     } else {
       return null;
     }
@@ -81,10 +81,10 @@ function comparisonModule(timeModule, buildItemPath) {
     if (simpleTypeEqualityComparator(validatorType)(itemValue, expectedItemValue)) {
       // Both have the same simple type (string, number, boolean, null) value
       return true;
-    } else if (isValueNullOrUndefined(itemValue) && isValueNullOrUndefined(expectedItemValue)) {
+    } else if (utils.isValueNullOrUndefined(itemValue) && utils.isValueNullOrUndefined(expectedItemValue)) {
       // Both values are missing, which means they can be considered equal
       return true;
-    } else if (isValueNullOrUndefined(itemValue) !== isValueNullOrUndefined(expectedItemValue)) {
+    } else if (utils.isValueNullOrUndefined(itemValue) !== utils.isValueNullOrUndefined(expectedItemValue)) {
       // One has a value while the other does not
       return false;
     } else {
@@ -282,11 +282,11 @@ function comparisonModule(timeModule, buildItemPath) {
     if (value instanceof Date) {
       return value.toISOString();
     } else {
-      return !isValueNullOrUndefined(value) ? value.toString() : 'null';
+      return !utils.isValueNullOrUndefined(value) ? value.toString() : 'null';
     }
   }
 
   function normalizeUuid(value) {
-    return !isValueNullOrUndefined(value) ? value.toLowerCase() : null;
+    return !utils.isValueNullOrUndefined(value) ? value.toLowerCase() : null;
   }
 }

--- a/templates/sync-function/json-stringify-module.js
+++ b/templates/sync-function/json-stringify-module.js
@@ -5,7 +5,7 @@ function jsonStringify(value) {
   var escMap = {'"': '\\"', '\\': '\\\\', '\b': '\\b', '\f': '\\f', '\n': '\\n', '\r': '\\r', '\t': '\\t'};
   var escFunc = function (m) { return escMap[m] || '\\u' + (m.charCodeAt(0) + 0x10000).toString(16).substr(1); };
   var escRegex = /[\\"\u0000-\u001F\u2028\u2029]/g;
-  if (isValueNullOrUndefined(value)) {
+  if (value === null || value === void 0) {
     return 'null';
   } else if (typeof value === 'number') {
     return isFinite(value) ? value.toString() : 'null';

--- a/templates/sync-function/template.js
+++ b/templates/sync-function/template.js
@@ -47,11 +47,17 @@ function synctos(doc, oldDoc) {
     return value;
   }
 
+  // Determine if a given value is an integer. Exists because Number.isInteger is not supported by Sync Gateway's JavaScript engine.
+  function isValueAnInteger(value) {
+    return typeof value === 'number' && isFinite(value) && Math.floor(value) === value;
+  }
+
   // Converts a given value to a JSON string. Exists because JSON.stringify is not supported by Sync Gateway's JavaScript engine.
   var jsonStringify = importSyncFunctionFragment('json-stringify-module.js');
 
   var utils = {
     isDocumentMissingOrDeleted: isDocumentMissingOrDeleted,
+    isValueAnInteger: isValueAnInteger,
     isValueNullOrUndefined: isValueNullOrUndefined,
     jsonStringify: jsonStringify,
     padRight: padRight,

--- a/templates/sync-function/time-module.js
+++ b/templates/sync-function/time-module.js
@@ -1,4 +1,4 @@
-function timeModule() {
+function timeModule(utils) {
   return {
     isIso8601DateTimeString: isIso8601DateTimeString,
     isIso8601DateString: isIso8601DateString,
@@ -51,7 +51,7 @@ function timeModule() {
     var second = timePieces[3] ? parseInt(timePieces[3], 10) : 0;
 
     // The millisecond component has a variable length; normalize the length by padding it with zeros
-    var millisecond = timePieces[4] ? parseInt(padRight(timePieces[4], 3, '0'), 10) : 0;
+    var millisecond = timePieces[4] ? parseInt(utils.padRight(timePieces[4], 3, '0'), 10) : 0;
 
     return [ hour, minute, second, millisecond ];
   }

--- a/templates/validation-environment-template.js
+++ b/templates/validation-environment-template.js
@@ -5,7 +5,7 @@ function makeValidationEnvironment(_, simple) {
   var simpleTypeFilter = simple.stub();
   var isDocumentMissingOrDeleted = simple.stub();
   var isValueNullOrUndefined = simple.stub();
-  var getEffectiveOldDoc = simple.stub();
+  var resolveOldDoc = simple.stub();
   var jsonStringify = simple.stub();
   var padRight = simple.stub();
   var getDocumentType = simple.stub();
@@ -26,7 +26,7 @@ function makeValidationEnvironment(_, simple) {
     simpleTypeFilter: simpleTypeFilter,
     isDocumentMissingOrDeleted: isDocumentMissingOrDeleted,
     isValueNullOrUndefined: isValueNullOrUndefined,
-    getEffectiveOldDoc: getEffectiveOldDoc,
+    resolveOldDoc: resolveOldDoc,
     jsonStringify: jsonStringify,
     padRight: padRight,
     getDocumentType: getDocumentType,

--- a/templates/validation-environment-template.js
+++ b/templates/validation-environment-template.js
@@ -5,10 +5,7 @@ function makeValidationEnvironment(_, simple) {
   var simpleTypeFilter = simple.stub();
   var isDocumentMissingOrDeleted = simple.stub();
   var isValueNullOrUndefined = simple.stub();
-  var resolveOldDoc = simple.stub();
   var jsonStringify = simple.stub();
-  var padRight = simple.stub();
-  var getDocumentType = simple.stub();
   var requireAccess = simple.stub();
   var requireRole = simple.stub();
   var requireUser = simple.stub();
@@ -26,10 +23,7 @@ function makeValidationEnvironment(_, simple) {
     simpleTypeFilter: simpleTypeFilter,
     isDocumentMissingOrDeleted: isDocumentMissingOrDeleted,
     isValueNullOrUndefined: isValueNullOrUndefined,
-    resolveOldDoc: resolveOldDoc,
     jsonStringify: jsonStringify,
-    padRight: padRight,
-    getDocumentType: getDocumentType,
     requireAccess: requireAccess,
     requireRole: requireRole,
     requireUser: requireUser,


### PR DESCRIPTION
Introduces the attachment module, which is responsible for validation of attachment constraints and attachment references. Also took the liberty of refactoring how utility functions (e.g. `isValueNullOrUndefined`, `isDocumentMissingOrDeleted`, `simpleTypeFilter`) are accessed by the sync function template's various submodules (i.e. they are now passed via the `utils` parameter).

This should be the final pull request to address issue #217.