### PR TITLE
Issue 311: Constraint that matches against string value, ignoring case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
 ## [Unreleased]
-Nothing yet.
+### Added
+- [#311](https://github.com/Kashoo/synctos/issues/311): Case insensitive equality constraint for strings
 
 ## [2.4.0] - 2018-04-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Validation for simple data types (e.g. integers, floating point numbers, strings
   * `minimumValueExclusive`: Reject strings with an alphanumeric sort order that is less than or equal to this. No restriction by default.
   * `maximumValue`: Reject strings with an alphanumeric sort order that is greater than this. No restriction by default.
   * `maximumValueExclusive`: Reject strings with an alphanumeric sort order that is greater than or equal to this. No restriction by default.
+  * `mustEqualIgnoreCase`: The item's value must be equal to the specified value, ignoring differences in case. For example, `"CAD"` and `"cad"` would be considered equal by this constraint. No restriction by default.
 * `integer`: The value is a number with no fractional component. Additional parameters:
   * `minimumValue`: Reject values that are less than this. No restriction by default.
   * `minimumValueExclusive`: Reject values that are less than or equal to this. No restriction by default.

--- a/src/testing/validation-error-formatter.js
+++ b/src/testing/validation-error-formatter.js
@@ -186,6 +186,15 @@ exports.mustBeTrimmedViolation = (itemPath) => `item "${itemPath}" must not have
 exports.mustEqualViolation =
   (itemPath, expectedItemValue) => `value of item "${itemPath}" must equal ${JSON.stringify(expectedItemValue)}`;
 
+  /**
+ * Formats a message for the error that occurs when a string does not equal the expected string (case insensitive).
+ *
+ * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "arrayProp[3].stringProp")
+ * @param {*} expectedItemValue The value that is expected
+ */
+exports.mustEqualIgnoreCaseViolation =
+  (itemPath, expectedItemValue) => `value of item "${itemPath}" must equal (case insensitive) "${expectedItemValue}"`;
+
 /**
  * Formats a message for the error that occurs when there is an attempt to assign an empty string or array to a property or element where
  * that is forbidden.

--- a/src/testing/validation-error-formatter.spec.js
+++ b/src/testing/validation-error-formatter.spec.js
@@ -172,6 +172,12 @@ describe('Validation error formatter', () => {
         .to.equal(`value of item "${fakeItemPath}" must equal ${JSON.stringify(value)}`);
     });
 
+    it('produces mustEqualIgnoreCase violation messages', () => {
+      const value = 'FOO';
+      expect(errorFormatter.mustEqualIgnoreCaseViolation(fakeItemPath, value))
+        .to.equal(`value of item "${fakeItemPath}" must equal (case insensitive) "${value}"`);
+    });
+
     it('produces mustNotBeEmpty violation messages', () => {
       expect(errorFormatter.mustNotBeEmptyViolation(fakeItemPath)).to.equal(`item "${fakeItemPath}" must not be empty`);
     });

--- a/src/validation/document-definitions-validator.spec.js
+++ b/src/validation/document-definitions-validator.spec.js
@@ -164,7 +164,8 @@ describe('Document definitions validator:', () => {
                     propertyValidators: {
                       stringProperty: {
                         type: 'string',
-                        mustEqual: null, // Must not be defined in conjunction with "regexPattern"
+                        mustEqual: 'FooBar', // Must not be defined in conjunction with "mustEqualIgnoreCase"
+                        mustEqualIgnoreCase: null, // Must not be null or defined with "mustEqual"
                         mustBeTrimmed: 0, // Must be a boolean
                         regexPattern: /^[a-z]+$/,
                         minimumLength: () => 9,
@@ -267,6 +268,7 @@ describe('Document definitions validator:', () => {
         'myDoc1.propertyValidators.nestedObject.propertyValidators.dateProperty.customValidation: \"customValidation\" must have an arity lesser or equal to 4',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.enumProperty.predefinedValues.3: \"predefinedValues\" at position 3 does not match any of the allowed types',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.enumProperty.mustEqual: \"mustEqual\" conflict with forbidden peer \"mustEqualStrict\"',
+        'myDoc1.propertyValidators.nestedObject.propertyValidators.enumProperty.mustEqualStrict: \"mustEqualStrict\" conflict with forbidden peer \"mustEqual\"',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.enumProperty.mustEqual: \"mustEqual\" must be a string',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.enumProperty.mustEqual: \"mustEqual\" must be a number',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.hashtableProperty.maximumSize: \"maximumSize\" must be larger than or equal to 2',
@@ -277,6 +279,9 @@ describe('Document definitions validator:', () => {
         'myDoc1.propertyValidators.nestedObject.propertyValidators.hashtableProperty.hashtableValuesValidator.mustEqual: \"mustEqual\" must be a string',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.minimumLength: \"minimumLength\" must be an integer',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.maximumLength: \"maximumLength\" must be an integer',
+        'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.stringProperty.mustEqual: \"mustEqual\" conflict with forbidden peer \"mustEqualIgnoreCase\"',
+        'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.stringProperty.mustEqualIgnoreCase: \"mustEqualIgnoreCase\" conflict with forbidden peer \"mustEqual\"',
+        'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.stringProperty.mustEqualIgnoreCase: \"mustEqualIgnoreCase\" must be a string',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.stringProperty.mustBeTrimmed: \"mustBeTrimmed\" must be a boolean',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.stringProperty.maximumLength: \"maximumLength\" must be larger than or equal to 0',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.arrayProperty.arrayElementsValidator.propertyValidators.booleanProperty.mustEqual: \"mustEqual\" must be a boolean',

--- a/src/validation/property-validator-schema.js
+++ b/src/validation/property-validator-schema.js
@@ -46,7 +46,7 @@ const typeEqualitySchemas = {
   hashtable: joi.object().unknown()
 };
 
-const validPropertyTypes = Object.keys(typeEqualitySchemas).sort().map((key) => key);
+const validPropertyTypes = Object.keys(typeEqualitySchemas).sort();
 
 const schema = joi.object().keys({
   type: dynamicConstraintSchema(joi.string().only(validPropertyTypes)).required()
@@ -116,7 +116,8 @@ function typeSpecificConstraintSchemas() {
       minimumValue: dynamicConstraintSchema(joi.string()),
       minimumValueExclusive: dynamicConstraintSchema(joi.string()),
       maximumValue: dynamicConstraintSchema(joi.string()),
-      maximumValueExclusive: dynamicConstraintSchema(joi.string())
+      maximumValueExclusive: dynamicConstraintSchema(joi.string()),
+      mustEqualIgnoreCase: dynamicConstraintSchema(joi.string())
     },
     integer: {
       minimumValue: dynamicConstraintSchema(integerSchema),
@@ -203,15 +204,17 @@ function makeTypeConstraintsSchema(typeName) {
     .without('mustNotBeNull', [ 'required', 'mustNotBeMissing' ])
 
     // Prevent the use of more than one constraint from the "equality" category
-    .without('mustEqual', [ 'mustEqualStrict' ])
+    .without('mustEqual', [ 'mustEqualStrict', 'mustEqualIgnoreCase' ])
+    .without('mustEqualStrict', [ 'mustEqual', 'mustEqualIgnoreCase' ])
+    .without('mustEqualIgnoreCase', [ 'mustEqual', 'mustEqualStrict' ])
 
     // Prevent the use of more than one constraint from the "minimum value" category
-    .without('minimumValue', [ 'minimumValueExclusive', 'mustEqual', 'mustEqualStrict' ])
-    .without('minimumValueExclusive', [ 'minimumValue', 'mustEqual', 'mustEqualStrict' ])
+    .without('minimumValue', [ 'minimumValueExclusive', 'mustEqual', 'mustEqualStrict', 'mustEqualIgnoreCase' ])
+    .without('minimumValueExclusive', [ 'minimumValue', 'mustEqual', 'mustEqualStrict', 'mustEqualIgnoreCase' ])
 
     // Prevent the use of more than one constraint from the "maximum value" category
-    .without('maximumValue', [ 'maximumValueExclusive', 'mustEqualStrict', 'mustEqual' ])
-    .without('maximumValueExclusive', [ 'maximumValue', 'mustEqualStrict', 'mustEqual' ])
+    .without('maximumValue', [ 'maximumValueExclusive', 'mustEqualStrict', 'mustEqual', 'mustEqualIgnoreCase' ])
+    .without('maximumValueExclusive', [ 'maximumValue', 'mustEqualStrict', 'mustEqual', 'mustEqualIgnoreCase' ])
 
     // Prevent the use of more than one constraint from the "immutability" category
     .without('immutable', [ 'immutableStrict', 'immutableWhenSet', 'immutableWhenSetStrict' ])

--- a/templates/sync-function/document-properties-validation-module.js
+++ b/templates/sync-function/document-properties-validation-module.js
@@ -286,6 +286,12 @@ function documentPropertiesValidationModule(utils, simpleTypeFilter, typeIdValid
         if (mustBeTrimmed && isStringUntrimmed(itemValue)) {
           validationErrors.push('item "' + buildItemPath(itemStack) + '" must not have any leading or trailing whitespace');
         }
+
+        var mustEqualIgnoreCase = resolveItemConstraint(validator.mustEqualIgnoreCase);
+        if (!utils.isValueNullOrUndefined(mustEqualIgnoreCase) &&
+            (itemValue.toLowerCase() !== mustEqualIgnoreCase.toLowerCase())) {
+          validationErrors.push('value of item "' + buildItemPath(itemStack) + '" must equal (case insensitive) "' + mustEqualIgnoreCase + '"');
+        }
       }
 
       function validateArray(elementValidator) {

--- a/test/resources/string-doc-definitions.js
+++ b/test/resources/string-doc-definitions.js
@@ -105,6 +105,15 @@ function() {
           type: 'string',
           minimumValueExclusive: dynamicMinimumValue,
           maximumValueExclusive: dynamicMaximumValue
+        },
+        dynamicCaseInsensitiveEqualityValue: {
+          type: 'string'
+        },
+        dynamicMustEqualIgnoreCaseValidationProp: {
+          type: 'string',
+          mustEqualIgnoreCase: function(doc, oldDoc, value, oldValue) {
+            return doc.dynamicCaseInsensitiveEqualityValue;
+          }
         }
       }
     }

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -452,4 +452,39 @@ describe('String validation type', () => {
       });
     });
   });
+
+  describe('case insensitive equality constraint', () => {
+    it('allows a value that matches the expected value exactly', () => {
+      const doc = {
+        _id: 'stringDoc',
+        dynamicCaseInsensitiveEqualityValue: 'FOObar',
+        dynamicMustEqualIgnoreCaseValidationProp: 'FOObar'
+      };
+
+      testFixture.verifyDocumentCreated(doc);
+    });
+
+    it('allows a value that differs from the expected value in case only', () => {
+      const doc = {
+        _id: 'stringDoc',
+        dynamicCaseInsensitiveEqualityValue: 'FOObar',
+        dynamicMustEqualIgnoreCaseValidationProp: 'fooBAR'
+      };
+
+      testFixture.verifyDocumentCreated(doc);
+    });
+
+    it('rejects a value that does not match', () => {
+      const doc = {
+        _id: 'stringDoc',
+        dynamicCaseInsensitiveEqualityValue: 'FOObar',
+        dynamicMustEqualIgnoreCaseValidationProp: 'FOObarBAZ'
+      };
+
+      testFixture.verifyDocumentNotCreated(
+        doc,
+        'stringDoc',
+        errorFormatter.mustEqualIgnoreCaseViolation('dynamicMustEqualIgnoreCaseValidationProp', 'FOObar'));
+    });
+  });
 });


### PR DESCRIPTION
# Description

The new constraint (`mustEqualIgnoreCase`) operates like `mustEqual` except that it applies only to strings and it ignores differences in case.

# Testing

Repeat for Sync Gateway 1.x and 2.x:

1. Generate a sync function from the string specification document definitions: `./make-sync-function -j test/resources/string-doc-definitions.js build/test-sync-function.json`
2. Copy and paste the sync function's contents into a Sync Gateway configuration file
3. Launch Sync Gateway with the configuration file
4. Attempt to create a document with a complete mismatch in values:

```
PUT /test/stringDoc HTTP/1.1
Host: localhost:4985
Content-Type: application/json

{
	"dynamicCaseInsensitiveEqualityValue": "foo",
	"dynamicMustEqualIgnoreCaseValidationProp": "bar"
}
```

The document should be rejected with the reason `"Invalid stringDoc document: value of item \"dynamicMustEqualIgnoreCaseValidationProp\" must equal (case insensitive) \"foo\""`.

5. Attempt to create a document where the values match exactly:

```
PUT /test/stringDoc HTTP/1.1
Host: localhost:4985
Content-Type: application/json

{
	"dynamicCaseInsensitiveEqualityValue": "fooBAR",
	"dynamicMustEqualIgnoreCaseValidationProp": "fooBAR"
}
```

The document should be created successfully.

6. Attempt to update the document where the values match except for case:

```
PUT /test/stringDoc?rev=1-2e5c14957f3f98cf42614ea3121981a7 HTTP/1.1
Host: localhost:4985
Content-Type: application/json

{
	"dynamicCaseInsensitiveEqualityValue": "fooBAR",
	"dynamicMustEqualIgnoreCaseValidationProp": "FOObar"
}
```

The document should be replaced successfully.

# Related Issue

* GitHub issue link: #311