### PR TITLE
Issue 285: Always throw an Error object to indicate invalid content or permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
 ## [Unreleased]
+### Added
+- [#285](https://github.com/Kashoo/synctos/issues/285): Throw an Error object when there is an authorization or validation failure
+
 ### Fixed
 - [#276](https://github.com/Kashoo/synctos/issues/276): Date range validation is incorrect for dates between years 0 and 99
 

--- a/templates/sync-function/authorization-module.js
+++ b/templates/sync-function/authorization-module.js
@@ -134,7 +134,11 @@ function authorizationModule(utils) {
       requireAccess([ ]);
     } else if (!channelMatch && !roleMatch && !userMatch) {
       // None of the authorization methods (e.g. channels, roles, users) succeeded
-      throw { forbidden: 'missing channel access' };
+      var errorMessage = 'missing channel access';
+      var error = new Error(errorMessage);
+      error.forbidden = errorMessage;
+
+      throw error;
     }
 
     return {

--- a/templates/sync-function/template.js
+++ b/templates/sync-function/template.js
@@ -117,7 +117,11 @@ function synctos(doc, oldDoc) {
 
       return;
     } else {
-      throw { forbidden: 'Unknown document type' };
+      var errorMessage = 'Unknown document type';
+      var error = new Error(errorMessage);
+      error.forbidden = errorMessage;
+
+      throw error;
     }
   }
 

--- a/templates/sync-function/validation-module.js
+++ b/templates/sync-function/validation-module.js
@@ -41,7 +41,11 @@ function validationModule(utils, simpleTypeFilter, typeIdValidator) {
     }
 
     if (validationErrors.length > 0) {
-      throw { forbidden: 'Invalid ' + docType + ' document: ' + validationErrors.join('; ') };
+      var errorMessage = 'Invalid ' + docType + ' document: ' + validationErrors.join('; ');
+      var error = new Error(errorMessage);
+      error.forbidden = errorMessage;
+
+      throw error;
     } else {
       return true;
     }
@@ -314,7 +318,7 @@ function validationModule(utils, simpleTypeFilter, typeIdValidator) {
               break;
             default:
               // This is not a document validation error; the item validator is configured incorrectly and must be fixed
-              throw { forbidden: 'No data type defined for validator of item "' + buildItemPath(itemStack) + '"' };
+              throw new Error('No data type defined for validator of item "' + buildItemPath(itemStack) + '"');
           }
         } else if (resolveItemConstraint(validator.required)) {
           // The item has no value (either it's null or undefined), but the validator indicates it is required


### PR DESCRIPTION
# Description

Throwing an Error object results in a more meaningful error message when there is an unexpected authorization or validation failure in a test case. Also, the result is functionally the same as throwing a plain object in a live instance of Sync Gateway.

# Testing

In addition to running the full test suite with `npm test`, there were three main scenarios to be verified manually. In each case, I generated a sync function from `test/resources/authorization-doc-definitions.js` and pasted it into a Sync Gateway configuration file. Then I executed each scenario using Sync Gateway 1.5.1 and 2.0.0 beta 2 to ensure that the error details are still generated properly.

### Unknown document type:

Submit the following request:

```
PUT /test/invalid-doc HTTP/1.1
Host: localhost:4985
Content-Type: application/json

{
	"foo": "bar"
}
```

The response should indicate 403 Forbidden and the body should contain the following:

```
{
    "error": "Forbidden",
    "reason": "Unknown document type"
}
```

### Invalid document contents:

Submit the following request:

```
PUT /test/explicitChannelsDoc HTTP/1.1
Host: localhost:4985
Content-Type: application/json

{
	"invalidProperty": true
}
```

The response should indicate 403 Forbidden and the body should contain the following:

```
{
    "error": "Forbidden",
    "reason": "Invalid explicitChannelsDoc document: property \"invalidProperty\" is not supported"
}
```

### Multiple authorization methods (channels, roles and users) failed:

Submit the following request:

```
PUT /test/dynamicChannelsRolesAndUsersDoc HTTP/1.1
Host: localhost:4984
Content-Type: application/json
Authorization: Basic am9lbDpwYXNzd29yZA==

{
	"users": [ "foo", "bar" ],
	"roles": [ "baz" ]
}
```

The response should indicate 403 Forbidden and the body should contain the following:

```
{
    "error": "Forbidden",
    "reason": "missing channel access"
}
```

# Related Issue

* GitHub issue link: #285
