### PR TITLE
Issue 288: Escape backticks only when writing a sync function to a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 
 ### Fixed
 - [#276](https://github.com/Kashoo/synctos/issues/276): Date range validation is incorrect for dates between years 0 and 99
+- [#288](https://github.com/Kashoo/synctos/issues/288): Backticks are escaped even if sync function is not written to a file
 
 ## [2.2.1] - 2018-03-21
 ### Fixed

--- a/make-sync-function
+++ b/make-sync-function
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
 const commander = require('./lib/commander/index');
 const syncFunctionLoader = require('./src/loading/sync-function-loader');
 const syncFunctionWriter = require('./src/saving/sync-function-writer');

--- a/make-sync-function
+++ b/make-sync-function
@@ -3,8 +3,8 @@
 const fs = require('fs');
 const path = require('path');
 const commander = require('./lib/commander/index');
-const mkdirp = require('./lib/mkdirp/index');
 const syncFunctionLoader = require('./src/loading/sync-function-loader');
+const syncFunctionWriter = require('./src/saving/sync-function-writer');
 
 const errorStatus = 1;
 
@@ -37,25 +37,14 @@ const outputFilename = commander.args[1];
 
 let syncFuncString;
 try {
+  syncFuncString = syncFunctionLoader.load(docDefnFilename);
+} catch (ex) {
+  process.exit(errorStatus);
+}
+
+try {
   const formatOptions = { jsonString: commander.jsonString };
-  syncFuncString = syncFunctionLoader.load(docDefnFilename, formatOptions);
-} catch (ex) {
-  process.exit(errorStatus);
-}
-
-try {
-  const outputDirectory = path.dirname(outputFilename);
-  if (!fs.existsSync(outputDirectory)) {
-    mkdirp.sync(outputDirectory);
-  }
-} catch (ex) {
-  console.error(`ERROR: Unable to create the sync function output directory: ${ex}`);
-
-  process.exit(errorStatus);
-}
-
-try {
-  fs.writeFileSync(outputFilename, syncFuncString, 'utf8');
+  syncFunctionWriter.save(outputFilename, syncFuncString, formatOptions);
 } catch (ex) {
   console.error(`ERROR: Unable to write the sync function to the output file: ${ex}`);
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,11 @@ exports.documentDefinitionsValidator = require('./validation/document-definition
 exports.syncFunctionLoader = require('./loading/sync-function-loader');
 
 /**
+ * The sync-function-writer module. Writes sync functions to files.
+ */
+exports.syncFunctionWriter = require('./saving/sync-function-writer');
+
+/**
  * The test-fixture-maker module. Provides a number of conveniences to test the behaviour of document definitions.
  */
 exports.testFixtureMaker = require('./testing/test-fixture-maker');

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -6,6 +6,7 @@ describe('Main package module', () => {
     expect(index).to.eql({
       documentDefinitionsValidator: require('./validation/document-definitions-validator'),
       syncFunctionLoader: require('./loading/sync-function-loader'),
+      syncFunctionWriter: require('./saving/sync-function-writer'),
       testFixtureMaker: require('./testing/test-fixture-maker'),
       testHelper: require('./testing/test-helper'),
       validationErrorFormatter: require('./testing/validation-error-formatter')

--- a/src/loading/sync-function-loader.js
+++ b/src/loading/sync-function-loader.js
@@ -18,22 +18,16 @@ const fileFragmentLoader = require('./file-fragment-loader');
 function loadFromFile(docDefinitionsFile, formatOptions = { }) {
   const syncFuncTemplateDir = path.resolve(__dirname, '../../templates/sync-function');
   const syncFuncTemplatePath = path.resolve(syncFuncTemplateDir, 'template.js');
-  let syncFuncTemplate;
-  try {
-    syncFuncTemplate = fs.readFileSync(syncFuncTemplatePath, 'utf8');
-  } catch (ex) {
-    console.error(`ERROR: Unable to read the sync function template file: ${ex}`);
-
-    throw ex;
-  }
+  const rawSyncFuncTemplate = fs.readFileSync(syncFuncTemplatePath, 'utf8');
 
   // Automatically replace each instance of the "importSyncFunctionFragment" macro with the contents of the file that is specified
-  syncFuncTemplate = fileFragmentLoader.load(syncFuncTemplateDir, 'importSyncFunctionFragment', syncFuncTemplate);
+  const fullSyncFuncTemplate =
+    fileFragmentLoader.load(syncFuncTemplateDir, 'importSyncFunctionFragment', rawSyncFuncTemplate);
 
   const docDefinitions = docDefinitionsLoader.load(docDefinitionsFile);
 
   // Load the document definitions into the sync function template
-  const rawSyncFuncString = syncFuncTemplate.replace('$DOCUMENT_DEFINITIONS$', () => docDefinitions);
+  const rawSyncFuncString = fullSyncFuncTemplate.replace('$DOCUMENT_DEFINITIONS$', () => docDefinitions);
 
   return formatSyncFunction(rawSyncFuncString, formatOptions);
 }

--- a/src/loading/sync-function-loader.js
+++ b/src/loading/sync-function-loader.js
@@ -2,8 +2,8 @@
  * Generates a complete sync function from the specified document definitions file.
  *
  * @param {string} docDefinitionsFile The path to the document definitions file
- * @param {Object} formatOptions Controls how the sync function is formatted. Options:
- *                               - jsonString: Whether to return the result as a JSON-compatible string
+ * @param {Object} [formatOptions] (DEPRECATED) Controls how the sync function is formatted. Options:
+ *                                 - jsonString: Boolean indicating whether to return the result enclosed in a JSON-compatible string
  *
  * @returns The full contents of the generated sync function as a string
  */
@@ -15,7 +15,7 @@ const indent = require('../../lib/indent.js/indent.min');
 const docDefinitionsLoader = require('./document-definitions-loader');
 const fileFragmentLoader = require('./file-fragment-loader');
 
-function loadFromFile(docDefinitionsFile, formatOptions) {
+function loadFromFile(docDefinitionsFile, formatOptions = { }) {
   const syncFuncTemplateDir = path.resolve(__dirname, '../../templates/sync-function');
   const syncFuncTemplatePath = path.resolve(syncFuncTemplateDir, 'template.js');
   let syncFuncTemplate;
@@ -35,16 +35,14 @@ function loadFromFile(docDefinitionsFile, formatOptions) {
   // Load the document definitions into the sync function template
   const rawSyncFuncString = syncFuncTemplate.replace('$DOCUMENT_DEFINITIONS$', () => docDefinitions);
 
-  return formatSyncFunction(rawSyncFuncString, formatOptions || { });
+  return formatSyncFunction(rawSyncFuncString, formatOptions);
 }
 
 function formatSyncFunction(rawSyncFuncString, formatOptions) {
-  // Normalize code block indentation, normalize line endings, replace blank lines with empty lines and then escape any
-  // occurrence of the backtick character so the sync function can be used in a Sync Gateway config file
+  // Normalize code block indentation, normalize line endings and then replace blank lines with empty lines
   const normalizedFuncString = indent.js(rawSyncFuncString, { tabString: '  ' })
     .replace(/(?:\r\n)|(?:\r)/g, () => '\n')
-    .replace(/^\s+$/gm, () => '')
-    .replace(/`/g, () => '\\`');
+    .replace(/^\s+$/gm, () => '');
 
   if (formatOptions.jsonString) {
     // Escape all escape sequences, backslash characters and line ending characters then wrap the result in quotes to

--- a/src/loading/sync-function-loader.spec.js
+++ b/src/loading/sync-function-loader.spec.js
@@ -45,29 +45,6 @@ describe('Sync function loader', () => {
       { jsonString: true });
   });
 
-  it('should throw an exception if the sync function template file does not exist', () => {
-    const docDefinitionsFile = 'my/doc-definitions.js';
-    const expectedException = new Error('my-expected-exception');
-
-    fsMock.readFileSync.throwWith(expectedException);
-    fileFragmentLoaderMock.load.returnWith('');
-    docDefinitionsLoaderMock.load.returnWith('');
-    indentMock.js.returnWith('');
-
-    expect(() => {
-      syncFunctionLoader.load(docDefinitionsFile);
-    }).to.throw(expectedException.message);
-
-    expect(fsMock.readFileSync.callCount).to.equal(1);
-    expect(fsMock.readFileSync.calls[0].args).to.eql([ syncFuncTemplateFile, 'utf8' ]);
-
-    expect(fileFragmentLoaderMock.load.callCount).to.equal(0);
-
-    expect(docDefinitionsLoaderMock.load.callCount).to.equal(0);
-
-    expect(indentMock.js.callCount).to.equal(0);
-  });
-
   function validateLoadSuccess(indentedSyncFunc, expectedSyncFunc, formatOptions) {
     const docDefinitionsFile = 'my/doc-definitions.js';
     const docDefinitionsContent = 'my-doc-definitions';

--- a/src/loading/sync-function-loader.spec.js
+++ b/src/loading/sync-function-loader.spec.js
@@ -35,15 +35,14 @@ describe('Sync function loader', () => {
   it('should load a sync function as a multi-line JavaScript block', () => {
     validateLoadSuccess(
       'my\n  \r\nfinal\rsync `func`',
-      null,
-      'my\n\nfinal\nsync \\`func\\`');
+      'my\n\nfinal\nsync `func`');
   });
 
   it('should load a validation function as a JSON string', () => {
     validateLoadSuccess(
       'my\n  \r\n"final"\r`sync` \\func\\',
-      { jsonString: true },
-      '"my\\n\\n\\"final\\"\\n\\\\`sync\\\\` \\\\func\\\\"');
+      '"my\\n\\n\\"final\\"\\n`sync` \\\\func\\\\"',
+      { jsonString: true });
   });
 
   it('should throw an exception if the sync function template file does not exist', () => {
@@ -69,7 +68,7 @@ describe('Sync function loader', () => {
     expect(indentMock.js.callCount).to.equal(0);
   });
 
-  function validateLoadSuccess(indentedSyncFunc, formatOptions, expectedSyncFunc) {
+  function validateLoadSuccess(indentedSyncFunc, expectedSyncFunc, formatOptions) {
     const docDefinitionsFile = 'my/doc-definitions.js';
     const docDefinitionsContent = 'my-doc-definitions';
     const originalSyncFuncTemplate = 'my-original-sync-fync-template';

--- a/src/saving/sync-function-writer.js
+++ b/src/saving/sync-function-writer.js
@@ -1,0 +1,43 @@
+/**
+ * Saves the sync function to the specified file. Recursively creates the parent directory as needed.
+ *
+ * @param {string} filePath The path at which to write the sync function file
+ * @param {string} syncFunctionString The full contents of the sync function
+ * @param {Object} [formatOptions] Controls how the sync function is formatted. Options:
+ *                                 - jsonString: Boolean indicating whether to return the result enclosed in a JSON-compatible string
+ */
+exports.save = save;
+
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('../../lib/mkdirp/index');
+
+function save(filePath, syncFunctionString, formatOptions = { }) {
+  const outputDirectory = path.dirname(filePath);
+  if (!fs.existsSync(outputDirectory)) {
+    mkdirp.sync(outputDirectory);
+  }
+
+  const formattedSyncFunction = formatSyncFunction(syncFunctionString, formatOptions);
+
+  fs.writeFileSync(filePath, formattedSyncFunction, 'utf8');
+}
+
+function formatSyncFunction(syncFunctionString, formatOptions) {
+  // Escape backticks so that the sync function can be directly copied and pasted into a Sync Gateway configuration file
+  // where backticks are used for multiline strings and then normalize line endings
+  const normalizedSyncFuncString = syncFunctionString.replace(/`/g, () => '\\`')
+    .replace(/(?:\r\n)|(?:\r)/g, () => '\n');
+
+  if (formatOptions.jsonString) {
+    // Escape all escape sequences, backslash characters and line ending characters then wrap the result in quotes to
+    // make it a valid JSON string
+    const formattedSyncFuncString = normalizedSyncFuncString.replace(/\\/g, () => '\\\\')
+      .replace(/"/g, () => '\\"')
+      .replace(/\n/g, () => '\\n');
+
+    return `"${formattedSyncFuncString}"`;
+  } else {
+    return normalizedSyncFuncString;
+  }
+}

--- a/src/saving/sync-function-writer.js
+++ b/src/saving/sync-function-writer.js
@@ -5,6 +5,8 @@
  * @param {string} syncFunctionString The full contents of the sync function
  * @param {Object} [formatOptions] Controls how the sync function is formatted. Options:
  *                                 - jsonString: Boolean indicating whether to return the result enclosed in a JSON-compatible string
+ *
+ * @throws if the output directory could not be created or the file could not be created/overwritten (e.g. access denied)
  */
 exports.save = save;
 

--- a/src/saving/sync-function-writer.spec.js
+++ b/src/saving/sync-function-writer.spec.js
@@ -1,0 +1,64 @@
+const { expect } = require('chai');
+const simpleMock = require('../../lib/simple-mock/index');
+const mockRequire = require('mock-require');
+
+describe('Sync function loader', () => {
+  let syncFunctionWriter, fsMock, mkdirpMock;
+
+  beforeEach(() => {
+    // Mock out the "require" calls in the module under test
+    fsMock = { existsSync: simpleMock.stub(), writeFileSync: simpleMock.stub() };
+    mockRequire('fs', fsMock);
+
+    mkdirpMock = { sync: simpleMock.stub() };
+    mockRequire('../../lib/mkdirp/index', mkdirpMock);
+
+    syncFunctionWriter = mockRequire.reRequire('./sync-function-writer');
+  });
+
+  afterEach(() => {
+    // Restore "require" calls to their original behaviour after each test case
+    mockRequire.stopAll();
+  });
+
+  it('should create an output directory that does not exist and save the sync function to the correct file', () => {
+    const outputDirectory = '/foo/bar/baz';
+    const filePath = `${outputDirectory}/qux.js`;
+    const syncFuncString = '"my" `sync` \\function\\:\r\ndo\rsomething\nhere';
+
+    // The output dir does not exist
+    fsMock.existsSync.returnWith(false);
+
+    syncFunctionWriter.save(filePath, syncFuncString);
+
+    expect(fsMock.existsSync.callCount).to.equal(1);
+    expect(fsMock.existsSync.calls[0].args).to.deep.equal([ outputDirectory ]);
+
+    expect(mkdirpMock.sync.callCount).to.equal(1);
+    expect(mkdirpMock.sync.calls[0].args).to.deep.equal([ outputDirectory ]);
+
+    expect(fsMock.writeFileSync.callCount).to.equal(1);
+    expect(fsMock.writeFileSync.calls[0].args)
+      .to.deep.equal([ filePath, '"my" \\`sync\\` \\function\\:\ndo\nsomething\nhere', 'utf8' ]);
+  });
+
+  it('should save the sync function to the correct file enclosed in a JSON-compatible string', () => {
+    const outputDirectory = '/foo/bar/baz';
+    const filePath = `${outputDirectory}/qux.js`;
+    const syncFuncString = '"my" `sync` \\function\\:\r\ndo\rsomething\nhere';
+
+    // The output dir does exist
+    fsMock.existsSync.returnWith(true);
+
+    syncFunctionWriter.save(filePath, syncFuncString, { jsonString: true });
+
+    expect(fsMock.existsSync.callCount).to.equal(1);
+    expect(fsMock.existsSync.calls[0].args).to.deep.equal([ outputDirectory ]);
+
+    expect(mkdirpMock.sync.callCount).to.equal(0);
+
+    expect(fsMock.writeFileSync.callCount).to.equal(1);
+    expect(fsMock.writeFileSync.calls[0].args)
+      .to.deep.equal([ filePath, '"\\"my\\" \\\\`sync\\\\` \\\\function\\\\:\\ndo\\nsomething\\nhere"', 'utf8' ]);
+  });
+});

--- a/src/testing/test-environment-maker.js
+++ b/src/testing/test-environment-maker.js
@@ -2,7 +2,10 @@
  * Creates simulated Sync Gateway sync function environments for use in tests.
  *
  * @param {string} rawSyncFunction The raw string contents of the sync function
- * @param {string} [syncFunctionFile] The optional path to the sync function file, to be used to generate stack traces when errors occur
+ * @param {boolean} [unescapeBackticks] Whether backticks in the sync function string have been replaced with an escape
+ *                                      sequence and must be "unescaped" for the test environment. False by default.
+ * @param {string} [syncFunctionFile] The optional path to the sync function file, to be used to generate stack traces
+ *                                    when errors occur
  *
  * @returns {Object} The simulated environment created for the sync function
  */
@@ -14,7 +17,7 @@ const vm = require('vm');
 const underscore = require('../../lib/underscore/underscore-min');
 const simpleMock = require('../../lib/simple-mock/index');
 
-function init(rawSyncFunction, syncFunctionFile) {
+function init(rawSyncFunction, unescapeBackticks, syncFunctionFile) {
   const options = {
     filename: syncFunctionFile,
     displayErrors: true
@@ -27,7 +30,11 @@ function init(rawSyncFunction, syncFunctionFile) {
   // the sync function
   const environmentString = environmentTemplate.replace(
     '$SYNC_FUNC_PLACEHOLDER$',
-    () => unescapeBackticks(rawSyncFunction));
+    () => {
+      // If the contents were read from a sync function file, then backtick escape sequences (i.e. "\`") must be
+      // unescaped first
+      return unescapeBackticks ? doUnescapeBackticks(rawSyncFunction) : rawSyncFunction;
+    });
 
   // The code that is compiled must be an expression or a sequence of one or more statements. Surrounding it with parentheses makes it a
   // valid statement.
@@ -44,6 +51,6 @@ function init(rawSyncFunction, syncFunctionFile) {
 // generator script automatically escapes backtick characters with the sequence "\`" so that it produces a valid multiline string.
 // However, when loaded by the test fixture, a sync function is not inserted into a Sync Gateway configuration file so we must "unescape"
 // backtick characters to preserve the original intention.
-function unescapeBackticks(originalString) {
+function doUnescapeBackticks(originalString) {
   return originalString.replace(/\\`/g, () => '`');
 }

--- a/src/testing/test-environment-maker.js
+++ b/src/testing/test-environment-maker.js
@@ -2,10 +2,10 @@
  * Creates simulated Sync Gateway sync function environments for use in tests.
  *
  * @param {string} rawSyncFunction The raw string contents of the sync function
- * @param {boolean} [unescapeBackticks] Whether backticks in the sync function string have been replaced with an escape
- *                                      sequence and must be "unescaped" for the test environment. False by default.
  * @param {string} [syncFunctionFile] The optional path to the sync function file, to be used to generate stack traces
  *                                    when errors occur
+ * @param {boolean} [unescapeBackticks] Whether backticks in the sync function string have been replaced with an escape
+ *                                      sequence and must be "unescaped" for the test environment. False by default.
  *
  * @returns {Object} The simulated environment created for the sync function
  */
@@ -17,7 +17,7 @@ const vm = require('vm');
 const underscore = require('../../lib/underscore/underscore-min');
 const simpleMock = require('../../lib/simple-mock/index');
 
-function init(rawSyncFunction, unescapeBackticks, syncFunctionFile) {
+function init(rawSyncFunction, syncFunctionFile, unescapeBackticks) {
   const options = {
     filename: syncFunctionFile,
     displayErrors: true

--- a/src/testing/test-environment-maker.spec.js
+++ b/src/testing/test-environment-maker.spec.js
@@ -23,14 +23,14 @@ describe('Test environment maker', () => {
   });
 
   it('creates a test environment from the input with a filename for stack traces', () => {
-    verifyParse('my-sync-func-\\`1\\`', false, 'my-original-filename');
+    verifyParse('my-sync-func-\\`1\\`', 'my-original-filename', true);
   });
 
   it('creates a test environment from the input but without a filename', () => {
-    verifyParse('my-sync-func-\\`2\\`', true);
+    verifyParse('my-sync-func-\\`2\\`', null, false);
   });
 
-  function verifyParse(rawSyncFunction, unescapeBackticks, originalFilename) {
+  function verifyParse(rawSyncFunction, originalFilename, unescapeBackticks) {
     const envTemplateFileContents = 'template: $SYNC_FUNC_PLACEHOLDER$';
     fsMock.readFileSync.returnWith(envTemplateFileContents);
 
@@ -44,7 +44,7 @@ describe('Test environment maker', () => {
 
     vmMock.runInThisContext.returnWith(mockVmEnvironment);
 
-    const result = testEnvironmentMaker.init(rawSyncFunction, unescapeBackticks, originalFilename);
+    const result = testEnvironmentMaker.init(rawSyncFunction, originalFilename, unescapeBackticks);
 
     expect(result).to.eql(expectedResult);
 

--- a/src/testing/test-environment-maker.spec.js
+++ b/src/testing/test-environment-maker.spec.js
@@ -23,20 +23,20 @@ describe('Test environment maker', () => {
   });
 
   it('creates a test environment from the input with a filename for stack traces', () => {
-    verifyParse('my-sync-func-`1`', 'my-original-filename');
+    verifyParse('my-sync-func-\\`1\\`', false, 'my-original-filename');
   });
 
   it('creates a test environment from the input but without a filename', () => {
-    verifyParse('my-sync-func-\\`2\\`');
+    verifyParse('my-sync-func-\\`2\\`', true);
   });
 
-  function verifyParse(rawSyncFunction, originalFilename) {
+  function verifyParse(rawSyncFunction, unescapeBackticks, originalFilename) {
     const envTemplateFileContents = 'template: $SYNC_FUNC_PLACEHOLDER$';
     fsMock.readFileSync.returnWith(envTemplateFileContents);
 
     const expectedTestEnvString = envTemplateFileContents.replace(
       '$SYNC_FUNC_PLACEHOLDER$',
-      () => rawSyncFunction.replace(/\\`/g, () => '`'));
+      () => unescapeBackticks ? rawSyncFunction.replace(/\\`/g, () => '`') : rawSyncFunction);
 
     const expectedResult = { bar: 'foo' };
     const mockVmEnvironment = simpleMock.stub();
@@ -44,7 +44,7 @@ describe('Test environment maker', () => {
 
     vmMock.runInThisContext.returnWith(mockVmEnvironment);
 
-    const result = testEnvironmentMaker.init(rawSyncFunction, originalFilename);
+    const result = testEnvironmentMaker.init(rawSyncFunction, unescapeBackticks, originalFilename);
 
     expect(result).to.eql(expectedResult);
 

--- a/src/testing/test-fixture-maker.js
+++ b/src/testing/test-fixture-maker.js
@@ -12,7 +12,7 @@ const validationErrorFormatter = require('./validation-error-formatter');
 exports.initFromSyncFunction = function(filePath) {
   const rawSyncFunction = fs.readFileSync(filePath, 'utf8').toString();
 
-  return init(rawSyncFunction, filePath);
+  return init(rawSyncFunction, true, filePath);
 };
 
 /**
@@ -23,11 +23,11 @@ exports.initFromSyncFunction = function(filePath) {
 exports.initFromDocumentDefinitions = function(filePath) {
   const rawSyncFunction = syncFunctionLoader.load(filePath);
 
-  return init(rawSyncFunction);
+  return init(rawSyncFunction, false);
 };
 
-function init(rawSyncFunction, syncFunctionFile) {
-  const testEnvironment = testEnvironmentMaker.init(rawSyncFunction, syncFunctionFile);
+function init(rawSyncFunction, unescapeBackticks, syncFunctionFile) {
+  const testEnvironment = testEnvironmentMaker.init(rawSyncFunction, unescapeBackticks, syncFunctionFile);
 
   const fixture = {
     /**
@@ -266,7 +266,7 @@ function init(rawSyncFunction, syncFunctionFile) {
   const defaultWriteChannel = 'write';
 
   function resetTestEnvironment() {
-    const newEnvironment = testEnvironmentMaker.init(rawSyncFunction, syncFunctionFile);
+    const newEnvironment = testEnvironmentMaker.init(rawSyncFunction, unescapeBackticks, syncFunctionFile);
     Object.assign(testEnvironment, newEnvironment);
 
     return testEnvironment;

--- a/src/testing/test-fixture-maker.js
+++ b/src/testing/test-fixture-maker.js
@@ -12,7 +12,7 @@ const validationErrorFormatter = require('./validation-error-formatter');
 exports.initFromSyncFunction = function(filePath) {
   const rawSyncFunction = fs.readFileSync(filePath, 'utf8').toString();
 
-  return init(rawSyncFunction, true, filePath);
+  return init(rawSyncFunction, filePath, true);
 };
 
 /**
@@ -23,11 +23,11 @@ exports.initFromSyncFunction = function(filePath) {
 exports.initFromDocumentDefinitions = function(filePath) {
   const rawSyncFunction = syncFunctionLoader.load(filePath);
 
-  return init(rawSyncFunction, false);
+  return init(rawSyncFunction);
 };
 
-function init(rawSyncFunction, unescapeBackticks, syncFunctionFile) {
-  const testEnvironment = testEnvironmentMaker.init(rawSyncFunction, unescapeBackticks, syncFunctionFile);
+function init(rawSyncFunction, syncFunctionFile, unescapeBackticks) {
+  const testEnvironment = testEnvironmentMaker.init(rawSyncFunction, syncFunctionFile, unescapeBackticks);
 
   const fixture = {
     /**
@@ -266,7 +266,7 @@ function init(rawSyncFunction, unescapeBackticks, syncFunctionFile) {
   const defaultWriteChannel = 'write';
 
   function resetTestEnvironment() {
-    const newEnvironment = testEnvironmentMaker.init(rawSyncFunction, unescapeBackticks, syncFunctionFile);
+    const newEnvironment = testEnvironmentMaker.init(rawSyncFunction, syncFunctionFile, unescapeBackticks);
     Object.assign(testEnvironment, newEnvironment);
 
     return testEnvironment;

--- a/src/testing/test-fixture-maker.spec.js
+++ b/src/testing/test-fixture-maker.spec.js
@@ -39,7 +39,7 @@ describe('Test fixture maker:', () => {
       expect(fsMock.readFileSync.calls[0].args).to.eql([ fakeFilePath, 'utf8' ]);
 
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, fakeFilePath ]);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, true, fakeFilePath ]);
 
       verifyTestEnvironment(testFixture);
     });
@@ -53,7 +53,7 @@ describe('Test fixture maker:', () => {
       expect(syncFunctionLoaderMock.load.calls[0].args).to.eql([ fakeFilePath ]);
 
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, void 0 ]);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, false, void 0 ]);
 
       verifyTestEnvironment(testFixture);
     });

--- a/src/testing/test-fixture-maker.spec.js
+++ b/src/testing/test-fixture-maker.spec.js
@@ -39,7 +39,7 @@ describe('Test fixture maker:', () => {
       expect(fsMock.readFileSync.calls[0].args).to.eql([ fakeFilePath, 'utf8' ]);
 
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, true, fakeFilePath ]);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, fakeFilePath, true ]);
 
       verifyTestEnvironment(testFixture);
     });
@@ -53,7 +53,7 @@ describe('Test fixture maker:', () => {
       expect(syncFunctionLoaderMock.load.calls[0].args).to.eql([ fakeFilePath ]);
 
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, false, void 0 ]);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, void 0, void 0 ]);
 
       verifyTestEnvironment(testFixture);
     });

--- a/src/testing/test-helper.js
+++ b/src/testing/test-helper.js
@@ -245,17 +245,17 @@ const defaultWriteChannel = 'write';
 function initSyncFunction(filePath) {
   const rawSyncFunction = fs.readFileSync(filePath, 'utf8').toString();
 
-  init(rawSyncFunction, true, filePath);
+  init(rawSyncFunction, filePath, true);
 }
 
 function initDocumentDefinitions(filePath) {
   const rawSyncFunction = syncFunctionLoader.load(filePath);
 
-  init(rawSyncFunction, false);
+  init(rawSyncFunction);
 }
 
-function init(rawSyncFunction, unescapeBackticks, syncFunctionFile) {
-  const testHelperEnvironment = testEnvironmentMaker.init(rawSyncFunction, unescapeBackticks, syncFunctionFile);
+function init(rawSyncFunction, syncFunctionFile, unescapeBackticks) {
+  const testHelperEnvironment = testEnvironmentMaker.init(rawSyncFunction, syncFunctionFile, unescapeBackticks);
 
   exports.requireAccess = testHelperEnvironment.requireAccess;
   exports.requireRole = testHelperEnvironment.requireRole;

--- a/src/testing/test-helper.js
+++ b/src/testing/test-helper.js
@@ -245,17 +245,17 @@ const defaultWriteChannel = 'write';
 function initSyncFunction(filePath) {
   const rawSyncFunction = fs.readFileSync(filePath, 'utf8').toString();
 
-  init(rawSyncFunction, filePath);
+  init(rawSyncFunction, true, filePath);
 }
 
 function initDocumentDefinitions(filePath) {
   const rawSyncFunction = syncFunctionLoader.load(filePath);
 
-  init(rawSyncFunction);
+  init(rawSyncFunction, false);
 }
 
-function init(rawSyncFunction, syncFunctionFile) {
-  const testHelperEnvironment = testEnvironmentMaker.init(rawSyncFunction, syncFunctionFile);
+function init(rawSyncFunction, unescapeBackticks, syncFunctionFile) {
+  const testHelperEnvironment = testEnvironmentMaker.init(rawSyncFunction, unescapeBackticks, syncFunctionFile);
 
   exports.requireAccess = testHelperEnvironment.requireAccess;
   exports.requireRole = testHelperEnvironment.requireRole;

--- a/src/testing/test-helper.spec.js
+++ b/src/testing/test-helper.spec.js
@@ -50,7 +50,7 @@ describe('Test helper (DEPRECATED):', () => {
       expect(fsMock.readFileSync.calls[0].args).to.eql([ fakeFilePath, 'utf8' ]);
 
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, true, fakeFilePath ]);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, fakeFilePath, true ]);
 
       verifyTestEnvironment();
     });
@@ -64,7 +64,7 @@ describe('Test helper (DEPRECATED):', () => {
       expect(syncFunctionLoaderMock.load.calls[0].args).to.eql([ fakeFilePath ]);
 
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, false, void 0 ]);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, void 0, void 0 ]);
 
       verifyTestEnvironment();
     });

--- a/src/testing/test-helper.spec.js
+++ b/src/testing/test-helper.spec.js
@@ -50,7 +50,7 @@ describe('Test helper (DEPRECATED):', () => {
       expect(fsMock.readFileSync.calls[0].args).to.eql([ fakeFilePath, 'utf8' ]);
 
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, fakeFilePath ]);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, true, fakeFilePath ]);
 
       verifyTestEnvironment();
     });
@@ -64,7 +64,7 @@ describe('Test helper (DEPRECATED):', () => {
       expect(syncFunctionLoaderMock.load.calls[0].args).to.eql([ fakeFilePath ]);
 
       expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, void 0 ]);
+      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, false, void 0 ]);
 
       verifyTestEnvironment();
     });


### PR DESCRIPTION
# Description

The backtick character is no longer escaped when document definitions are read from the file system. Instead, backticks are escaped only at the time that the generated sync function is subsequently written to a file.

# Testing

Ran the full test suite with `npm test`. Also applied a generated sync function to a Sync Gateway configuration file, both as a JavaScript block (i.e. by running `./make-sync-function test/resources/timezone-doc-definitions.js build/output.js`) and enclosed in a JSON string (i.e. by running `./make-sync-function -j test/resources/timezone-doc-definitions.js build/output.txt`) and then ensuring that I could create and replace documents without JavaScript errors.

# Related Issue

* GitHub issue link: #288