### PR TITLE
Issue 272: Release of 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
-## [Unreleased]
+## [2.2.1] - 2018-03-21
 ### Fixed
 - [#270](https://github.com/Kashoo/synctos/issues/270): JavaScript error on document write in Sync Gateway 1.x
 
@@ -174,7 +174,8 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ## [1.0.0] - 2016-07-12
 First public release
 
-[Unreleased]: https://github.com/Kashoo/synctos/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/Kashoo/synctos/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/Kashoo/synctos/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Kashoo/synctos/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/Kashoo/synctos/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/Kashoo/synctos/compare/v2.0.1...v2.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "synctos",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctos",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "The Syncmaker. A tool to build comprehensive sync functions for Couchbase Sync Gateway.",
   "keywords": [
     "couchbase",


### PR DESCRIPTION
# Description

- Updated the changelog
- Updated the package's version number

# Testing

Locally updated [kashoo-document-definitions](https://github.com/Kashoo/kashoo-document-definitions) to target the version of synctos with a fix for issue #270. Executed several document writes using both Sync Gateway 1.5.1 and [2.0.0 beta 2](https://packages.couchbase.com/releases/couchbase-sync-gateway/2.0.0-beta2/couchbase-sync-gateway-enterprise_2.0.0-beta2_x86_64.tar.gz).

# Related Issue

* GitHub issue link: #272
