### PR TITLE
Issue 276: Prevent years 0-99 from being translated to 1900-1999

### DIFF
--- a/templates/sync-function/time-module.js
+++ b/templates/sync-function/time-module.js
@@ -155,14 +155,16 @@ function timeModule(utils) {
         return NaN;
       }
 
-      return Date.UTC(
-        date.year,
-        date.month - 1,
-        date.day,
-        time.hour,
-        time.minute - time.timezoneOffsetMinutes,
-        time.second,
-        time.millisecond);
+      var dateAndTime = new Date();
+      dateAndTime.setUTCFullYear(date.year);
+      dateAndTime.setUTCMonth(date.month - 1);
+      dateAndTime.setUTCDate(date.day);
+      dateAndTime.setUTCHours(time.hour);
+      dateAndTime.setUTCMinutes(time.minute - time.timezoneOffsetMinutes);
+      dateAndTime.setUTCSeconds(time.second);
+      dateAndTime.setUTCMilliseconds(time.millisecond);
+
+      return dateAndTime.getTime();
     } else {
       return NaN;
     }

--- a/test/date.spec.js
+++ b/test/date.spec.js
@@ -296,4 +296,30 @@ describe('Date validation type:', () => {
       testFixture.verifyDocumentNotReplaced(doc, oldDoc, 'dateDoc', [ errorFormatter.immutableItemViolation('immutableValidationProp') ]);
     });
   });
+
+  describe('interpretation of years between 0 and 99', () => {
+    it('does not treat year 0 as 1900', () => {
+      const doc = {
+        _id: 'dateDoc',
+        twoDigitYearValidationProp: '0000-03-23'
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'dateDoc',
+        [ errorFormatter.minimumValueViolation('twoDigitYearValidationProp', '1900-01-01')]);
+    });
+
+    it('does not treat year 99 as 1999', () => {
+      const doc = {
+        _id: 'dateDoc',
+        twoDigitYearValidationProp: '0099-09-09'
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'dateDoc',
+        [ errorFormatter.minimumValueViolation('twoDigitYearValidationProp', '1900-01-01')]);
+    });
+  });
 });

--- a/test/datetime.spec.js
+++ b/test/datetime.spec.js
@@ -511,4 +511,30 @@ describe('Date/time validation type', () => {
         [ errorFormatter.immutableItemViolation('immutabilityValidationProp') ]);
     });
   });
+
+  describe('interpretation of years between 0 and 99', () => {
+    it('does not treat year 1900 as less than or equal to year 99', () => {
+      const doc = {
+        _id: 'datetimeDoc',
+        twoDigitYearValidationProp: '1900-04-09T08:38:29Z'
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'datetimeDoc',
+        [ errorFormatter.maximumValueViolation('twoDigitYearValidationProp', '0099-12-31T23:59:59.999+12:00')]);
+    });
+
+    it('does not treat year 1999 as less than or equal to year 99', () => {
+      const doc = {
+        _id: 'datetimeDoc',
+        twoDigitYearValidationProp: '1999-06-01T15:44Z'
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'datetimeDoc',
+        [ errorFormatter.maximumValueViolation('twoDigitYearValidationProp', '0099-12-31T23:59:59.999+12:00')]);
+    });
+  });
 });

--- a/test/resources/date-doc-definitions.js
+++ b/test/resources/date-doc-definitions.js
@@ -21,6 +21,10 @@
       immutableValidationProp: {
         type: 'date',
         immutableWhenSet: true
+      },
+      twoDigitYearValidationProp: {
+        type: 'date',
+        minimumValue: '1900-01-01'
       }
     }
   },

--- a/test/resources/datetime-doc-definitions.js
+++ b/test/resources/datetime-doc-definitions.js
@@ -26,6 +26,10 @@
       immutabilityValidationProp: {
         type: 'datetime',
         immutable: true
+      },
+      twoDigitYearValidationProp: {
+        type: 'datetime',
+        maximumValue: '0099-12-31T23:59:59.999+12:00'
       }
     }
   },


### PR DESCRIPTION
# Description

Force the JavaScript engine to use full years so that one- and two-digit years (i.e. years 0 through 99) in date and date-time strings are interpreted correctly, rather than as years between 1900 and 1999.

# Testing

Followed the steps to reproduce from the related issue with Sync Gateway 1.5.1 and [2.0.0 Beta 2](https://packages.couchbase.com/releases/couchbase-sync-gateway/2.0.0-beta2/couchbase-sync-gateway-enterprise_2.0.0-beta2_x86_64.tar.gz) after applying these changes.

# Related Issue

* GitHub issue link: #276
