### PR TITLE
Issue #274: Release procedure documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,14 +107,14 @@ If/when a change is deemed satisfactory, it is the responsibility of the reviewe
 
 # Publishing
 
-Follow these steps when it is time to publish a new release:
+When it is time to publish a new release, a project contributor should follow these steps:
 
 1. Create a GitHub issue/ticket for the release (e.g. https://github.com/Kashoo/synctos/issues/272) with the [task](https://github.com/Kashoo/synctos/issues?q=is%3Aissue+label%3Atask) label and assigned to your own GitHub user
 2. Create a release branch (e.g. `v2.2.1-release`)
 3. Create a GitHub release candidate tag (e.g. `v2.2.1-rc.1`) from the HEAD of the release branch; include the version's changelog content in the description and mark it as a "pre-release"
 4. Validate the release candidate with [kashoo-document-definitions](https://github.com/Kashoo/kashoo-document-definitions), for example, by changing the package's "synctos" dependency version to target the release candidate tag (e.g. "git@github.com:Kashoo/synctos.git#v2.2.1-rc.1") and then running `npm install && npm test`. Confirm that a generated sync function also works with live instances of both Sync Gateway 1.x and 2.x.
 5. Create a new branch (e.g. `issue-272-release-2.2.1`) based off of the _release_ branch, rather than the master branch:
-    1. Modify the "Unreleased" section of `CHANGELOG.md` to display the new version number and date stamp
+    1. Modify the "Unreleased" section of `CHANGELOG.md` to display the new version number and date stamp. Be sure to also create a new range comparison link for the new version (e.g. `[2.2.1]: https://github.com/Kashoo/synctos/compare/v2.2.0...v2.2.1`) and update the range comparison link for the "Unreleased" section (e.g. `[Unreleased]: https://github.com/Kashoo/synctos/compare/v2.2.1...HEAD`) at the bottom of the file.
     2. Update the "version" property in `package.json` and then regenerate the package lock file using `npm install`
     3. Upgrade the project's npm development dependencies (i.e. the "devDependencies" property in `package.json`) as necessary
     4. Create a pull request that targets the _release_ branch, rather than the master branch (e.g. https://github.com/Kashoo/synctos/pull/273)
@@ -122,7 +122,7 @@ Follow these steps when it is time to publish a new release:
 7. Publish the new version to npm: `git checkout <release_branch_name> && git reset --hard && git pull && npm publish`
 8. Merge the release branch into the master branch
 9. Delete the release branch
-10. Restore the "Unreleased" section to `CHANGELOG.md` in the master branch
+10. Restore the "Unreleased" section to `CHANGELOG.md` in the master branch. Ensure that the range comparison link at the bottom of the file for the "Unreleased" section is accurate (e.g. `[Unreleased]: https://github.com/Kashoo/synctos/compare/v2.2.1...HEAD`).
 11. Upgrade the project's runtime dependencies (i.e. the contents of the `lib` directory) as necessary
 12. Post a release announcement to the official Couchbase forum: https://forums.couchbase.com/t/utility-to-make-building-sync-functions-for-sync-gateway-easier/9107
 13. Close the GitHub issue/ticket for the release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,3 +104,25 @@ Once a change has been posted as a GitHub pull request, a synctos project contri
 Special care should be taken to ensure that each submission is captured as a GitHub issue, thoroughly documented in `README.md` and in `CHANGELOG.md`'s "Unreleased" section, comprehensively covered by test cases, includes examples in the sample document definitions directory, does not introduce breaking changes to public APIs, does not introduce new package dependencies and does not make use of advanced JavaScript/ECMAScript language features that are not supported by the [version](https://github.com/robertkrimen/otto/tree/5282a5a45ba989692b3ae22f730fa6b9dd67662f) of the otto JavaScript engine/interpreter that is used by Sync Gateway.
 
 If/when a change is deemed satisfactory, it is the responsibility of the reviewer to merge the pull request and delete its feature branch, where possible.
+
+# Publishing
+
+Follow these steps when it is time to publish a new release:
+
+1. Create a GitHub issue/ticket for the release (e.g. https://github.com/Kashoo/synctos/issues/272) with the [task](https://github.com/Kashoo/synctos/issues?q=is%3Aissue+label%3Atask) label and assigned to your own GitHub user
+2. Create a release branch (e.g. `v2.2.1-release`)
+3. Create a GitHub release candidate tag (e.g. `v2.2.1-rc.1`) from the HEAD of the release branch; include the version's changelog content in the description and mark it as a "pre-release"
+4. Validate the release candidate with [kashoo-document-definitions](https://github.com/Kashoo/kashoo-document-definitions), for example, by changing the package's "synctos" dependency version to target the release candidate tag (e.g. "git@github.com:Kashoo/synctos.git#v2.2.1-rc.1") and then running `npm install && npm test`. Confirm that a generated sync function also works with live instances of both Sync Gateway 1.x and 2.x.
+5. Create a new branch (e.g. `issue-272-release-2.2.1`) based off of the _release_ branch, rather than the master branch:
+    1. Modify the "Unreleased" section of `CHANGELOG.md` to display the new version number and date stamp
+    2. Update the "version" property in `package.json` and then regenerate the package lock file using `npm install`
+    3. Upgrade the project's npm development dependencies (i.e. the "devDependencies" property in `package.json`) as necessary
+    4. Create a pull request that targets the _release_ branch, rather than the master branch (e.g. https://github.com/Kashoo/synctos/pull/273)
+6. After the pull request is reviewed and merged, create a GitHub release tag (e.g. `v2.2.1`) from the HEAD of the release branch; include the version's changelog content in the description
+7. Publish the new version to npm: `git checkout <release_branch_name> && git reset --hard && git pull && npm publish`
+8. Merge the release branch into the master branch
+9. Delete the release branch
+10. Restore the "Unreleased" section to `CHANGELOG.md` in the master branch
+11. Upgrade the project's runtime dependencies (i.e. the contents of the `lib` directory) as necessary
+12. Post a release announcement to the official Couchbase forum: https://forums.couchbase.com/t/utility-to-make-building-sync-functions-for-sync-gateway-easier/9107
+13. Close the GitHub issue/ticket for the release


### PR DESCRIPTION
# Description

Added release procedure documentation to the contribution guidelines (`CONTRIBUTING.md`) file.

# Testing

I have followed these steps for many past releases, though they are only just now being stored in the repo.

# Related Issue

* GitHub issue link: #274
