### PR TITLE
Issue 289: Extract shared logic from test and validation environment makers

### DIFF
--- a/src/environments/stubbed-environment-maker.js
+++ b/src/environments/stubbed-environment-maker.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const vm = require('vm');
+
+/**
+ * Creates a stubbed Sync Gateway environment for document definitions or a sync function for use in tests, schema
+ * validation, etc.
+ *
+ * @param {string} templateFile The absolute path to the template into which to insert the source contents
+ * @param {string} macroName The name of the macro to replace with the given source contents
+ * @param {string} sourceContents The raw string contents to be inserted into the template
+ * @param {string} [sourceFile] The optional path to the file from which the source contents originated, to be used to
+ *                              generate stack traces when errors occur
+ * @param {boolean} [unescapeBackticks] Whether backticks in the sync function string have been replaced with an escape
+ *                                      sequence and must be "unescaped" for the test environment. False by default.
+ *
+ * @returns {*} The raw stubbed environment
+ */
+exports.create = function(templateFile, macroName, sourceContents, sourceFile, unescapeBackticks) {
+  const vmOptions = {
+    filename: sourceFile,
+    displayErrors: true
+  };
+
+  const environmentTemplate = fs.readFileSync(templateFile, 'utf8').trim()
+    .replace(/(?:\r\n)|(?:\r)|(?:\n)/g, () => ' '); // Compress the template to one line to ensure stack trace line numbers are correct
+
+  // The test environment includes a placeholder string (a macro) that is to be replaced with the contents of the source
+  const environmentString = environmentTemplate.replace(
+    macroName,
+    () => {
+      // If the contents were read from a sync function file, then backtick escape sequences (i.e. "\`") must be
+      // unescaped first
+      return unescapeBackticks ? doUnescapeBackticks(sourceContents) : sourceContents;
+    });
+
+  // The code that is compiled must be an expression or a sequence of one or more statements. Surrounding it with
+  // parentheses makes it a valid expression.
+  const environmentStatement = `(${environmentString});`;
+
+  // Compile the environment within the current virtual machine context so it can share access to the "requireAccess",
+  // "channel", etc. stubs as defined by the template
+  return vm.runInThisContext(environmentStatement, vmOptions);
+};
+
+// Sync Gateway configuration files use the backtick character to denote the beginning and end of a multiline string.
+// The sync function generator script automatically escapes backtick characters with the sequence "\`" so that it
+// produces a valid multiline string. However, when loaded by the test fixture, a sync function is not inserted into a
+// Sync Gateway configuration file so we must "unescape" backtick characters to preserve the original intention.
+function doUnescapeBackticks(originalString) {
+  return originalString.replace(/\\`/g, () => '`');
+}

--- a/src/environments/stubbed-environment-maker.spec.js
+++ b/src/environments/stubbed-environment-maker.spec.js
@@ -1,0 +1,61 @@
+const { expect } = require('chai');
+const simpleMock = require('../../lib/simple-mock/index');
+const mockRequire = require('mock-require');
+
+describe('Stubbed environment maker', () => {
+  let environmentMaker, fsMock, vmMock;
+
+  beforeEach(() => {
+    // Mock out the "require" calls in the module under test
+    fsMock = { readFileSync: simpleMock.stub() };
+    mockRequire('fs', fsMock);
+
+    vmMock = { runInThisContext: simpleMock.stub() };
+    mockRequire('vm', vmMock);
+
+    environmentMaker = mockRequire.reRequire('./stubbed-environment-maker');
+  });
+
+  afterEach(() => {
+    // Restore "require" calls to their original behaviour after each test case
+    mockRequire.stopAll();
+  });
+
+  it('creates a environment from the input with a filename for stack traces', () => {
+    verifyParse('my-sync-func-\\`1\\`', 'my-sync-func-`1`', 'my-original-filename', true);
+  });
+
+  it('creates a environment from the input but without a filename', () => {
+    verifyParse('my-sync-func-\\`2\\`', 'my-sync-func-\\`2\\`');
+  });
+
+  function verifyParse(originalContents, expectedContents, originalFilename, unescapeBackticks) {
+    const templateFile = 'my-template-file-path';
+    const macroName = '$my-template-macro$';
+
+    const envTemplateFileContents = `template: ${macroName}`;
+    fsMock.readFileSync.returnWith(envTemplateFileContents);
+
+    const expectedEnvString = envTemplateFileContents.replace(macroName, () => expectedContents);
+
+    const expectedResult = { bar: 'foo' };
+    vmMock.runInThisContext.returnWith(expectedResult);
+
+    const result =
+      environmentMaker.create(templateFile, macroName, originalContents, originalFilename, unescapeBackticks);
+
+    expect(result).to.eql(expectedResult);
+
+    expect(fsMock.readFileSync.callCount).to.equal(1);
+    expect(fsMock.readFileSync.calls[0].args).to.eql([ templateFile, 'utf8' ]);
+
+    expect(vmMock.runInThisContext.callCount).to.equal(1);
+    expect(vmMock.runInThisContext.calls[0].args).to.eql([
+      `(${expectedEnvString});`,
+      {
+        filename: originalFilename,
+        displayErrors: true
+      }
+    ]);
+  }
+});

--- a/src/environments/stubbed-environment-maker.spec.js
+++ b/src/environments/stubbed-environment-maker.spec.js
@@ -22,27 +22,27 @@ describe('Stubbed environment maker', () => {
   });
 
   it('creates a environment from the input with a filename for stack traces', () => {
-    verifyParse('my-sync-func-\\`1\\`', 'my-sync-func-`1`', 'my-original-filename', true);
+    verifyParse('my-sync-func-\\`1\\`', 'my-filename');
   });
 
   it('creates a environment from the input but without a filename', () => {
-    verifyParse('my-sync-func-\\`2\\`', 'my-sync-func-\\`2\\`');
+    verifyParse('my-sync-func-\\`2\\`');
   });
 
-  function verifyParse(originalContents, expectedContents, originalFilename, unescapeBackticks) {
+  function verifyParse(fileContents, filename) {
     const templateFile = 'my-template-file-path';
     const macroName = '$my-template-macro$';
 
     const envTemplateFileContents = `template: ${macroName}`;
     fsMock.readFileSync.returnWith(envTemplateFileContents);
 
-    const expectedEnvString = envTemplateFileContents.replace(macroName, () => expectedContents);
+    const expectedEnvString = envTemplateFileContents.replace(macroName, () => fileContents);
 
     const expectedResult = { bar: 'foo' };
     vmMock.runInThisContext.returnWith(expectedResult);
 
     const result =
-      environmentMaker.create(templateFile, macroName, originalContents, originalFilename, unescapeBackticks);
+      environmentMaker.create(templateFile, macroName, fileContents, filename);
 
     expect(result).to.eql(expectedResult);
 
@@ -53,7 +53,7 @@ describe('Stubbed environment maker', () => {
     expect(vmMock.runInThisContext.calls[0].args).to.eql([
       `(${expectedEnvString});`,
       {
-        filename: originalFilename,
+        filename: filename,
         displayErrors: true
       }
     ]);

--- a/src/loading/sync-function-loader.js
+++ b/src/loading/sync-function-loader.js
@@ -27,7 +27,7 @@ function loadFromFile(docDefinitionsFile, formatOptions = { }) {
   const docDefinitions = docDefinitionsLoader.load(docDefinitionsFile);
 
   // Load the document definitions into the sync function template
-  const rawSyncFuncString = fullSyncFuncTemplate.replace('$DOCUMENT_DEFINITIONS$', () => docDefinitions);
+  const rawSyncFuncString = fullSyncFuncTemplate.replace('$DOCUMENT_DEFINITIONS_PLACEHOLDER$', () => docDefinitions);
 
   return formatSyncFunction(rawSyncFuncString, formatOptions);
 }

--- a/src/loading/sync-function-loader.spec.js
+++ b/src/loading/sync-function-loader.spec.js
@@ -49,7 +49,7 @@ describe('Sync function loader', () => {
     const docDefinitionsFile = 'my/doc-definitions.js';
     const docDefinitionsContent = 'my-doc-definitions';
     const originalSyncFuncTemplate = 'my-original-sync-fync-template';
-    const updatedSyncFuncTemplate = 'function my-sync-func-template() { $DOCUMENT_DEFINITIONS$; }';
+    const updatedSyncFuncTemplate = 'function my-sync-func-template() { $DOCUMENT_DEFINITIONS_PLACEHOLDER$; }';
 
     fsMock.readFileSync.returnWith(originalSyncFuncTemplate);
     fileFragmentLoaderMock.load.returnWith(updatedSyncFuncTemplate);

--- a/src/testing/test-environment-maker.js
+++ b/src/testing/test-environment-maker.js
@@ -1,61 +1,30 @@
+const path = require('path');
+const simpleMock = require('../../lib/simple-mock/index');
+const stubbedEnvironmentMaker = require('../environments/stubbed-environment-maker');
+const underscore = require('../../lib/underscore/underscore-min');
+
 /**
  * Creates simulated Sync Gateway sync function environments for use in tests.
  *
- * @param {string} rawSyncFunction The raw string contents of the sync function
+ * @param {string} syncFunctionString The raw string contents of the sync function
  * @param {string} [syncFunctionFile] The optional path to the sync function file, to be used to generate stack traces
  *                                    when errors occur
  * @param {boolean} [unescapeBackticks] Whether backticks in the sync function string have been replaced with an escape
  *                                      sequence and must be "unescaped" for the test environment. False by default.
  *
- * @returns {Object} The simulated environment created for the sync function
+ * @returns {Object} The simulated environment that was created for the sync function
  */
-exports.init = init;
-
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-const underscore = require('../../lib/underscore/underscore-min');
-const simpleMock = require('../../lib/simple-mock/index');
-
-function init(rawSyncFunction, syncFunctionFile, unescapeBackticks) {
+exports.create = function(syncFunctionString, syncFunctionFile, unescapeBackticks) {
   // If the given file path is relative, it will be interpreted as relative to the process' current working directory.
   // On the other hand, if it's already absolute, it will remain unchanged.
-  const absoluteFilePath = syncFunctionFile ? path.resolve(process.cwd(), syncFunctionFile) : syncFunctionFile;
-  const options = {
-    filename: absoluteFilePath,
-    displayErrors: true
-  };
+  const absoluteSyncFuncFilePath = syncFunctionFile ? path.resolve(process.cwd(), syncFunctionFile) : syncFunctionFile;
 
-  const filePath = path.resolve(__dirname, '../../templates/environments/test-environment-template.js');
-  const environmentTemplate = fs.readFileSync(filePath, 'utf8')
-    .trim()
-    .replace(/(?:\r\n)|(?:\r)|(?:\n)/g, () => ' '); // Ensures stack trace line numbers are correct by compressing the template to one line
-
-  // The test environment includes a placeholder string called "$SYNC_FUNC_PLACEHOLDER$" that is to be replaced with the contents of
-  // the sync function
-  const environmentString = environmentTemplate.replace(
+  const envFunction = stubbedEnvironmentMaker.create(
+    path.resolve(__dirname, '../../templates/environments/test-environment-template.js'),
     '$SYNC_FUNC_PLACEHOLDER$',
-    () => {
-      // If the contents were read from a sync function file, then backtick escape sequences (i.e. "\`") must be
-      // unescaped first
-      return unescapeBackticks ? doUnescapeBackticks(rawSyncFunction) : rawSyncFunction;
-    });
+    syncFunctionString,
+    absoluteSyncFuncFilePath,
+    unescapeBackticks);
 
-  // The code that is compiled must be an expression or a sequence of one or more statements. Surrounding it with parentheses makes it a
-  // valid statement.
-  const environmentStatement = `(${environmentString});`;
-
-  // Compile the test environment function within the current virtual machine context so it can share access to the "requireAccess",
-  // "channel", etc. stubs with the test-fixture-maker module
-  const environmentFunction = vm.runInThisContext(environmentStatement, options);
-
-  return environmentFunction(underscore, simpleMock);
-}
-
-// Sync Gateway configuration files use the backtick character to denote the beginning and end of a multiline string. The sync function
-// generator script automatically escapes backtick characters with the sequence "\`" so that it produces a valid multiline string.
-// However, when loaded by the test fixture, a sync function is not inserted into a Sync Gateway configuration file so we must "unescape"
-// backtick characters to preserve the original intention.
-function doUnescapeBackticks(originalString) {
-  return originalString.replace(/\\`/g, () => '`');
-}
+  return envFunction(underscore, simpleMock);
+};

--- a/src/testing/test-environment-maker.spec.js
+++ b/src/testing/test-environment-maker.spec.js
@@ -20,25 +20,22 @@ describe('Test environment maker', () => {
     mockRequire.stopAll();
   });
 
-  it('creates a stubbed environment for tests with backticks unescaped', () => {
-    verify(true);
+  it('creates a stubbed environment for tests with backtick escape sequences unescaped', () => {
+    verify('my-\\`sync\\`-func-\\`1\\`', 'my-`sync`-func-`1`', 'my-filename', true);
   });
 
-  it('creates a stubbed environment for tests with backticks left unescaped', () => {
-    verify(false);
+  it('creates a stubbed environment for tests with backtick escape sequences left unmodified', () => {
+    verify('my-sync-func-\\`2\\`', 'my-sync-func-\\`2\\`');
   });
 
-  function verify(unescapeBackticks) {
-    const syncFunctionString = 'my-sync-func';
-    const syncFunctionFile = 'my-original-filename';
-
+  function verify(originalSyncFuncString, expectedSyncFuncString, syncFunctionFile, unescapeBackticks) {
     const expectedResult = { foo: 'baz' };
     const mockEnvironment = simpleMock.stub();
     mockEnvironment.returnWith(expectedResult);
 
     stubbedEnvironmentMakerMock.create.returnWith(mockEnvironment);
 
-    const result = testEnvironmentMaker.create(syncFunctionString, syncFunctionFile, unescapeBackticks);
+    const result = testEnvironmentMaker.create(originalSyncFuncString, syncFunctionFile, unescapeBackticks);
 
     expect(result).to.eql(expectedResult);
 
@@ -46,9 +43,8 @@ describe('Test environment maker', () => {
     expect(stubbedEnvironmentMakerMock.create.calls[0].args).to.eql([
       path.resolve(__dirname, '../../templates/environments/test-environment-template.js'),
       '$SYNC_FUNC_PLACEHOLDER$',
-      syncFunctionString,
-      path.resolve(process.cwd(), syncFunctionFile),
-      unescapeBackticks
+      expectedSyncFuncString,
+      syncFunctionFile ? path.resolve(process.cwd(), syncFunctionFile) : syncFunctionFile
     ]);
 
     expect(mockEnvironment.callCount).to.equal(1);

--- a/src/testing/test-fixture-maker.js
+++ b/src/testing/test-fixture-maker.js
@@ -27,7 +27,7 @@ exports.initFromDocumentDefinitions = function(filePath) {
 };
 
 function init(rawSyncFunction, syncFunctionFile, unescapeBackticks) {
-  const testEnvironment = testEnvironmentMaker.init(rawSyncFunction, syncFunctionFile, unescapeBackticks);
+  const testEnvironment = testEnvironmentMaker.create(rawSyncFunction, syncFunctionFile, unescapeBackticks);
 
   const fixture = {
     /**
@@ -270,7 +270,7 @@ function init(rawSyncFunction, syncFunctionFile, unescapeBackticks) {
   const defaultWriteChannel = 'write';
 
   function resetTestEnvironment() {
-    const newEnvironment = testEnvironmentMaker.init(rawSyncFunction, syncFunctionFile, unescapeBackticks);
+    const newEnvironment = testEnvironmentMaker.create(rawSyncFunction, syncFunctionFile, unescapeBackticks);
     Object.assign(testEnvironment, newEnvironment);
 
     return testEnvironment;

--- a/src/testing/test-fixture-maker.spec.js
+++ b/src/testing/test-fixture-maker.spec.js
@@ -18,8 +18,8 @@ describe('Test fixture maker:', () => {
     syncFunctionLoaderMock.load.returnWith(fakeSyncFunctionContents);
     mockRequire('../loading/sync-function-loader', syncFunctionLoaderMock);
 
-    testEnvironmentMakerMock = { init: simpleMock.stub() };
-    testEnvironmentMakerMock.init.callFn(fakeTestEnvironment);
+    testEnvironmentMakerMock = { create: simpleMock.stub() };
+    testEnvironmentMakerMock.create.callFn(fakeTestEnvironment);
     mockRequire('./test-environment-maker', testEnvironmentMakerMock);
 
     testFixtureMaker = mockRequire.reRequire('./test-fixture-maker');
@@ -38,8 +38,8 @@ describe('Test fixture maker:', () => {
       expect(fsMock.readFileSync.callCount).to.equal(1);
       expect(fsMock.readFileSync.calls[0].args).to.eql([ fakeFilePath, 'utf8' ]);
 
-      expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, fakeFilePath, true ]);
+      expect(testEnvironmentMakerMock.create.callCount).to.equal(1);
+      expect(testEnvironmentMakerMock.create.calls[0].args).to.eql([ fakeSyncFunctionContents, fakeFilePath, true ]);
 
       verifyTestEnvironment(testFixture);
     });
@@ -52,8 +52,8 @@ describe('Test fixture maker:', () => {
       expect(syncFunctionLoaderMock.load.callCount).to.equal(1);
       expect(syncFunctionLoaderMock.load.calls[0].args).to.eql([ fakeFilePath ]);
 
-      expect(testEnvironmentMakerMock.init.callCount).to.equal(1);
-      expect(testEnvironmentMakerMock.init.calls[0].args).to.eql([ fakeSyncFunctionContents, void 0, void 0 ]);
+      expect(testEnvironmentMakerMock.create.callCount).to.equal(1);
+      expect(testEnvironmentMakerMock.create.calls[0].args).to.eql([ fakeSyncFunctionContents, void 0, void 0 ]);
 
       verifyTestEnvironment(testFixture);
     });

--- a/src/validation/document-definitions-validator.js
+++ b/src/validation/document-definitions-validator.js
@@ -19,7 +19,7 @@ exports.validate = (documentDefinitions, docDefinitionsFilename) => {
 };
 
 function validateDocumentDefinitionsString(rawDocDefinitionsString, docDefinitionsFilename) {
-  const validationEnv = validationEnvironmentMaker.init(rawDocDefinitionsString, docDefinitionsFilename);
+  const validationEnv = validationEnvironmentMaker.create(rawDocDefinitionsString, docDefinitionsFilename);
 
   return validateDocumentDefinitionsObjectOrFunction(validationEnv.documentDefinitions);
 }

--- a/src/validation/validation-environment-maker.js
+++ b/src/validation/validation-environment-maker.js
@@ -1,42 +1,22 @@
+const path = require('path');
+const simpleMock = require('../../lib/simple-mock/index');
+const stubbedEnvironmentMaker = require('../environments/stubbed-environment-maker');
+const underscore = require('../../lib/underscore/underscore-min');
+
 /**
  * Parses the given document definitions string as JavaScript and creates a stubbed environment where the global Sync Gateway functions and
  * variables (e.g. doc, oldDoc, simpleTypeFilter, requireAccess) are simple stubs.
  *
  * @param {string} docDefinitionsString The document definitions as a string
- * @param {string} [originalFilename] The optional name/path of the file from which the document definitions were read. To be used in
- *                                    stack traces.
  *
  * @returns A JavaScript object that exposes the document definitions via the "documentDefinitions" property along with the stubbed global
  *          dependencies via properties that match their names (e.g. "doc", "oldDoc", "typeIdValidator", "channel")
  */
-exports.init = init;
-
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-const underscore = require('../../lib/underscore/underscore-min');
-const simpleMock = require('../../lib/simple-mock/index');
-
-function init(docDefinitionsString, originalFilename) {
-  const options = {
-    filename: originalFilename,
-    displayErrors: true
-  };
-
-  const filePath = path.resolve(__dirname, '../../templates/environments/validation-environment-template.js');
-  const envTemplateString = fs.readFileSync(filePath, 'utf8').trim();
-
-  // The validation environment includes a placeholder string called "$DOC_DEFINITIONS_PLACEHOLDER$" that is to be replaced with the
-  // contents of the document definitions
-  const envString = envTemplateString.replace('$DOC_DEFINITIONS_PLACEHOLDER$', () => docDefinitionsString);
-
-  // The code that is compiled must be an expression or a sequence of one or more statements. Surrounding it with parentheses makes it a
-  // valid statement.
-  const envStatement = `(${envString});`;
-
-  // Compile the document definitions environment function within the current virtual machine context so it can share access to the
-  // "requireAccess", "channel", etc. stubs
-  const envFunction = vm.runInThisContext(envStatement, options);
+exports.create = function(docDefinitionsString) {
+  const envFunction = stubbedEnvironmentMaker.create(
+    path.resolve(__dirname, '../../templates/environments/validation-environment-template.js'),
+    '$DOC_DEFINITIONS_PLACEHOLDER$',
+    docDefinitionsString);
 
   return envFunction(underscore, simpleMock);
-}
+};

--- a/templates/sync-function/.jshintrc
+++ b/templates/sync-function/.jshintrc
@@ -4,7 +4,7 @@
   "node": false,
   "varstmt": false,
   "globals": {
-    "$DOCUMENT_DEFINITIONS$": false,
+    "$DOCUMENT_DEFINITIONS_PLACEHOLDER$": false,
     "_": false,
     "access": false,
     "channel": false,

--- a/templates/sync-function/template.js
+++ b/templates/sync-function/template.js
@@ -88,7 +88,7 @@ function synctos(doc, oldDoc) {
   // The expiry module is responsible for controlling when the document will expire and be purged from the DB
   var expiryModule = importSyncFunctionFragment('./expiry-module.js')(utils);
 
-  var rawDocDefinitions = $DOCUMENT_DEFINITIONS$;
+  var rawDocDefinitions = $DOCUMENT_DEFINITIONS_PLACEHOLDER$;
 
   var docDefinitions;
   if (typeof rawDocDefinitions === 'function') {


### PR DESCRIPTION
# Description

Introduces a new `stubbed-environment-maker` module that is used by the existing `test-environment-maker` and `validation-environment-maker` modules to generate fake Sync Gateway environments for tests and schema validation, respectively.

# Testing

Execute `npm test`.

# Related Issue

* GitHub issue link: #289