### PR TITLE
Update template string macro names

### DIFF
--- a/src/loading/sync-function-loader.js
+++ b/src/loading/sync-function-loader.js
@@ -33,7 +33,7 @@ function loadFromFile(docDefinitionsFile, formatOptions) {
   const docDefinitions = docDefinitionsLoader.load(docDefinitionsFile);
 
   // Load the document definitions into the sync function template
-  const rawSyncFuncString = syncFuncTemplate.replace('%SYNC_DOCUMENT_DEFINITIONS%', () => docDefinitions);
+  const rawSyncFuncString = syncFuncTemplate.replace('$DOCUMENT_DEFINITIONS$', () => docDefinitions);
 
   return formatSyncFunction(rawSyncFuncString, formatOptions || { });
 }

--- a/src/loading/sync-function-loader.spec.js
+++ b/src/loading/sync-function-loader.spec.js
@@ -73,7 +73,7 @@ describe('Sync function loader', () => {
     const docDefinitionsFile = 'my/doc-definitions.js';
     const docDefinitionsContent = 'my-doc-definitions';
     const originalSyncFuncTemplate = 'my-original-sync-fync-template';
-    const updatedSyncFuncTemplate = 'function my-sync-func-template() { %SYNC_DOCUMENT_DEFINITIONS%; }';
+    const updatedSyncFuncTemplate = 'function my-sync-func-template() { $DOCUMENT_DEFINITIONS$; }';
 
     fsMock.readFileSync.returnWith(originalSyncFuncTemplate);
     fileFragmentLoaderMock.load.returnWith(updatedSyncFuncTemplate);

--- a/src/testing/test-environment-maker.js
+++ b/src/testing/test-environment-maker.js
@@ -23,10 +23,10 @@ function init(rawSyncFunction, syncFunctionFile) {
   const filePath = path.resolve(__dirname, '../../templates/environments/test-environment-template.js');
   const environmentTemplate = fs.readFileSync(filePath, 'utf8').trim();
 
-  // The test environment includes a placeholder string called "%SYNC_FUNC_PLACEHOLDER%" that is to be replaced with the contents of
+  // The test environment includes a placeholder string called "$SYNC_FUNC_PLACEHOLDER$" that is to be replaced with the contents of
   // the sync function
   const environmentString = environmentTemplate.replace(
-    '%SYNC_FUNC_PLACEHOLDER%',
+    '$SYNC_FUNC_PLACEHOLDER$',
     () => unescapeBackticks(rawSyncFunction));
 
   // The code that is compiled must be an expression or a sequence of one or more statements. Surrounding it with parentheses makes it a

--- a/src/testing/test-environment-maker.spec.js
+++ b/src/testing/test-environment-maker.spec.js
@@ -31,11 +31,11 @@ describe('Test environment maker', () => {
   });
 
   function verifyParse(rawSyncFunction, originalFilename) {
-    const envTemplateFileContents = 'template: %SYNC_FUNC_PLACEHOLDER%';
+    const envTemplateFileContents = 'template: $SYNC_FUNC_PLACEHOLDER$';
     fsMock.readFileSync.returnWith(envTemplateFileContents);
 
     const expectedTestEnvString = envTemplateFileContents.replace(
-      '%SYNC_FUNC_PLACEHOLDER%',
+      '$SYNC_FUNC_PLACEHOLDER$',
       () => rawSyncFunction.replace(/\\`/g, () => '`'));
 
     const expectedResult = { bar: 'foo' };

--- a/src/testing/test-helper.spec.js
+++ b/src/testing/test-helper.spec.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const simpleMock = require('../../lib/simple-mock/index');
 const mockRequire = require('mock-require');
 
-describe('Test helper:', () => {
+describe('Test helper (DEPRECATED):', () => {
   let testHelper, fsMock, syncFunctionLoaderMock, testEnvironmentMakerMock, fakeTestEnvironment;
 
   const fakeFilePath = 'my-file-path';

--- a/src/validation/validation-environment-maker.js
+++ b/src/validation/validation-environment-maker.js
@@ -26,9 +26,9 @@ function init(docDefinitionsString, originalFilename) {
   const filePath = path.resolve(__dirname, '../../templates/environments/validation-environment-template.js');
   const envTemplateString = fs.readFileSync(filePath, 'utf8').trim();
 
-  // The validation environment includes a placeholder string called "%DOC_DEFINITIONS_PLACEHOLDER%" that is to be replaced with the
+  // The validation environment includes a placeholder string called "$DOC_DEFINITIONS_PLACEHOLDER$" that is to be replaced with the
   // contents of the document definitions
-  const envString = envTemplateString.replace('%DOC_DEFINITIONS_PLACEHOLDER%', () => docDefinitionsString);
+  const envString = envTemplateString.replace('$DOC_DEFINITIONS_PLACEHOLDER$', () => docDefinitionsString);
 
   // The code that is compiled must be an expression or a sequence of one or more statements. Surrounding it with parentheses makes it a
   // valid statement.

--- a/src/validation/validation-environment-maker.spec.js
+++ b/src/validation/validation-environment-maker.spec.js
@@ -23,11 +23,11 @@ describe('Validation environment maker', () => {
   });
 
   function verifyParse(rawDocumentDefinitions, originalFilename) {
-    const envTemplateFileContents = 'template: %DOC_DEFINITIONS_PLACEHOLDER%';
+    const envTemplateFileContents = 'template: $DOC_DEFINITIONS_PLACEHOLDER$';
     fsMock.readFileSync.returnWith(envTemplateFileContents);
 
     const expectedEnvString = envTemplateFileContents.replace(
-      '%DOC_DEFINITIONS_PLACEHOLDER%',
+      '$DOC_DEFINITIONS_PLACEHOLDER$',
       () => rawDocumentDefinitions);
 
     const expectedResult = { foo: 'bar' };

--- a/templates/environments/.jshintrc
+++ b/templates/environments/.jshintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "../../.jshintrc",
+  "globals": {
+    "$DOC_DEFINITIONS_PLACEHOLDER$": false,
+    "$SYNC_FUNC_PLACEHOLDER$": false
+  }
+}

--- a/templates/environments/test-environment-template.js
+++ b/templates/environments/test-environment-template.js
@@ -19,6 +19,6 @@ function makeTestEnvironment(_, simple) {
     channel,
     access,
     role,
-    syncFunction: %SYNC_FUNC_PLACEHOLDER%
+    syncFunction: $SYNC_FUNC_PLACEHOLDER$
   };
 }

--- a/templates/environments/validation-environment-template.js
+++ b/templates/environments/validation-environment-template.js
@@ -28,6 +28,6 @@ function makeValidationEnvironment(_, simple) {
     channel,
     access,
     role,
-    documentDefinitions: %DOC_DEFINITIONS_PLACEHOLDER%
+    documentDefinitions: $DOC_DEFINITIONS_PLACEHOLDER$
   };
 }

--- a/templates/sync-function/.jshintrc
+++ b/templates/sync-function/.jshintrc
@@ -4,6 +4,7 @@
   "node": false,
   "varstmt": false,
   "globals": {
+    "$DOCUMENT_DEFINITIONS$": false,
     "_": false,
     "access": false,
     "channel": false,

--- a/templates/sync-function/template.js
+++ b/templates/sync-function/template.js
@@ -75,7 +75,7 @@ function synctos(doc, oldDoc) {
   // The access assignment module is responsible for dynamically assigning channels and roles to users
   var accessAssignmentModule = importSyncFunctionFragment('./access-assignment-module.js')(utils);
 
-  var rawDocDefinitions = %SYNC_DOCUMENT_DEFINITIONS%;
+  var rawDocDefinitions = $DOCUMENT_DEFINITIONS$;
 
   var docDefinitions;
   if (typeof rawDocDefinitions === 'function') {


### PR DESCRIPTION
# Description

Changed `%SYNC_DOCUMENT_DEFINITIONS%`, `%SYNC_FUNC_PLACEHOLDER%` and `%DOC_DEFINITIONS_PLACEHOLDER%` to `$DOCUMENT_DEFINITIONS$`, `$SYNC_FUNC_PLACEHOLDER$` and `$DOC_DEFINITIONS_PLACEHOLDER$`, respectively. The new macro names are legal JavaScript names, so there are no longer JavaScript errors when editing the raw template files.

# Testing

Ran the full test suite with `npm test`.

# Related Issue

* GitHub issue link: N/A
