### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,42 @@
+Select from either the [Bug Report](#bug-report) or [Feature Request](#feature-request) templates below to file an issue. Review the project's [contribution guidelines](https://github.com/Kashoo/synctos/blob/master/CONTRIBUTING.md) before proceeding.
+
+# Bug Report
+
+Complete this section to report a bug in the application's behaviour or in the sync functions it generates. Delete this section if you would rather submit a [feature request](#feature-request) instead.
+
+## Steps to reproduce
+
+Provide a step-by-step guide to reproduce the issue:
+
+1. Do X
+2. Do Y
+3. etc.
+
+## Actual behaviour
+
+Explain what actually happens if the steps are executed.
+
+## Expected behaviour
+
+Explain what _should_ happen if the steps are executed.
+
+## Environment
+
+List the version(s) of synctos, Couchbase Server, Sync Gateway and operating system that the issue has been observed on:
+
+* Synctos:
+* Couchbase Server:
+* Sync Gateway:
+* Operating system:
+
+# Feature Request
+
+Complete this section to submit a request for a new feature or an enhancement to an existing feature. Delete this section if you would rather submit a [bug report](#bug-report) instead.
+
+## Description
+
+Detail the feature and explain how it would be useful.
+
+## Examples
+
+Provide example configuration, JSON documents, usage steps, etc. to further illustrate your request.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,20 @@
-Select from either the [Bug Report](#bug-report) or [Feature Request](#feature-request) templates below to file an issue. Review the project's [contribution guidelines](https://github.com/Kashoo/synctos/blob/master/CONTRIBUTING.md) before proceeding.
+Select from either the Feature Request or Bug Report templates below to file an issue. Review the project's [contribution guidelines](https://github.com/Kashoo/synctos/blob/master/CONTRIBUTING.md) before proceeding.
+
+# Feature Request
+
+Complete this section to submit a request for a new feature or an enhancement to an existing feature. Delete this section if you would rather submit a bug report instead.
+
+## Description
+
+Detail the feature and explain how it would be useful.
+
+## Examples
+
+Provide example configuration, JSON documents, usage steps, etc. to further illustrate your request.
 
 # Bug Report
 
-Complete this section to report a bug in the application's behaviour or in the sync functions it generates. Delete this section if you would rather submit a [feature request](#feature-request) instead.
+Complete this section to report a bug in the application's behaviour or in the sync functions it generates. Delete this section if you would rather submit a feature request instead.
 
 ## Steps to reproduce
 
@@ -28,15 +40,3 @@ List the version(s) of synctos, Couchbase Server, Sync Gateway and operating sys
 * Couchbase Server:
 * Sync Gateway:
 * Operating system:
-
-# Feature Request
-
-Complete this section to submit a request for a new feature or an enhancement to an existing feature. Delete this section if you would rather submit a [bug report](#bug-report) instead.
-
-## Description
-
-Detail the feature and explain how it would be useful.
-
-## Examples
-
-Provide example configuration, JSON documents, usage steps, etc. to further illustrate your request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+# Description
+
+Enter a few sentences to describe the issue that is being addressed by this change. Review the project's [contribution guidelines](https://github.com/Kashoo/synctos/blob/master/CONTRIBUTING.md) before proceeding.
+
+# Testing
+
+Describe how the changes have been tested and how a reviewer can test for themselves. Provide example configuration if necessary.
+
+# Related Issue
+
+* GitHub issue link:


### PR DESCRIPTION
Whenever a new issue or pull request is created from now on, these [templates](https://blog.github.com/2016-02-17-issue-and-pull-request-templates/) must be filled in to provide context.