### PR TITLE
Issue 302: Always add access assignments to custom action metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
 ## [Unreleased]
-Nothing yet.
+### Fixed
+- [#302](https://github.com/Kashoo/synctos/issues/302): Access assignment results are sometimes unavailable to subsequent custom actions
 
 ## [2.3.0] - 2018-04-09
 ### Added

--- a/templates/sync-function/template.js
+++ b/templates/sync-function/template.js
@@ -150,12 +150,13 @@ function synctos(doc, oldDoc) {
 
   if (theDocDefinition.accessAssignments && !doc._deleted) {
     var accessAssignments = accessAssignmentModule.assignUserAccess(doc, oldDoc, theDocDefinition);
-
-    if (theDocDefinition.customActions &&
-        typeof theDocDefinition.customActions.onAccessAssignmentsSucceeded === 'function' &&
-        accessAssignments.length > 0) {
+    if (accessAssignments.length > 0) {
       customActionMetadata.accessAssignments = accessAssignments;
-      theDocDefinition.customActions.onAccessAssignmentsSucceeded(doc, oldDoc, customActionMetadata);
+
+      if (theDocDefinition.customActions &&
+          typeof theDocDefinition.customActions.onAccessAssignmentsSucceeded === 'function') {
+        theDocDefinition.customActions.onAccessAssignmentsSucceeded(doc, oldDoc, customActionMetadata);
+      }
     }
   }
 

--- a/test/resources/custom-actions-doc-definitions.js
+++ b/test/resources/custom-actions-doc-definitions.js
@@ -15,6 +15,24 @@ function() {
   var authorizedRoles = { write: 'write-role' };
   var authorizedUsers = { write: 'write-user' };
 
+  var accessAssignments = [
+    {
+      users: 'user1',
+      roles: 'role1',
+      channels: 'channel1'
+    },
+    {
+      type: 'role',
+      users: [ 'user1', 'user2' ],
+      roles: [ 'role1' ]
+    },
+    {
+      type: 'channel',
+      roles: [ 'role1', 'role2' ],
+      channels: [ 'channel1', 'channel2' ]
+    }
+  ];
+
   return {
     onTypeIdentifiedDoc: {
       typeFilter: function(doc, oldDoc) {
@@ -54,13 +72,7 @@ function() {
       authorizedRoles: authorizedRoles,
       authorizedUsers: authorizedUsers,
       propertyValidators: { },
-      accessAssignments: [
-        {
-          users: 'user1',
-          roles: 'role1',
-          channels: 'channel1'
-        }
-      ],
+      accessAssignments: accessAssignments,
       customActions: { onAccessAssignmentsSucceeded: customAction('onAccessAssignmentsSucceeded') }
     },
     missingAccessAssignmentsDoc: {
@@ -92,6 +104,7 @@ function() {
       authorizedRoles: authorizedRoles,
       authorizedUsers: authorizedUsers,
       propertyValidators: { },
+      accessAssignments: accessAssignments,
       customActions: { onDocumentChannelAssignmentSucceeded: customAction('onDocumentChannelAssignmentSucceeded') }
     }
   };


### PR DESCRIPTION
# Description

If a document type includes access assignments, the access assignment results are now always included in the custom action metadata for subsequent custom actions (e.g. `onDocumentChannelAssignmentSucceeded`) to reference, even when there is no `onAccessAssignmentsSucceeded` custom action.

# Testing

Updated the test cases in `custom-actions.spec.js` and followed the steps to reproduce from the related issue.

# Related Issue

* GitHub issue link: #302