### PR TITLE
Issue #270: Avoid JavaScript errors if the JSON object does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
 ## [Unreleased]
-Nothing yet.
+### Fixed
+- [#270](https://github.com/Kashoo/synctos/issues/270): JavaScript error on document write in Sync Gateway 1.x
 
 ## [2.2.0] - 2018-03-20
 ### Added

--- a/templates/sync-function/template.js
+++ b/templates/sync-function/template.js
@@ -54,7 +54,8 @@ function synctos(doc, oldDoc) {
 
   // Converts a given value to a JSON string. Exists because JSON.stringify is not supported by all versions of Sync
   // Gateway's JavaScript engine.
-  var jsonStringify = (JSON && JSON.stringify) ? JSON.stringify : importSyncFunctionFragment('json-stringify-module.js');
+  var jsonStringify =
+    (typeof JSON !== 'undefined') ? JSON.stringify : importSyncFunctionFragment('json-stringify-module.js');
 
   var utils = {
     isDocumentMissingOrDeleted: isDocumentMissingOrDeleted,


### PR DESCRIPTION
# Description

JavaScript engines are meant to throw a runtime error when they encounter an attempt to access a variable that has not been declared. Because the global `JSON` object does not exist in the JavaScript engine used by Sync Gateway 1.x, attempts to check for its existence must use `typeof JSON !== 'undefined'` to avoid the error ([more info](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined#Typeof_operator_and_undefined)).

Does not affect Sync Gateway 2.x since the global `JSON` object does exist in that version's JavaScript engine.

# Testing

Completed the steps to reproduce from the related issue using both Sync Gateway 1.5.1 and [2.0.0 beta 2](https://packages.couchbase.com/releases/couchbase-sync-gateway/2.0.0-beta2/couchbase-sync-gateway-enterprise_2.0.0-beta2_x86_64.tar.gz).

# Related Issue

* GitHub issue link: #270
