### PR TITLE
Issue 188: Dynamic access assignments constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
 ## [Unreleased]
-Nothing yet.
+### Added
+- [#188](https://github.com/Kashoo/synctos/issues/188): Support dynamic definition of channel/role access assignments
 
 ## [2.0.1] - 2018-02-19
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ authorizedUsers: function(doc, oldDoc) {
 }
 ```
 
-* `accessAssignments`: (optional) Defines either the channel access to assign to users/roles or the role access to assign to users when a document of the corresponding type is successfully created, replaced or deleted. It is specified as a list, where each entry is an object that defines `users`, `roles` and/or `channels` properties, depending on the access assignment type. The value of each property can be either a list of strings that specify the raw user/role/channel names or a function that returns the corresponding values as a dynamically-constructed list and accepts the following parameters: (1) the new document and (2) the old document that is being replaced/deleted (if any). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be `true`, so be sure to account for such cases. And, if the old document has been deleted or simply does not exist, the second parameter will be `null`. The assignment types are specified as follows:
+* `accessAssignments`: (optional) Defines either the channel access to assign to users/roles or the role access to assign to users when a document of the corresponding type is successfully created, replaced or deleted. The constraint can be defined as either a list, where each entry is an object that defines `users`, `roles` and/or `channels` properties, depending on the access assignment type, or it can be defined dynamically as a function that accepts the following parameters: (1) the new document and (2) the old document that is being replaced/deleted (if any). NOTE: In cases where the document is in the process of being deleted, the first parameter's `_deleted` property will be `true` and, if the old document has been deleted or simply does not exist, the second parameter will be `null`. The assignment types are specified as follows:
   * Channel access assignments:
-    * `type`: May be either "channel", `null` or `undefined`.
+    * `type`: May be either "channel", `null` or missing/`undefined`.
     * `channels`: The channels to assign to users and/or roles.
     * `roles`: The roles to which to assign the channels.
     * `users`: The users to which to assign the channels.

--- a/src/validation/document-definition-schema.js
+++ b/src/validation/document-definition-schema.js
@@ -64,7 +64,7 @@ module.exports = exports = joi.object().options({ convert: false }).keys({
   authorizedRoles: authorizationSchema,
   authorizedUsers: authorizationSchema,
 
-  accessAssignments: joi.array().items(
+  accessAssignments: dynamicConstraintSchema(joi.array().items(
     joi.object().keys({ type: joi.string().only([ 'channel', 'role', null ]) })
       // Each access assignment may be either a role assignment
       .when(
@@ -87,7 +87,7 @@ module.exports = exports = joi.object().options({ convert: false }).keys({
             roles: accessAssignmentEntryPropertySchema,
             users: accessAssignmentEntryPropertySchema
           }).or('roles', 'users') // At least one of "roles" or "users" must be provided
-        })),
+        }))),
 
   customActions: joi.object().min(1).keys({
     onTypeIdentificationSucceeded: customActionEventSchema,

--- a/templates/sync-function/access-assignment-module.js
+++ b/templates/sync-function/access-assignment-module.js
@@ -87,9 +87,19 @@ function accessAssignmentModule() {
     };
   }
 
+  // Transforms the given access assignments definition into an array of access assignment entries (e.g. if it was defined as a function)
+  function resolveAccessAssignmentsDefinition(doc, oldDoc, accessAssignmentsDefinition) {
+    if (typeof accessAssignmentsDefinition === 'function') {
+      return accessAssignmentsDefinition(doc, oldDoc);
+    } else {
+      return accessAssignmentsDefinition || [ ];
+    }
+  }
+
   // Assigns role access to users and/or channel access to users/roles according to the given access assignment definitions
-  function assignUserAccess(doc, oldDoc, accessAssignmentDefinitions) {
+  function assignUserAccess(doc, oldDoc, documentDefinition) {
     var effectiveOldDoc = getEffectiveOldDoc(oldDoc);
+    var accessAssignmentDefinitions = resolveAccessAssignmentsDefinition(doc, effectiveOldDoc, documentDefinition.accessAssignments);
 
     var effectiveAssignments = [ ];
     for (var assignmentIndex = 0; assignmentIndex < accessAssignmentDefinitions.length; assignmentIndex++) {

--- a/templates/sync-function/template.js
+++ b/templates/sync-function/template.js
@@ -126,10 +126,13 @@ function synctos(doc, oldDoc) {
     theDocDefinition.customActions.onValidationSucceeded(doc, oldDoc, customActionMetadata);
   }
 
-  if (theDocDefinition.accessAssignments && theDocDefinition.accessAssignments.length > 0) {
-    customActionMetadata.accessAssignments = accessAssignmentModule.assignUserAccess(doc, oldDoc, theDocDefinition.accessAssignments);
+  if (theDocDefinition.accessAssignments) {
+    var accessAssignments = accessAssignmentModule.assignUserAccess(doc, oldDoc, theDocDefinition);
 
-    if (theDocDefinition.customActions && typeof theDocDefinition.customActions.onAccessAssignmentsSucceeded === 'function') {
+    if (theDocDefinition.customActions &&
+        typeof theDocDefinition.customActions.onAccessAssignmentsSucceeded === 'function' &&
+        accessAssignments.length > 0) {
+      customActionMetadata.accessAssignments = accessAssignments;
       theDocDefinition.customActions.onAccessAssignmentsSucceeded(doc, oldDoc, customActionMetadata);
     }
   }

--- a/test/resources/access-assignment-doc-definitions.js
+++ b/test/resources/access-assignment-doc-definitions.js
@@ -29,11 +29,11 @@
       }
     ]
   },
-  dynamicAccessDoc: {
-    channels: { write: 'write' },
-    typeFilter: function(doc) {
-      return doc._id === 'dynamicAccessDoc';
+  dynamicAccessEntryItemsDoc: {
+    typeFilter: function(doc, oldDoc, docType) {
+      return doc._id === docType;
     },
+    channels: { write: 'write' },
     propertyValidators: {
       users: {
         type: 'array'
@@ -45,16 +45,12 @@
     accessAssignments: [
       {
         type: 'role',
-        users: function(doc, oldDoc) {
-          // The sync function template should automatically replace the oldDoc param value with null if its _deleted property is true
-          return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.users;
-        },
-        roles: function(doc, oldDoc) {
-          return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.roles;
-        }
+        users: function(doc, oldDoc) { return doc.users; },
+        roles: function(doc, oldDoc) { return doc.roles; }
       },
       {
         type: 'channel',
+        // The sync function template should automatically replace the oldDoc param value with null if its _deleted property is true
         users: function(doc, oldDoc) {
           return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.users;
         },
@@ -66,23 +62,57 @@
         }
       },
       {
-        // With no "type" property defined, it should default to channel access assignment
-        roles: function(doc, oldDoc) {
-          return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.roles;
-        },
-        channels: function(doc, oldDoc) {
-          return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc._id + '-channel4';
-        }
+        // With a null "type" property defined, it should default to channel access assignment
+        type: null,
+        roles: function(doc, oldDoc) { return doc.roles; },
+        channels: function(doc, oldDoc) { return doc._id + '-channel4'; }
       },
       {
         // With no "type" property defined, it should default to channel access assignment
-        users: function(doc, oldDoc) {
-          return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.users;
-        },
-        channels: function(doc, oldDoc) {
-          return (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc._id + '-channel3';
-        }
+        users: function(doc, oldDoc) { return doc.users; },
+        channels: function(doc, oldDoc) { return doc._id + '-channel3'; }
       }
     ]
+  },
+  dynamicAccessConstraintDoc: {
+    typeFilter: function(doc, oldDoc, docType) {
+      return doc._id === docType;
+    },
+    channels: { write: [ 'write' ] },
+    propertyValidators: {
+      users: {
+        type: 'array'
+      },
+      roles: {
+        type: 'array'
+      }
+    },
+    accessAssignments: function(doc, oldDoc) {
+      return [
+        {
+          type: 'role',
+          users: doc.users,
+          roles: doc.roles
+        },
+        {
+          type: 'channel',
+          // The sync function template should automatically replace the oldDoc param value with null if its _deleted property is true
+          users: (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.users,
+          roles: (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : doc.roles,
+          channels: (oldDoc && oldDoc._deleted) ? 'this-should-never-happen' : [ doc._id + '-channel1', doc._id + '-channel2' ]
+        },
+        {
+          // With no "type" property defined, it should default to channel access assignment
+          roles: doc.roles,
+          channels: doc._id + '-channel4'
+        },
+        {
+          // With a null "type" property defined, it should default to channel access assignment
+          type: null,
+          users: doc.users,
+          channels: doc._id + '-channel3'
+        }
+      ];
+    }
   }
 }


### PR DESCRIPTION
The `accessAssignments` constraint can now be defined dynamically as a function as with other top-level document definition constraint properties (e.g. `channels`, `allowUnknownProperties`, `attachmentConstraints`, etc.).

Fully addresses issue #188.