### PR TITLE
Issue 279: Refactor custom action tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Once a change has been posted as a GitHub pull request, a synctos project contri
 
 Special care should be taken to ensure that each submission is captured as a GitHub issue, thoroughly documented in `README.md` and in `CHANGELOG.md`'s "Unreleased" section, comprehensively covered by test cases, includes examples in the sample document definitions directory, does not introduce breaking changes to public APIs, does not introduce new package dependencies and does not make use of advanced JavaScript/ECMAScript language features that are not supported by the [version](https://github.com/robertkrimen/otto/tree/5282a5a45ba989692b3ae22f730fa6b9dd67662f) of the otto JavaScript engine/interpreter that is used by Sync Gateway.
 
-If/when a change is deemed satisfactory, it is the responsibility of the reviewer to merge the pull request and delete its feature branch, where possible.
+If/when a change is deemed satisfactory, it is the responsibility of the reviewer to merge the pull request and delete its feature branch, where possible. Be sure to close the corresponding GitHub issue if its requirements have been fully satisfied by the pull request's changes.
 
 # Publishing
 

--- a/etc/jshintrc-sync-function-template.json
+++ b/etc/jshintrc-sync-function-template.json
@@ -8,7 +8,6 @@
     "_": false,
     "access": false,
     "channel": false,
-    "customActionStub": false,
     "JSON": false,
     "requireAccess": false,
     "requireRole": false,

--- a/src/testing/test-environment-maker.js
+++ b/src/testing/test-environment-maker.js
@@ -34,7 +34,7 @@ function init(rawSyncFunction, syncFunctionFile) {
   const environmentStatement = `(${environmentString});`;
 
   // Compile the test environment function within the current virtual machine context so it can share access to the "requireAccess",
-  // "channel", "customActionStub", etc. stubs with the test-fixture-maker module
+  // "channel", etc. stubs with the test-fixture-maker module
   const environmentFunction = vm.runInThisContext(environmentStatement, options);
 
   return environmentFunction(underscore, simpleMock);

--- a/src/testing/test-fixture-maker.spec.js
+++ b/src/testing/test-fixture-maker.spec.js
@@ -17,7 +17,6 @@ describe('Test fixture maker:', () => {
       channel: simpleMock.stub(),
       access: simpleMock.stub(),
       role: simpleMock.stub(),
-      customActionStub: simpleMock.stub(),
       syncFunction: simpleMock.stub()
     };
 

--- a/src/testing/test-helper.js
+++ b/src/testing/test-helper.js
@@ -264,9 +264,6 @@ function init(rawSyncFunction, syncFunctionFile) {
   exports.access = testHelperEnvironment.access;
   exports.role = testHelperEnvironment.role;
 
-  // A function stub that can be used in document definitions for test cases to verify custom actions
-  exports.customActionStub = testHelperEnvironment.customActionStub;
-
   exports.syncFunction = testHelperEnvironment.syncFunction;
 }
 

--- a/src/testing/test-helper.spec.js
+++ b/src/testing/test-helper.spec.js
@@ -17,7 +17,6 @@ describe('Test helper:', () => {
       channel: simpleMock.stub(),
       access: simpleMock.stub(),
       role: simpleMock.stub(),
-      customActionStub: simpleMock.stub(),
       syncFunction: simpleMock.stub()
     };
 
@@ -77,7 +76,6 @@ describe('Test helper:', () => {
       expect(testHelper.channel).to.equal(fakeTestEnvironment.channel);
       expect(testHelper.access).to.equal(fakeTestEnvironment.access);
       expect(testHelper.role).to.equal(fakeTestEnvironment.role);
-      expect(testHelper.customActionStub).to.equal(fakeTestEnvironment.customActionStub);
       expect(testHelper.syncFunction).to.equal(fakeTestEnvironment.syncFunction);
     }
   });

--- a/src/validation/validation-environment-maker.js
+++ b/src/validation/validation-environment-maker.js
@@ -35,7 +35,7 @@ function init(docDefinitionsString, originalFilename) {
   const envStatement = `(${envString});`;
 
   // Compile the document definitions environment function within the current virtual machine context so it can share access to the
-  // "requireAccess", "channel", "customActionStub", etc. stubs
+  // "requireAccess", "channel", etc. stubs
   const envFunction = vm.runInThisContext(envStatement, options);
 
   return envFunction(underscore, simpleMock);

--- a/templates/environments/test-environment-template.js
+++ b/templates/environments/test-environment-template.js
@@ -10,8 +10,6 @@ function makeTestEnvironment(_, simple) {
   const access = simple.stub();
   const role = simple.stub();
 
-  const customActionStub = simple.stub();
-
   return {
     _,
     JSON,
@@ -21,7 +19,6 @@ function makeTestEnvironment(_, simple) {
     channel,
     access,
     role,
-    customActionStub,
     syncFunction: %SYNC_FUNC_PLACEHOLDER%
   };
 }

--- a/templates/environments/validation-environment-template.js
+++ b/templates/environments/validation-environment-template.js
@@ -13,8 +13,6 @@ function makeValidationEnvironment(_, simple) {
   const access = simple.stub();
   const role = simple.stub();
 
-  const customActionStub = simple.stub();
-
   return {
     _,
     doc,
@@ -30,7 +28,6 @@ function makeValidationEnvironment(_, simple) {
     channel,
     access,
     role,
-    customActionStub,
     documentDefinitions: %DOC_DEFINITIONS_PLACEHOLDER%
   };
 }

--- a/templates/sync-function/.jshintrc
+++ b/templates/sync-function/.jshintrc
@@ -7,7 +7,6 @@
     "_": false,
     "access": false,
     "channel": false,
-    "customActionStub": false,
     "importSyncFunctionFragment": false,
     "JSON": false,
     "requireAccess": false,

--- a/templates/sync-function/template.js
+++ b/templates/sync-function/template.js
@@ -2,7 +2,7 @@
 function synctos(doc, oldDoc) {
   // Whether the given value is either null or undefined
   function isValueNullOrUndefined(value) {
-    return typeof value === 'undefined' || value === null;
+    return value === void 0 || value === null;
   }
 
   // Whether the given document is missing/nonexistant (i.e. null or undefined) or deleted (its "_deleted" property is true)

--- a/templates/sync-function/validation-module.js
+++ b/templates/sync-function/validation-module.js
@@ -187,12 +187,12 @@ function validationModule(utils, simpleTypeFilter, typeIdValidator) {
         }
 
         var expectedEqualValue = resolveItemConstraint(validator.mustEqual);
-        if (typeof expectedEqualValue !== 'undefined') {
+        if (expectedEqualValue !== void 0) {
           storeOptionalValidationErrors(comparisonModule.validateEquality(itemStack, expectedEqualValue, validator.type));
         }
 
         var expectedStrictEqualValue = resolveItemConstraint(validator.mustEqualStrict);
-        if (typeof expectedStrictEqualValue !== 'undefined') {
+        if (expectedStrictEqualValue !== void 0) {
           // Omitting validator type forces it to perform strict equality comparisons for specialized string types
           // (e.g. "date", "datetime", "time", "timezone", "uuid")
           storeOptionalValidationErrors(comparisonModule.validateEquality(itemStack, expectedStrictEqualValue));
@@ -319,7 +319,7 @@ function validationModule(utils, simpleTypeFilter, typeIdValidator) {
         } else if (resolveItemConstraint(validator.required)) {
           // The item has no value (either it's null or undefined), but the validator indicates it is required
           validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be null or missing');
-        } else if (resolveItemConstraint(validator.mustNotBeMissing) && typeof itemValue === 'undefined') {
+        } else if (resolveItemConstraint(validator.mustNotBeMissing) && itemValue === void 0) {
           // The item is missing (i.e. it's undefined), but the validator indicates it must not be
           validationErrors.push('item "' + buildItemPath(itemStack) + '" must not be missing');
         } else if (resolveItemConstraint(validator.mustNotBeNull) && itemValue === null) {

--- a/test/custom-actions.spec.js
+++ b/test/custom-actions.spec.js
@@ -21,18 +21,15 @@ describe('Custom actions:', () => {
     const oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', () => {
-      testFixture.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, null, 'onTypeIdentificationSucceeded');
+      verifyCustomActionExecution(doc, null, docType, 'onTypeIdentificationSucceeded');
     });
 
     it('executes a custom action when a document is replaced', () => {
-      testFixture.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, oldDoc, 'onTypeIdentificationSucceeded');
+      verifyCustomActionExecution(doc, oldDoc, docType, 'onTypeIdentificationSucceeded');
     });
 
     it('executes a custom action when a document is deleted', () => {
-      testFixture.verifyDocumentDeleted(oldDoc, expectedAuthorization);
-      verifyCustomActionExecuted(getDeletedDoc(docType), oldDoc, 'onTypeIdentificationSucceeded');
+      verifyCustomActionExecution(getDeletedDoc(docType), oldDoc, docType, 'onTypeIdentificationSucceeded');
     });
 
     it('does not execute a custom action if the type cannot be identified', () => {
@@ -51,7 +48,6 @@ describe('Custom actions:', () => {
       }).to.throw();
 
       testFixture.verifyValidationErrors(unknownDocType, errorFormatter.unknownDocumentType(), syncFuncError);
-      verifyCustomActionNotExecuted();
     });
   });
 
@@ -61,23 +57,19 @@ describe('Custom actions:', () => {
     const oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', () => {
-      testFixture.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, null, 'onAuthorizationSucceeded');
+      verifyCustomActionExecution(doc, null, docType, 'onAuthorizationSucceeded');
     });
 
     it('executes a custom action when a document is replaced', () => {
-      testFixture.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, oldDoc, 'onAuthorizationSucceeded');
+      verifyCustomActionExecution(doc, oldDoc, docType, 'onAuthorizationSucceeded');
     });
 
     it('executes a custom action when a document is deleted', () => {
-      testFixture.verifyDocumentDeleted(oldDoc, expectedAuthorization);
-      verifyCustomActionExecuted(getDeletedDoc(docType), oldDoc, 'onAuthorizationSucceeded');
+      verifyCustomActionExecution(getDeletedDoc(docType), oldDoc, docType, 'onAuthorizationSucceeded');
     });
 
     it('does not execute a custom action if authorization was denied', () => {
       testFixture.verifyAccessDenied(doc, null, expectedAuthorization);
-      verifyCustomActionNotExecuted();
     });
   });
 
@@ -87,18 +79,15 @@ describe('Custom actions:', () => {
     const oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', () => {
-      testFixture.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, null, 'onValidationSucceeded');
+      verifyCustomActionExecution(doc, null, docType, 'onValidationSucceeded');
     });
 
     it('executes a custom action when a document is replaced', () => {
-      testFixture.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, oldDoc, 'onValidationSucceeded');
+      verifyCustomActionExecution(doc, oldDoc, docType, 'onValidationSucceeded');
     });
 
     it('executes a custom action when a document is deleted', () => {
-      testFixture.verifyDocumentDeleted(oldDoc, expectedAuthorization);
-      verifyCustomActionExecuted(getDeletedDoc(docType), oldDoc, 'onValidationSucceeded');
+      verifyCustomActionExecution(getDeletedDoc(docType), oldDoc, docType, 'onValidationSucceeded');
     });
 
     it('does not execute a custom action if the document contents are invalid', () => {
@@ -108,7 +97,6 @@ describe('Custom actions:', () => {
       };
 
       testFixture.verifyDocumentNotCreated(doc, docType, errorFormatter.unsupportedProperty('unsupportedProperty'), expectedAuthorization);
-      verifyCustomActionNotExecuted();
     });
   });
 
@@ -118,32 +106,27 @@ describe('Custom actions:', () => {
     const oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', () => {
-      testFixture.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, null, 'onAccessAssignmentsSucceeded');
+      verifyCustomActionExecution(doc, null, docType, 'onAccessAssignmentsSucceeded');
     });
 
     it('executes a custom action when a document is replaced', () => {
-      testFixture.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, oldDoc, 'onAccessAssignmentsSucceeded');
+      verifyCustomActionExecution(doc, oldDoc, docType, 'onAccessAssignmentsSucceeded');
     });
 
     it('does not execute a custom action when a document is deleted', () => {
       testFixture.verifyDocumentDeleted(oldDoc, expectedAuthorization);
-      verifyCustomActionNotExecuted();
     });
 
     it('does not execute a custom action if the document definition does not define access assignments', () => {
       const doc = { _id: 'missingAccessAssignmentsDoc' };
 
       testFixture.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionNotExecuted();
     });
 
     it('does not execute a custom action if the document definition has an empty access assignments definition', () => {
       const doc = { _id: 'emptyAccessAssignmentsDoc' };
 
       testFixture.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionNotExecuted();
     });
   });
 
@@ -153,19 +136,15 @@ describe('Custom actions:', () => {
     const oldDoc = { _id: docType };
 
     it('executes a custom action when a document is created', () => {
-      testFixture.verifyDocumentCreated(doc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, null, 'onDocumentChannelAssignmentSucceeded');
+      verifyCustomActionExecution(doc, null, docType, 'onDocumentChannelAssignmentSucceeded');
     });
 
     it('executes a custom action when a document is replaced', () => {
-
-      testFixture.verifyDocumentReplaced(doc, oldDoc, expectedAuthorization);
-      verifyCustomActionExecuted(doc, oldDoc, 'onDocumentChannelAssignmentSucceeded');
+      verifyCustomActionExecution(doc, oldDoc, docType, 'onDocumentChannelAssignmentSucceeded');
     });
 
     it('executes a custom action when a document is deleted', () => {
-      testFixture.verifyDocumentDeleted(oldDoc, expectedAuthorization);
-      verifyCustomActionExecuted(getDeletedDoc(docType), oldDoc, 'onDocumentChannelAssignmentSucceeded');
+      verifyCustomActionExecution(getDeletedDoc(docType), oldDoc, docType, 'onDocumentChannelAssignmentSucceeded');
     });
 
     it('does not execute a custom action if doc channel assignment fails', () => {
@@ -175,29 +154,47 @@ describe('Custom actions:', () => {
       expect(() => {
         testFixture.testEnvironment.syncFunction(doc);
       }).to.throw(expectedError);
-
-      verifyCustomActionNotExecuted();
     });
   });
 
-  function verifyCustomActionExecuted(doc, oldDoc, expectedActionType) {
-    expect(testFixture.testEnvironment.customActionStub.callCount).to.equal(1);
-    expect(testFixture.testEnvironment.customActionStub.calls[0].args[0]).to.eql(doc);
-    expect(testFixture.testEnvironment.customActionStub.calls[0].args[1]).to.eql(oldDoc);
+  function verifyCustomActionExecution(doc, oldDoc, docType, expectedActionType) {
+    let syncFuncError = null;
+    expect(() => {
+      try {
+        testFixture.testEnvironment.syncFunction(doc, oldDoc);
+      } catch (ex) {
+        syncFuncError = ex;
+        throw ex;
+      }
+    }).to.throw();
 
-    verifyCustomActionMetadata(testFixture.testEnvironment.customActionStub.calls[0].args[2], doc._id, expectedActionType);
-  }
+    expect(syncFuncError.doc).to.eql(doc);
+    expect(syncFuncError.oldDoc).to.eql(oldDoc);
+    expect(syncFuncError.actionType).to.eql(expectedActionType);
 
-  function verifyCustomActionNotExecuted() {
-    expect(testFixture.testEnvironment.customActionStub.callCount).to.equal(0);
+    verifyCustomActionMetadata(syncFuncError.customActionMetadata, docType, expectedActionType);
   }
 
   function verifyCustomActionMetadata(actualMetadata, docType, expectedActionType) {
     verifyTypeMetadata(actualMetadata, docType);
+
+    if (expectedActionType === 'onTypeIdentificationSucceeded') {
+      return;
+    }
+
     verifyAuthorizationMetadata(actualMetadata);
+
+    if (expectedActionType === 'onAuthorizationSucceeded' || expectedActionType === 'onValidationSucceeded') {
+      return;
+    }
+
     verifyAccessAssignmentMetadata(actualMetadata);
+
+    if (expectedActionType === 'onAccessAssignmentsSucceeded') {
+      return;
+    }
+
     verifyDocChannelsMetadata(actualMetadata);
-    verifyCustomActionTypeMetadata(actualMetadata, expectedActionType);
   }
 
   function verifyTypeMetadata(actualMetadata, docType) {
@@ -230,10 +227,6 @@ describe('Custom actions:', () => {
 
   function verifyDocChannelsMetadata(actualMetadata) {
     expect(actualMetadata.documentChannels).to.eql([ 'write-channel' ]);
-  }
-
-  function verifyCustomActionTypeMetadata(actualMetadata, expectedActionType) {
-    expect(actualMetadata.actionType).to.equal(expectedActionType);
   }
 
   function getDeletedDoc(docType) {

--- a/test/resources/custom-actions-doc-definitions.js
+++ b/test/resources/custom-actions-doc-definitions.js
@@ -1,10 +1,13 @@
 function() {
   function customAction(actionType) {
     return function(doc, oldDoc, customActionMetadata) {
-      customActionMetadata.actionType = actionType;
-
-      // This function is defined as a stub by the test-fixture-maker module to make it easy to verify whether a custom action has been executed
-      customActionStub(doc, oldDoc, customActionMetadata);
+      // The most reliable means to get a result from a sync function is to throw it
+      throw {
+        doc: doc,
+        oldDoc: oldDoc,
+        customActionMetadata: customActionMetadata,
+        actionType: actionType
+      };
     };
   }
 


### PR DESCRIPTION
# Description

Eliminates reliance on the stubbed function (`customActionStub`) that was injected into every test environment to test the custom actions feature. The new approach is more precise about which custom action event was actually executed to generate each piece of metadata that is passed along.

# Testing

Executed the full test suite with `npm test`.

# Related Issue

* GitHub issue link: #279
