### PR TITLE
Issue 281: Test environment reset function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 /.nyc_output
+/.vscode
 /node_modules
 /build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ## [Unreleased]
 ### Added
 - [#285](https://github.com/Kashoo/synctos/issues/285): Throw an Error object when there is an authorization or validation failure
+- [#281](https://github.com/Kashoo/synctos/issues/281): Mechanism to reset test environment between test cases
 
 ### Fixed
 - [#276](https://github.com/Kashoo/synctos/issues/276): Date range validation is incorrect for dates between years 0 and 99

--- a/README.md
+++ b/README.md
@@ -811,14 +811,14 @@ After that, create a new specification file in your project's `test/` directory 
 var testFixtureMaker = require('synctos').testFixtureMaker;
 ```
 
-Create a new `describe` block to encapsulate the forthcoming test cases and also initialize the synctos test fixture before each test case using the `beforeEach` function. For example:
+Create a new `describe` block to encapsulate the forthcoming test cases, initialize the synctos test fixture and also reset the state after each test case using the `afterEach` function. For example:
 
 ```
 describe('My new sync function', function() {
-  var testFixture;
+  var testFixture = testFixtureMaker.initFromDocumentDefinitions('/path/to/my-doc-definitions.js');
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromDocumentDefinitions('/path/to/my-doc-definitions.js');
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   ...

--- a/src/testing/test-fixture-maker.js
+++ b/src/testing/test-fixture-maker.js
@@ -37,6 +37,12 @@ function init(rawSyncFunction, syncFunctionFile) {
     validationErrorFormatter,
 
     /**
+     * Resets the test fixture's environment to its initial state. Should be called after each test case to ensure the
+     * environment is in a pristine state at all times.
+     */
+    resetTestEnvironment,
+
+    /**
      * Attempts to write the specified doc and then verifies that it completed successfully with the expected channels.
      *
      * @param {Object} doc The document to write. May include property "_deleted=true" to simulate a delete operation.
@@ -258,6 +264,13 @@ function init(rawSyncFunction, syncFunctionFile) {
   };
 
   const defaultWriteChannel = 'write';
+
+  function resetTestEnvironment() {
+    const newEnvironment = testEnvironmentMaker.init(rawSyncFunction, syncFunctionFile);
+    Object.assign(testEnvironment, newEnvironment);
+
+    return testEnvironment;
+  }
 
   function verifyRequireAccess(expectedChannels) {
     assert.ok(

--- a/test/access-assignment.spec.js
+++ b/test/access-assignment.spec.js
@@ -2,10 +2,11 @@ const { expect } = require('chai');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('User and role access assignment:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-access-assignment-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-access-assignment-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('Static assignment of channels to users and roles and assignment of roles to users', () => {

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Array validation type', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-array-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-array-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('length constraints', () => {

--- a/test/attachment-constraints.spec.js
+++ b/test/attachment-constraints.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('File attachment constraints:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-attachment-constraints-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-attachment-constraints-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('with static validation', () => {

--- a/test/attachment-reference.spec.js
+++ b/test/attachment-reference.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Attachment reference validation type', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-attachment-reference-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-attachment-reference-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('file extensions constraint', () => {

--- a/test/authorization.spec.js
+++ b/test/authorization.spec.js
@@ -1,10 +1,10 @@
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Authorization:', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-authorization-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-authorization-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('for a document with explicit channel definitions', () => {

--- a/test/channel-assignment.spec.js
+++ b/test/channel-assignment.spec.js
@@ -1,10 +1,10 @@
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Channel assignment:', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-authorization-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-authorization-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('for a document with explicit channel definitions', () => {

--- a/test/custom-actions.spec.js
+++ b/test/custom-actions.spec.js
@@ -3,7 +3,8 @@ const errorFormatter = require('../src/testing/validation-error-formatter');
 const { expect } = require('chai');
 
 describe('Custom actions:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-custom-actions-sync-function.js');
 
   const expectedAuthorization = {
     expectedChannels: [ 'write-channel' ],
@@ -11,8 +12,8 @@ describe('Custom actions:', () => {
     expectedUsers: [ 'write-user' ]
   };
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-custom-actions-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('the onTypeIdentificationSucceeded event', () => {

--- a/test/custom-validation.spec.js
+++ b/test/custom-validation.spec.js
@@ -1,10 +1,11 @@
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Custom validation constraint:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-custom-validation-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-custom-validation-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   it('allows a document if custom validation succeeds', () => {

--- a/test/date.spec.js
+++ b/test/date.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Date validation type:', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-date-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-date-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('format validation', () => {

--- a/test/datetime.spec.js
+++ b/test/datetime.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Date/time validation type', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-datetime-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-datetime-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('format validation', () => {

--- a/test/document-id-regex-pattern.spec.js
+++ b/test/document-id-regex-pattern.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Document ID regular expression pattern constraint:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-document-id-regex-pattern-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-document-id-regex-pattern-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('with a static constraint value', () => {

--- a/test/dynamic-constraints.spec.js
+++ b/test/dynamic-constraints.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Dynamic constraints', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-dynamic-constraints-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-dynamic-constraints-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   it('allows a new doc to be created when the property constraints are satisfied', () => {

--- a/test/enum.spec.js
+++ b/test/enum.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Enum validation type', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-enum-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-enum-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('static validation', () => {

--- a/test/fragment.spec.js
+++ b/test/fragment.spec.js
@@ -1,10 +1,10 @@
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Document definition fragments:', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-fragment-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-fragment-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   it('can create documents for a document type whose definition was imported with a single-quoted filename', () => {

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Functionality that is common to all documents:', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-general-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-general-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('the document type identifier', () => {
@@ -47,10 +47,6 @@ describe('Functionality that is common to all documents:', () => {
   });
 
   describe('type validation', () => {
-    beforeEach(() => {
-      testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-general-sync-function.js');
-    });
-
     it('rejects an array property value that is not the right type', () => {
       const doc = {
         _id: 'generalDoc',

--- a/test/hashtable.spec.js
+++ b/test/hashtable.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Hashtable validation type', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-hashtable-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-hashtable-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('size constraints', () => {

--- a/test/immutable-docs.spec.js
+++ b/test/immutable-docs.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Immutable document validation:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-docs-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-docs-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('full document immutability constraint', () => {

--- a/test/immutable-items-strict.spec.js
+++ b/test/immutable-items-strict.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Strict immutable item constraint:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-items-strict-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-items-strict-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('array type with static property validation', () => {

--- a/test/immutable-items.spec.js
+++ b/test/immutable-items.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Immutable item validation parameter', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-items-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-items-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('array type with static property validation', () => {

--- a/test/immutable-nested-properties.spec.js
+++ b/test/immutable-nested-properties.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Immutable nested properties:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-nested-properties-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-nested-properties-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('when an object with an immutable property is nested in an array', () => {

--- a/test/immutable-when-set-strict.spec.js
+++ b/test/immutable-when-set-strict.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Strict immutable when set constraint:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-when-set-strict-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-when-set-strict-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('a property with static validation', () => {

--- a/test/immutable-when-set.spec.js
+++ b/test/immutable-when-set.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Immutable when set constraint:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-when-set-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-immutable-when-set-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('a property with static validation', () => {

--- a/test/must-equal-strict.spec.js
+++ b/test/must-equal-strict.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Strict equality constraint:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-must-equal-strict-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-must-equal-strict-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('array type with static property validation', () => {

--- a/test/must-equal.spec.js
+++ b/test/must-equal.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Equality constraint:', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-must-equal-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-must-equal-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('array type with static property validation', () => {

--- a/test/must-not-be-missing.spec.js
+++ b/test/must-not-be-missing.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Non-missing value constraint', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-must-not-be-missing-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-must-not-be-missing-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('with static validation', () => {

--- a/test/must-not-be-null.spec.js
+++ b/test/must-not-be-null.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Non-null value constraint', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-must-not-be-null-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-must-not-be-null-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('with static validation', () => {

--- a/test/property-validators.spec.js
+++ b/test/property-validators.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Property validators:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-property-validators-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-property-validators-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('static validation at the document level', () => {

--- a/test/range-constraint.spec.js
+++ b/test/range-constraint.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Range constraints:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-range-constraint-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-range-constraint-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('static inclusive ranges', () => {

--- a/test/required.spec.js
+++ b/test/required.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Required value constraint', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-required-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-required-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('with static validation', () => {

--- a/test/sample-business.spec.js
+++ b/test/sample-business.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample Business config doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   function verifyBusinessConfigCreated(businessId, doc) {

--- a/test/sample-notification-transport-processing-summary.spec.js
+++ b/test/sample-notification-transport-processing-summary.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample notification transport processing summary doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   function verifyProcessingSummaryWritten(doc, oldDoc) {

--- a/test/sample-notification-transport.spec.js
+++ b/test/sample-notification-transport.spec.js
@@ -3,14 +3,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample business notification transport doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   const expectedDocType = 'notificationTransport';

--- a/test/sample-notification.spec.js
+++ b/test/sample-notification.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample business notification doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   const expectedDocType = 'notification';

--- a/test/sample-notifications-config.spec.js
+++ b/test/sample-notifications-config.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample business notifications config doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   const expectedDocType = 'notificationsConfig';

--- a/test/sample-notifications-reference.spec.js
+++ b/test/sample-notifications-reference.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample business notifications reference doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   const expectedDocType = 'notificationsReference';

--- a/test/sample-payment-attempt.spec.js
+++ b/test/sample-payment-attempt.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample invoice payment processing attempt doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   function verifyPaymentAttemptWritten(businessId, doc, oldDoc) {

--- a/test/sample-payment-processor-definition.spec.js
+++ b/test/sample-payment-processor-definition.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample payment processor definition doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   const expectedDocType = 'paymentProcessorDefinition';

--- a/test/sample-payment-processor-settlement.spec.js
+++ b/test/sample-payment-processor-settlement.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample payment processor settlement doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   function verifySettlementWritten(businessId, doc, oldDoc) {

--- a/test/sample-payment-requisition.spec.js
+++ b/test/sample-payment-requisition.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample invoice payment requisition doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   const expectedDocType = 'paymentRequisition';

--- a/test/sample-payment-requisitions-reference.spec.js
+++ b/test/sample-payment-requisitions-reference.spec.js
@@ -2,14 +2,12 @@ const sampleSpecHelperMaker = require('./helpers/sample-spec-helper-maker');
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Sample payment requisitions reference doc definition', () => {
-  let testFixture;
-  let errorFormatter;
-  let sampleSpecHelper;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
+  const errorFormatter = testFixture.validationErrorFormatter;
+  const sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-sample-sync-function.js');
-    errorFormatter = testFixture.validationErrorFormatter;
-    sampleSpecHelper = sampleSpecHelperMaker.init(testFixture);
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   const expectedDocType = 'paymentRequisitionsReference';

--- a/test/simple-type-filter.spec.js
+++ b/test/simple-type-filter.spec.js
@@ -1,10 +1,11 @@
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Simple type filter:', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-simple-type-filter-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-simple-type-filter-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   function testSimpleTypeFilter(docTypeId) {

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('String validation type', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-string-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-string-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('length constraints', () => {

--- a/test/time.spec.js
+++ b/test/time.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Time validation type:', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-time-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-time-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('format', () => {

--- a/test/timezone.spec.js
+++ b/test/timezone.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Time zone validation type:', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-timezone-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-timezone-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('format', () => {

--- a/test/type-id-validator.spec.js
+++ b/test/type-id-validator.spec.js
@@ -2,10 +2,11 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('Type identifier validator', () => {
-  let testFixture;
+  const testFixture =
+    testFixtureMaker.initFromSyncFunction('build/sync-functions/test-type-id-validator-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-type-id-validator-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   it('allows a valid string value', () => {

--- a/test/underscore-js.spec.js
+++ b/test/underscore-js.spec.js
@@ -1,10 +1,10 @@
 const testFixtureMaker = require('../src/testing/test-fixture-maker');
 
 describe('Underscore.js library', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-underscore-js-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-underscore-js-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   it('allows a document that satisfies a custom validation constraint implemented with Underscore.js', () => {

--- a/test/uuid.spec.js
+++ b/test/uuid.spec.js
@@ -2,10 +2,10 @@ const testFixtureMaker = require('../src/testing/test-fixture-maker');
 const errorFormatter = require('../src/testing/validation-error-formatter');
 
 describe('UUID validation type:', () => {
-  let testFixture;
+  const testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-uuid-sync-function.js');
 
-  beforeEach(() => {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/test-uuid-sync-function.js');
+  afterEach(() => {
+    testFixture.resetTestEnvironment();
   });
 
   describe('format validation', () => {


### PR DESCRIPTION
# Description

Call the test fixture object's new `resetTestEnvironment` function between test cases to ensure that each test case has a pristine test environment.

# Testing

Ran the full test suite with `npm test`.

# Related Issue

* GitHub issue link: #281
