### PR TITLE
Issue 252: Expose Sync Gateway API stubs via test environment

### DIFF
--- a/src/testing/test-fixture-maker.js
+++ b/src/testing/test-fixture-maker.js
@@ -31,19 +31,6 @@ function init(rawSyncFunction, syncFunctionFile) {
 
   const fixture = {
     /**
-     * The generated document sync function to use for testing.
-     *
-     * @param {Object} doc The document to write. May include property "_deleted=true" to simulate a delete operation.
-     * @param {Object} oldDoc The document to replace or delete. May be null or undefined or include property "_deleted=true" to simulate a
-     *                        create operation.
-     * @param {Object} userContext The CouchDB [user context](http://docs.couchdb.org/en/latest/json-structure.html#userctx-object)
-     *                             of the authenticated user
-     * @param {Object} securityInfo The CouchDB [security object](http://docs.couchdb.org/en/latest/json-structure.html#security-object)
-     *                              for the database
-     */
-    syncFunction: testEnvironment.syncFunction,
-
-    /**
      * An object that contains functions that are used to format expected validation error messages in specifications. Documentation can be
      * found in the "validation-error-formatter" module.
      */
@@ -256,88 +243,53 @@ function init(rawSyncFunction, syncFunctionFile) {
     verifyUnknownDocumentType,
 
     /**
-     * A stub of the requireAccess function from the Sync Gateway sync function API:
-     * https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#requireaccesschannels
+     * The test environment that the test fixture uses to simulate execution of the sync function. Exposes the sync
+     * function itself via the "syncFunction" property along with several simple-mock stubs for the following Sync
+     * Gateway API functions:
      *
-     * @param {string|string[]} channels The names of one or more channels that are authorized to perform the operation,
-     *                                   specified either as a list or a single string
+     * - requireAccess: https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#requireaccesschannels
+     * - requireRole: https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#requirerolerolename
+     * - requireUser: https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#requireuserusername
+     * - channel: https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#channel-name
+     * - access: https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#access-username-channelname
+     * - role: https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#role-username-rolename
      */
-    requireAccess: testEnvironment.requireAccess,
-
-    /**
-     * A stub of the requireRole function from the Sync Gateway sync function API:
-     * https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#requirerolerolename
-     *
-     * @param {string|string[]} role The names of one or more roles that are authorized to perform the operation,
-     *                               specified either as a list or a single string
-     */
-    requireRole: testEnvironment.requireRole,
-
-    /**
-     * A stub of the requireUser function from the Sync Gateway sync function API:
-     * https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#requireuserusername
-     *
-     * @param {string|string[]} username The names of one or more users that are authorized to perform the operation,
-     *                                   specified either as a list or a single string
-     */
-    requireUser: testEnvironment.requireUser,
-
-    /**
-     * A stub of the channel function from the Sync Gateway sync function API:
-     * https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#channel-name
-     *
-     * @param {string|string[]} name The names of one or more channels to be assigned to the document, specified either
-     *                               as a list or a single string
-     */
-    channel: testEnvironment.channel,
-
-    /**
-     * A stub of the access function from the Sync Gateway sync function API:
-     * https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#access-username-channelname
-     *
-     * @param {string|string[]} username The names of one or more users or roles that are to be granted access to the
-     *                                   channel(s), specified either as a list or a single string. Role names must be
-     *                                   prefixed with "role:" to distinguish them from usernames.
-     * @param {string|string[]} channels The names of one or more channels to assign the specified users/roles to
-     */
-    access: testEnvironment.access,
-
-    /**
-     * A stub of the role function from the Sync Gateway sync function API:
-     * https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/sync-function-api-guide/index.html#role-username-rolename
-     * @param {string|string[]} username The names of one or more users that are to be granted access to the role(s),
-     *                                   specified either as a list or a single string
-     * @param {string|string[]} role The names of one or more roles to assign the specified users to
-     */
-    role: testEnvironment.role,
-
-    customActionStub: testEnvironment.customActionStub
+    testEnvironment
   };
 
   const defaultWriteChannel = 'write';
 
   function verifyRequireAccess(expectedChannels) {
-    assert.ok(fixture.requireAccess.callCount > 0, `Document does not specify required channels. Expected: ${expectedChannels}`);
+    assert.ok(
+      testEnvironment.requireAccess.callCount > 0,
+      `Document does not specify required channels. Expected: ${expectedChannels}`);
 
-    checkAuthorizations(expectedChannels, fixture.requireAccess.calls[0].arg, 'channel');
+    checkAuthorizations(expectedChannels, testEnvironment.requireAccess.calls[0].arg, 'channel');
   }
 
   function verifyRequireRole(expectedRoles) {
-    assert.ok(fixture.requireRole.callCount > 0, `Document does not specify required roles. Expected: ${expectedRoles}`);
+    assert.ok(
+      testEnvironment.requireRole.callCount > 0,
+      `Document does not specify required roles. Expected: ${expectedRoles}`);
 
-    checkAuthorizations(expectedRoles, fixture.requireRole.calls[0].arg, 'role');
+    checkAuthorizations(expectedRoles, testEnvironment.requireRole.calls[0].arg, 'role');
   }
 
   function verifyRequireUser(expectedUsers) {
-    assert.ok(fixture.requireUser.callCount > 0, `Document does not specify required users. Expected: ${expectedUsers}`);
+    assert.ok(
+      testEnvironment.requireUser.callCount > 0,
+      `Document does not specify required users. Expected: ${expectedUsers}`);
 
-    checkAuthorizations(expectedUsers, fixture.requireUser.calls[0].arg, 'user');
+    checkAuthorizations(expectedUsers, testEnvironment.requireUser.calls[0].arg, 'user');
   }
 
   function verifyChannelAssignment(expectedChannels) {
-    assert.equal(fixture.channel.callCount, 1, `Document was not assigned to any channels. Expected: ${expectedChannels}`);
+    assert.equal(
+      testEnvironment.channel.callCount,
+      1,
+      `Document was not assigned to any channels. Expected: ${expectedChannels}`);
 
-    checkAuthorizations(expectedChannels, fixture.channel.calls[0].arg, 'channel');
+    checkAuthorizations(expectedChannels, testEnvironment.channel.calls[0].arg, 'channel');
   }
 
   function checkAuthorizations(expectedAuthorizations, actualAuthorizations, authorizationType) {
@@ -408,7 +360,7 @@ function init(rawSyncFunction, syncFunctionFile) {
       }
     }
 
-    if (!accessAssignmentCallExists(fixture.access, expectedUsersAndRoles, expectedChannels)) {
+    if (!accessAssignmentCallExists(testEnvironment.access, expectedUsersAndRoles, expectedChannels)) {
       assert.fail(`Missing expected call to assign channel access (${JSON.stringify(expectedChannels)}) to users and roles (${JSON.stringify(expectedUsersAndRoles)})`);
     }
   }
@@ -436,7 +388,7 @@ function init(rawSyncFunction, syncFunctionFile) {
       }
     }
 
-    if (!accessAssignmentCallExists(fixture.role, expectedUsers, expectedRoles)) {
+    if (!accessAssignmentCallExists(testEnvironment.role, expectedUsers, expectedRoles)) {
       assert.fail(`Missing expected call to assign role access (${JSON.stringify(expectedRoles)}) to users (${JSON.stringify(expectedUsers)})`);
     }
   }
@@ -456,21 +408,21 @@ function init(rawSyncFunction, syncFunctionFile) {
       }
     });
 
-    if (fixture.access.callCount !== expectedAccessCalls) {
-      assert.fail(`Number of calls to assign channel access (${fixture.access.callCount}) does not match expected (${expectedAccessCalls})`);
+    if (testEnvironment.access.callCount !== expectedAccessCalls) {
+      assert.fail(`Number of calls to assign channel access (${testEnvironment.access.callCount}) does not match expected (${expectedAccessCalls})`);
     }
 
-    if (fixture.role.callCount !== expectedRoleCalls) {
-      assert.fail(`Number of calls to assign role access (${fixture.role.callCount}) does not match expected (${expectedRoleCalls})`);
+    if (testEnvironment.role.callCount !== expectedRoleCalls) {
+      assert.fail(`Number of calls to assign role access (${testEnvironment.role.callCount}) does not match expected (${expectedRoleCalls})`);
     }
   }
 
   function verifyOperationChannelsAssigned(doc, expectedChannels) {
-    if (fixture.channel.callCount !== 1) {
+    if (testEnvironment.channel.callCount !== 1) {
       assert.fail('Document channels were not assigned');
     }
 
-    const actualChannels = fixture.channel.calls[0].arg;
+    const actualChannels = testEnvironment.channel.calls[0].arg;
     if (Array.isArray(expectedChannels)) {
       expectedChannels.forEach((expectedChannel) => {
         assert.ok(
@@ -491,8 +443,14 @@ function init(rawSyncFunction, syncFunctionFile) {
       // for authorization
       expectedOperationChannels = expectedAuthorization;
       verifyRequireAccess(expectedAuthorization);
-      assert.equal(fixture.requireRole.callCount, 0, `Unexpected document roles assigned: ${JSON.stringify(fixture.requireRole.calls)}`);
-      assert.equal(fixture.requireUser.callCount, 0, `Unexpected document users assigned: ${JSON.stringify(fixture.requireUser.calls)}`);
+      assert.equal(
+        testEnvironment.requireRole.callCount,
+        0,
+        `Unexpected document roles assigned: ${JSON.stringify(testEnvironment.requireRole.calls)}`);
+      assert.equal(
+        testEnvironment.requireUser.callCount,
+        0,
+        `Unexpected document users assigned: ${JSON.stringify(testEnvironment.requireUser.calls)}`);
     } else {
       if (expectedAuthorization.expectedChannels) {
         expectedOperationChannels = expectedAuthorization.expectedChannels;
@@ -502,13 +460,19 @@ function init(rawSyncFunction, syncFunctionFile) {
       if (expectedAuthorization.expectedRoles) {
         verifyRequireRole(expectedAuthorization.expectedRoles);
       } else {
-        assert.equal(fixture.requireRole.callCount, 0, `Unexpected document roles assigned: ${JSON.stringify(fixture.requireRole.calls)}`);
+        assert.equal(
+          testEnvironment.requireRole.callCount,
+          0,
+          `Unexpected document roles assigned: ${JSON.stringify(testEnvironment.requireRole.calls)}`);
       }
 
       if (expectedAuthorization.expectedUsers) {
         verifyRequireUser(expectedAuthorization.expectedUsers);
       } else {
-        assert.equal(fixture.requireUser.callCount, 0, `Unexpected document users assigned: ${JSON.stringify(fixture.requireUser.calls)}`);
+        assert.equal(
+          testEnvironment.requireUser.callCount,
+          0,
+          `Unexpected document users assigned: ${JSON.stringify(testEnvironment.requireUser.calls)}`);
       }
 
       if (!expectedAuthorization.expectedChannels && !expectedAuthorization.expectedRoles && !expectedAuthorization.expectedUsers) {
@@ -520,7 +484,7 @@ function init(rawSyncFunction, syncFunctionFile) {
   }
 
   function verifyDocumentAccepted(doc, oldDoc, expectedAuthorization, expectedAccessAssignments) {
-    fixture.syncFunction(doc, oldDoc || null);
+    testEnvironment.syncFunction(doc, oldDoc || null);
 
     if (expectedAccessAssignments) {
       verifyAccessAssignments(expectedAccessAssignments);
@@ -546,7 +510,7 @@ function init(rawSyncFunction, syncFunctionFile) {
   function verifyDocumentRejected(doc, oldDoc, docType, expectedErrorMessages, expectedAuthorization) {
     let syncFuncError = null;
     try {
-      fixture.syncFunction(doc, oldDoc || null);
+      testEnvironment.syncFunction(doc, oldDoc || null);
     } catch (ex) {
       syncFuncError = ex;
     }
@@ -555,7 +519,10 @@ function init(rawSyncFunction, syncFunctionFile) {
       verifyValidationErrors(docType, expectedErrorMessages, syncFuncError);
       verifyAuthorization(expectedAuthorization);
 
-      assert.equal(fixture.channel.callCount, 0, `Document was erroneously assigned to channels: ${JSON.stringify(fixture.channel.calls)}`);
+      assert.equal(
+        testEnvironment.channel.callCount,
+        0,
+        `Document was erroneously assigned to channels: ${JSON.stringify(testEnvironment.channel.calls)}`);
     } else {
       assert.fail('Document validation succeeded when it was expected to fail');
     }
@@ -633,13 +600,13 @@ function init(rawSyncFunction, syncFunctionFile) {
     const userAccessDeniedError = new Error('User access denied!');
     const generalAuthFailedMessage = 'missing channel access';
 
-    fixture.requireAccess.throwWith(channelAccessDeniedError);
-    fixture.requireRole.throwWith(roleAccessDeniedError);
-    fixture.requireUser.throwWith(userAccessDeniedError);
+    testEnvironment.requireAccess.throwWith(channelAccessDeniedError);
+    testEnvironment.requireRole.throwWith(roleAccessDeniedError);
+    testEnvironment.requireUser.throwWith(userAccessDeniedError);
 
     let syncFuncError = null;
     try {
-      fixture.syncFunction(doc, oldDoc || null);
+      testEnvironment.syncFunction(doc, oldDoc || null);
     } catch (ex) {
       syncFuncError = ex;
     }
@@ -683,7 +650,7 @@ function init(rawSyncFunction, syncFunctionFile) {
   function verifyUnknownDocumentType(doc, oldDoc) {
     let syncFuncError = null;
     try {
-      fixture.syncFunction(doc, oldDoc || null);
+      testEnvironment.syncFunction(doc, oldDoc || null);
     } catch (ex) {
       syncFuncError = ex;
     }
@@ -694,10 +661,22 @@ function init(rawSyncFunction, syncFunctionFile) {
         'Unknown document type',
         `Document validation error does not indicate the document type is unrecognized. Actual: ${JSON.stringify(syncFuncError)}`);
 
-      assert.equal(fixture.channel.callCount, 0, `Document was erroneously assigned to channels: ${JSON.stringify(fixture.channel.calls)}`);
-      assert.equal(fixture.requireAccess.callCount, 0, `Unexpected attempt to specify required channels: ${JSON.stringify(fixture.requireAccess.calls)}`);
-      assert.equal(fixture.requireRole.callCount, 0, `Unexpected attempt to specify required roles: ${JSON.stringify(fixture.requireRole.calls)}`);
-      assert.equal(fixture.requireUser.callCount, 0, `Unexpected attempt to specify required users: ${JSON.stringify(fixture.requireUser.calls)}`);
+      assert.equal(
+        testEnvironment.channel.callCount,
+        0,
+        `Document was erroneously assigned to channels: ${JSON.stringify(testEnvironment.channel.calls)}`);
+      assert.equal(
+        testEnvironment.requireAccess.callCount,
+        0,
+        `Unexpected attempt to specify required channels: ${JSON.stringify(testEnvironment.requireAccess.calls)}`);
+      assert.equal(
+        testEnvironment.requireRole.callCount,
+        0,
+        `Unexpected attempt to specify required roles: ${JSON.stringify(testEnvironment.requireRole.calls)}`);
+      assert.equal(
+        testEnvironment.requireUser.callCount,
+        0,
+        `Unexpected attempt to specify required users: ${JSON.stringify(testEnvironment.requireUser.calls)}`);
     } else {
       assert.fail('Document type was successfully identified when it was expected to be unknown');
     }

--- a/src/testing/test-fixture-maker.spec.js
+++ b/src/testing/test-fixture-maker.spec.js
@@ -53,7 +53,7 @@ describe('Test fixture maker:', () => {
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
       expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, fakeFilePath ]);
 
-      verifyTestEnvironment(testFixture);
+      expect(testFixture.testEnvironment).to.deep.equal(fakeTestEnvironment);
     });
 
     it('can initialize directly from document definitions', () => {
@@ -67,19 +67,8 @@ describe('Test fixture maker:', () => {
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
       expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, void 0 ]);
 
-      verifyTestEnvironment(testFixture);
+      expect(testFixture.testEnvironment).to.deep.equal(fakeTestEnvironment);
     });
-
-    function verifyTestEnvironment(testFixture) {
-      expect(testFixture.requireAccess).to.equal(fakeTestEnvironment.requireAccess);
-      expect(testFixture.requireRole).to.equal(fakeTestEnvironment.requireRole);
-      expect(testFixture.requireUser).to.equal(fakeTestEnvironment.requireUser);
-      expect(testFixture.channel).to.equal(fakeTestEnvironment.channel);
-      expect(testFixture.access).to.equal(fakeTestEnvironment.access);
-      expect(testFixture.role).to.equal(fakeTestEnvironment.role);
-      expect(testFixture.customActionStub).to.equal(fakeTestEnvironment.customActionStub);
-      expect(testFixture.syncFunction).to.equal(fakeTestEnvironment.syncFunction);
-    }
   });
 
   describe('when verifying that document authorization is denied', () => {
@@ -93,8 +82,8 @@ describe('Test fixture maker:', () => {
       const actualChannels = [ 'my-channel-1', 'my-channel-2' ];
       const expectedChannels = [ 'my-channel-1' ];
 
-      testFixture.syncFunction = () => {
-        testFixture.requireAccess(actualChannels);
+      testFixture.testEnvironment.syncFunction = () => {
+        testFixture.testEnvironment.requireAccess(actualChannels);
       };
 
       expect(() => {
@@ -106,8 +95,8 @@ describe('Test fixture maker:', () => {
       const actualChannels = [ 'my-channel-1' ];
       const expectedChannels = [ 'my-channel-1', 'my-channel-2' ];
 
-      testFixture.syncFunction = () => {
-        testFixture.requireAccess(actualChannels);
+      testFixture.testEnvironment.syncFunction = () => {
+        testFixture.testEnvironment.requireAccess(actualChannels);
       };
 
       expect(() => {
@@ -116,7 +105,7 @@ describe('Test fixture maker:', () => {
     });
 
     it('fails if the sync function does not throw an error', () => {
-      testFixture.syncFunction = () => { };
+      testFixture.testEnvironment.syncFunction = () => { };
 
       expect(() => {
         testFixture.verifyAccessDenied({ }, null, [ ]);
@@ -124,8 +113,8 @@ describe('Test fixture maker:', () => {
     });
 
     it('succeeds if there are no expected channels, roles or users allowed', () => {
-      testFixture.syncFunction = () => {
-        testFixture.requireAccess([ ]);
+      testFixture.testEnvironment.syncFunction = () => {
+        testFixture.testEnvironment.requireAccess([ ]);
       };
 
       expect(() => {
@@ -142,7 +131,7 @@ describe('Test fixture maker:', () => {
     });
 
     it('fails if the document type is recognized', () => {
-      testFixture.syncFunction = () => { };
+      testFixture.testEnvironment.syncFunction = () => { };
 
       expect(() => {
         testFixture.verifyUnknownDocumentType({ });
@@ -159,7 +148,7 @@ describe('Test fixture maker:', () => {
     });
 
     it('fails if the sync function does not throw an error', () => {
-      testFixture.syncFunction = () => { };
+      testFixture.testEnvironment.syncFunction = () => { };
 
       expect(() => {
         testFixture.verifyDocumentRejected({ }, null, docType, [ ], { expectedRoles: 'my-role' });
@@ -169,7 +158,7 @@ describe('Test fixture maker:', () => {
     it('fails if the validation error message format is invalid', () => {
       const errorMessage = 'Foo: bar';
 
-      testFixture.syncFunction = () => {
+      testFixture.testEnvironment.syncFunction = () => {
         throw { forbidden: errorMessage };
       };
 
@@ -182,7 +171,7 @@ describe('Test fixture maker:', () => {
       const expectedErrors = [ 'my-error-1', 'my-error-2' ];
       const errorMessage = `Invalid ${docType} document: ${expectedErrors[0]}`;
 
-      testFixture.syncFunction = () => {
+      testFixture.testEnvironment.syncFunction = () => {
         throw { forbidden: errorMessage };
       };
 
@@ -197,7 +186,7 @@ describe('Test fixture maker:', () => {
       const expectedErrors = [ actualErrors[0] ];
       const expectedErrorMessage = `Invalid ${docType} document: ${expectedErrors[0]}`;
 
-      testFixture.syncFunction = () => {
+      testFixture.testEnvironment.syncFunction = () => {
         throw { forbidden: actualErrorMessage };
       };
 
@@ -215,8 +204,8 @@ describe('Test fixture maker:', () => {
     });
 
     it('fails if the channel assignment function was not called', () => {
-      testFixture.syncFunction = () => {
-        testFixture.requireAccess([ ]);
+      testFixture.testEnvironment.syncFunction = () => {
+        testFixture.testEnvironment.requireAccess([ ]);
       };
 
       expect(() => {
@@ -241,8 +230,8 @@ describe('Test fixture maker:', () => {
       };
       const expectedEffectiveRoles = expectedChannelAccessAssignment.expectedRoles.map((role) => `role:${role}`);
 
-      testFixture.syncFunction = () => {
-        testFixture.access(expectedEffectiveRoles, actualChannels);
+      testFixture.testEnvironment.syncFunction = () => {
+        testFixture.testEnvironment.access(expectedEffectiveRoles, actualChannels);
       };
 
       expect(() => {
@@ -259,8 +248,8 @@ describe('Test fixture maker:', () => {
       const expectedEffectiveRoles = expectedRoleAccessAssignment.expectedRoles.map((role) => `role:${role}`);
       const actualUsers = [ 'my-user-1', 'my-user-2', 'my-user-2' ];
 
-      testFixture.syncFunction = () => {
-        testFixture.role(actualUsers, expectedEffectiveRoles);
+      testFixture.testEnvironment.syncFunction = () => {
+        testFixture.testEnvironment.role(actualUsers, expectedEffectiveRoles);
       };
 
       expect(() => {
@@ -269,8 +258,8 @@ describe('Test fixture maker:', () => {
     });
 
     it('fails if there is a call to assign channel access when none is expected', () => {
-      testFixture.syncFunction = () => {
-        testFixture.access();
+      testFixture.testEnvironment.syncFunction = () => {
+        testFixture.testEnvironment.access();
       };
 
       expect(() => {
@@ -279,8 +268,8 @@ describe('Test fixture maker:', () => {
     });
 
     it('fails if there is a call to assign role access when none is expected', () => {
-      testFixture.syncFunction = () => {
-        testFixture.role();
+      testFixture.testEnvironment.syncFunction = () => {
+        testFixture.testEnvironment.role();
       };
 
       expect(() => {
@@ -295,7 +284,7 @@ describe('Test fixture maker:', () => {
         expectedUsers: [ 'my-user-1' ]
       };
 
-      testFixture.syncFunction = () => { };
+      testFixture.testEnvironment.syncFunction = () => { };
 
       expect(() => {
         testFixture.verifyDocumentAccepted({ }, void 0, [ ], [ expectedInvalidAccessAssignment ]);

--- a/test/access-assignment.spec.js
+++ b/test/access-assignment.spec.js
@@ -59,9 +59,9 @@ describe('User and role access assignment:', () => {
       };
 
       expect(() => {
-        testFixture.syncFunction(doc);
+        testFixture.testEnvironment.syncFunction(doc);
       }).to.throw();
-      expect(testFixture.access.callCount).to.equal(0);
+      expect(testFixture.testEnvironment.access.callCount).to.equal(0);
     });
 
     it('is NOT applied when replacing an invalid document', () => {
@@ -72,9 +72,9 @@ describe('User and role access assignment:', () => {
       const oldDoc = { _id: 'staticAccessDoc' };
 
       expect(() => {
-        testFixture.syncFunction(doc, oldDoc);
+        testFixture.testEnvironment.syncFunction(doc, oldDoc);
       }).to.throw();
-      expect(testFixture.access.callCount).to.equal(0);
+      expect(testFixture.testEnvironment.access.callCount).to.equal(0);
     });
   });
 
@@ -175,9 +175,9 @@ describe('User and role access assignment:', () => {
       };
 
       expect(() => {
-        testFixture.syncFunction(doc);
+        testFixture.testEnvironment.syncFunction(doc);
       }).to.throw();
-      expect(testFixture.access.callCount).to.equal(0);
+      expect(testFixture.testEnvironment.access.callCount).to.equal(0);
     });
 
     it('is NOT applied when replacing an invalid document', () => {
@@ -190,9 +190,9 @@ describe('User and role access assignment:', () => {
       const oldDoc = { _id: 'dynamicAccessConstraintDoc' };
 
       expect(() => {
-        testFixture.syncFunction(doc, oldDoc);
+        testFixture.testEnvironment.syncFunction(doc, oldDoc);
       }).to.throw();
-      expect(testFixture.access.callCount).to.equal(0);
+      expect(testFixture.testEnvironment.access.callCount).to.equal(0);
     });
   });
 
@@ -287,9 +287,9 @@ describe('User and role access assignment:', () => {
       };
 
       expect(() => {
-        testFixture.syncFunction(doc);
+        testFixture.testEnvironment.syncFunction(doc);
       }).to.throw();
-      expect(testFixture.access.callCount).to.equal(0);
+      expect(testFixture.testEnvironment.access.callCount).to.equal(0);
     });
 
     it('is NOT applied when replacing an invalid document', () => {
@@ -302,9 +302,9 @@ describe('User and role access assignment:', () => {
       const oldDoc = { _id: 'dynamicAccessEntryItemsDoc' };
 
       expect(() => {
-        testFixture.syncFunction(doc, oldDoc);
+        testFixture.testEnvironment.syncFunction(doc, oldDoc);
       }).to.throw();
-      expect(testFixture.access.callCount).to.equal(0);
+      expect(testFixture.testEnvironment.access.callCount).to.equal(0);
     });
   });
 });

--- a/test/attachment-constraints.spec.js
+++ b/test/attachment-constraints.spec.js
@@ -80,7 +80,7 @@ describe('File attachment constraints:', () => {
           let syncFuncError = null;
           expect(() => {
             try {
-              testFixture.syncFunction(doc);
+              testFixture.testEnvironment.syncFunction(doc);
             } catch (ex) {
               syncFuncError = ex;
 
@@ -113,7 +113,7 @@ describe('File attachment constraints:', () => {
           let syncFuncError = null;
           expect(() => {
             try {
-              testFixture.syncFunction(doc, oldDoc);
+              testFixture.testEnvironment.syncFunction(doc, oldDoc);
             } catch (ex) {
               syncFuncError = ex;
 
@@ -156,7 +156,7 @@ describe('File attachment constraints:', () => {
           let syncFuncError = null;
           expect(() => {
             try {
-              testFixture.syncFunction(doc);
+              testFixture.testEnvironment.syncFunction(doc);
             } catch (ex) {
               syncFuncError = ex;
 
@@ -198,7 +198,7 @@ describe('File attachment constraints:', () => {
           let syncFuncError = null;
           expect(() => {
             try {
-              testFixture.syncFunction(doc, oldDoc);
+              testFixture.testEnvironment.syncFunction(doc, oldDoc);
             } catch (ex) {
               syncFuncError = ex;
 
@@ -236,7 +236,7 @@ describe('File attachment constraints:', () => {
           let syncFuncError = null;
           expect(() => {
             try {
-              testFixture.syncFunction(doc);
+              testFixture.testEnvironment.syncFunction(doc);
             } catch (ex) {
               syncFuncError = ex;
 
@@ -277,7 +277,7 @@ describe('File attachment constraints:', () => {
           let syncFuncError = null;
           expect(() => {
             try {
-              testFixture.syncFunction(doc, oldDoc);
+              testFixture.testEnvironment.syncFunction(doc, oldDoc);
             } catch (ex) {
               syncFuncError = ex;
 
@@ -318,7 +318,7 @@ describe('File attachment constraints:', () => {
           let syncFuncError = null;
           expect(() => {
             try {
-              testFixture.syncFunction(doc);
+              testFixture.testEnvironment.syncFunction(doc);
             } catch (ex) {
               syncFuncError = ex;
 
@@ -359,7 +359,7 @@ describe('File attachment constraints:', () => {
           let syncFuncError = null;
           expect(() => {
             try {
-              testFixture.syncFunction(doc, oldDoc);
+              testFixture.testEnvironment.syncFunction(doc, oldDoc);
             } catch (ex) {
               syncFuncError = ex;
 
@@ -412,7 +412,7 @@ describe('File attachment constraints:', () => {
         let syncFuncError = null;
         expect(() => {
           try {
-            testFixture.syncFunction(doc);
+            testFixture.testEnvironment.syncFunction(doc);
           } catch (ex) {
             syncFuncError = ex;
 
@@ -470,7 +470,7 @@ describe('File attachment constraints:', () => {
         let syncFuncError = null;
         expect(() => {
           try {
-            testFixture.syncFunction(doc, oldDoc);
+            testFixture.testEnvironment.syncFunction(doc, oldDoc);
           } catch (ex) {
             syncFuncError = ex;
 

--- a/test/custom-actions.spec.js
+++ b/test/custom-actions.spec.js
@@ -42,7 +42,7 @@ describe('Custom actions:', () => {
       let syncFuncError = null;
       expect(() => {
         try {
-          testFixture.syncFunction(doc);
+          testFixture.testEnvironment.syncFunction(doc);
         } catch (ex) {
           syncFuncError = ex;
 
@@ -170,10 +170,10 @@ describe('Custom actions:', () => {
 
     it('does not execute a custom action if doc channel assignment fails', () => {
       const expectedError = new Error('bad channels!');
-      testFixture.channel.throwWith(expectedError);
+      testFixture.testEnvironment.channel.throwWith(expectedError);
 
       expect(() => {
-        testFixture.syncFunction(doc);
+        testFixture.testEnvironment.syncFunction(doc);
       }).to.throw(expectedError);
 
       verifyCustomActionNotExecuted();
@@ -181,15 +181,15 @@ describe('Custom actions:', () => {
   });
 
   function verifyCustomActionExecuted(doc, oldDoc, expectedActionType) {
-    expect(testFixture.customActionStub.callCount).to.equal(1);
-    expect(testFixture.customActionStub.calls[0].args[0]).to.eql(doc);
-    expect(testFixture.customActionStub.calls[0].args[1]).to.eql(oldDoc);
+    expect(testFixture.testEnvironment.customActionStub.callCount).to.equal(1);
+    expect(testFixture.testEnvironment.customActionStub.calls[0].args[0]).to.eql(doc);
+    expect(testFixture.testEnvironment.customActionStub.calls[0].args[1]).to.eql(oldDoc);
 
-    verifyCustomActionMetadata(testFixture.customActionStub.calls[0].args[2], doc._id, expectedActionType);
+    verifyCustomActionMetadata(testFixture.testEnvironment.customActionStub.calls[0].args[2], doc._id, expectedActionType);
   }
 
   function verifyCustomActionNotExecuted() {
-    expect(testFixture.customActionStub.callCount).to.equal(0);
+    expect(testFixture.testEnvironment.customActionStub.callCount).to.equal(0);
   }
 
   function verifyCustomActionMetadata(actualMetadata, docType, expectedActionType) {

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -228,7 +228,7 @@ describe('Functionality that is common to all documents:', () => {
       let syncFuncError = null;
       expect(() => {
         try {
-          testFixture.syncFunction(doc);
+          testFixture.testEnvironment.syncFunction(doc);
         } catch (ex) {
           syncFuncError = ex;
 
@@ -263,7 +263,7 @@ describe('Functionality that is common to all documents:', () => {
     let syncFuncError = null;
     expect(() => {
       try {
-        testFixture.syncFunction(doc);
+        testFixture.testEnvironment.syncFunction(doc);
       } catch (ex) {
         syncFuncError = ex;
 

--- a/test/sample-notification-transport.spec.js
+++ b/test/sample-notification-transport.spec.js
@@ -17,12 +17,12 @@ describe('Sample business notification transport doc definition', () => {
   const expectedBasePrivilege = 'NOTIFICATIONS_CONFIG';
 
   function verifyAuthorizationCustomAction(docId, action) {
-    expect(testFixture.requireAccess.callCount).to.equal(2);
-    expect(testFixture.requireAccess.calls[1].arg).to.equal(`${docId}-${action}`);
+    expect(testFixture.testEnvironment.requireAccess.callCount).to.equal(2);
+    expect(testFixture.testEnvironment.requireAccess.calls[1].arg).to.equal(`${docId}-${action}`);
   }
 
   function verifyNoAuthorizationCustomAction() {
-    expect(testFixture.requireAccess.callCount).to.equal(1);
+    expect(testFixture.testEnvironment.requireAccess.callCount).to.equal(1);
   }
 
   it('successfully creates a valid notification transport document', () => {


### PR DESCRIPTION
Ensures that the properties of a test fixture's test environment are the single source of truth for the Sync Gateway API function stubs by no longer exposing them directly through the test fixture object. Now they can only be accessed through a test fixture's `testEnvironment` property. This prevents cases where the test environment can get out of sync with the test fixture if the caller reassigns one of the properties in question (e.g. when `test-fixture-maker.spec.js` reassigns the `syncFunction` property).

This last bit of refactoring should be the final step to address issue #252.