### PR TITLE
Issue 316: Regular expression pattern constraint for attachment references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ### Added
 - [#311](https://github.com/Kashoo/synctos/issues/311): Case insensitive equality constraint for strings
 - [#313](https://github.com/Kashoo/synctos/issues/313): Attachment filename regular expression constraint
+- [#316](https://github.com/Kashoo/synctos/issues/316): Attachment reference regular expression constraint
 
 ## [2.4.0] - 2018-04-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ Validation for simple data types (e.g. integers, floating point numbers, strings
   * `supportedExtensions`: An array of case-insensitive file extensions that are allowed for the attachment's filename (e.g. "txt", "jpg", "pdf"). Takes precedence over the document-wide `supportedExtensions` constraint for the referenced attachment. No restriction by default.
   * `supportedContentTypes`: An array of content/MIME types that are allowed for the attachment's contents (e.g. "image/png", "text/html", "application/xml"). Takes precedence over the document-wide `supportedContentTypes` constraint for the referenced attachment. No restriction by default.
   * `maximumSize`: The maximum file size, in bytes, of the attachment. May not be greater than 20MB (20,971,520 bytes), as Couchbase Server/Sync Gateway sets that as the hard limit per document or attachment. Takes precedence over the document-wide `maximumIndividualSize` constraint for the referenced attachment. Unlimited by default.
+  * `regexPattern`: A regular expression pattern that must be satisfied by the value. Takes precedence over the document-wide `attachmentConstraints.filenameRegexPattern` constraint for the referenced attachment. No restriction by default.
 
 ##### Complex type validation
 

--- a/src/testing/validation-error-formatter.js
+++ b/src/testing/validation-error-formatter.js
@@ -16,6 +16,16 @@ exports.attachmentFilenameRegexPatternViolation =
   (attachmentName, expectedRegex) => `attachment "${attachmentName}" must conform to expected pattern ${expectedRegex}`;
 
 /**
+ * Formats a message for the error that occurs when an attachment reference's value does not match the expected regular
+ * expression pattern.
+ *
+ * @param {string} itemPath The full path of the property or element in which the error occurs (e.g. "objectProp.attachmentRefProp")
+ * @param {RegExp} expectedRegex The regular expression pattern to which the value must conform
+ */
+exports.attachmentReferenceRegexPatternViolation =
+  (itemPath, expectedRegex) => `attachment reference "${itemPath}" must conform to expected pattern ${expectedRegex}`;
+
+/**
  * Formats a message for the error that occurs when there is an attempt to delete a document that cannot be deleted.
  */
 exports.cannotDeleteDocViolation = () => 'documents of this type cannot be deleted';

--- a/src/testing/validation-error-formatter.spec.js
+++ b/src/testing/validation-error-formatter.spec.js
@@ -79,6 +79,12 @@ describe('Validation error formatter', () => {
   describe('at the property/element level', () => {
     const fakeItemPath = 'my.fake[item]';
 
+    it('produces attachment reference regex pattern violation messages', () => {
+      const expectedRegex = /^[A-Za-z][A-Za-z0-9]*\.[a-z]{3}$/;
+      expect(errorFormatter.attachmentReferenceRegexPatternViolation(fakeItemPath, expectedRegex))
+        .to.equal(`attachment reference "${fakeItemPath}" must conform to expected pattern ${expectedRegex}`);
+    });
+
     it('produces invalid date format messages', () => {
       expect(errorFormatter.dateFormatInvalid(fakeItemPath))
         .to.equal(`item "${fakeItemPath}" must be an ECMAScript simplified ISO 8601 date string with no time or time zone components`);

--- a/src/validation/document-definitions-validator.spec.js
+++ b/src/validation/document-definitions-validator.spec.js
@@ -19,7 +19,7 @@ describe('Document definitions validator:', () => {
         allowUnknownProperties: 1, // Must be a boolean
         immutable: true,
         cannotDelete: true, // Must not be defined if "immutable" is also defined
-        attachmentConstraints: (a, b) => b, // "allowAttachments" must also be defined,
+        attachmentConstraints: (a, b) => b, // "allowAttachments" must also be defined
         accessAssignments: [
           { // Must include either a "roles" or "users" property
             channels: [ ] // Must not be empty
@@ -139,6 +139,10 @@ describe('Document definitions validator:', () => {
                   ],
                   mustEqual: true, // Must be an integer or string
                   mustEqualStrict: 3 // Must not be defined in conjunction with "mustEqual"
+                },
+                attachmentReferenceProperty: {
+                  type: 'attachmentReference',
+                  regexPattern: '^abc$' // Must be a RegExp object
                 },
                 hashtableProperty: {
                   type: 'hashtable',
@@ -273,6 +277,7 @@ describe('Document definitions validator:', () => {
         'myDoc1.propertyValidators.nestedObject.propertyValidators.enumProperty.mustEqualStrict: \"mustEqualStrict\" conflict with forbidden peer \"mustEqual\"',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.enumProperty.mustEqual: \"mustEqual\" must be a string',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.enumProperty.mustEqual: \"mustEqual\" must be a number',
+        'myDoc1.propertyValidators.nestedObject.propertyValidators.attachmentReferenceProperty.regexPattern: \"regexPattern\" must be an object',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.hashtableProperty.maximumSize: \"maximumSize\" must be larger than or equal to 2',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.hashtableProperty.hashtableKeysValidator.regexPattern: "regexPattern" must be an object',
         'myDoc1.propertyValidators.nestedObject.propertyValidators.hashtableProperty.hashtableValuesValidator.minimumValue: \"minimumValue\" with value \"Mon, 25 Dec 1995 13:30:00 +0430\" fails to match the required pattern: /^([+-]\\d{6}|\\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\\d|3[01]))?)?(T((([01]\\d|2[0-3])(:[0-5]\\d)(:[0-5]\\d(\\.\\d{1,3})?)?)|(24:00(:00(\\.0{1,3})?)?))(Z|([+-])([01]\\d|2[0-3]):([0-5]\\d))?)?$/',

--- a/src/validation/property-validator-schema.js
+++ b/src/validation/property-validator-schema.js
@@ -168,7 +168,8 @@ function typeSpecificConstraintSchemas() {
     attachmentReference: {
       maximumSize: dynamicConstraintSchema(integerSchema.min(1).max(20971520)),
       supportedExtensions: dynamicConstraintSchema(joi.array().min(1).items(joi.string())),
-      supportedContentTypes: dynamicConstraintSchema(joi.array().min(1).items(joi.string().min(1)))
+      supportedContentTypes: dynamicConstraintSchema(joi.array().min(1).items(joi.string().min(1))),
+      regexPattern: dynamicConstraintSchema(regexSchema)
     },
     array: {
       mustNotBeEmpty: dynamicConstraintSchema(joi.boolean()),

--- a/templates/sync-function/attachments-validation-module.js
+++ b/templates/sync-function/attachments-validation-module.js
@@ -24,6 +24,11 @@ function attachmentsValidationModule(utils, buildItemPath, resolveItemConstraint
         }
       }
 
+      var regexPattern = resolveItemConstraint(validator.regexPattern);
+      if (regexPattern && !regexPattern.test(itemValue)) {
+        validationErrors.push('attachment reference "' + buildItemPath(itemStack) + '" must conform to expected pattern ' + regexPattern);
+      }
+
       // Because the addition of an attachment is typically a separate operation from the creation/update of the associated document, we
       // can't guarantee that the attachment is present when the attachment reference property is created/updated for it, so only
       // validate it if it's present. The good news is that, because adding an attachment is a two part operation (create/update the
@@ -113,7 +118,12 @@ function attachmentsValidationModule(utils, buildItemPath, resolveItemConstraint
       }
 
       if (filenameRegexPattern && !filenameRegexPattern.test(attachmentName)) {
-        validationErrors.push('attachment "' + attachmentName + '" must conform to expected pattern ' + filenameRegexPattern);
+        // If this attachment is owned by an attachment reference property, that property's content types constraint
+        // (if any) takes precedence
+        if (utils.isValueNullOrUndefined(attachmentRefValidator) ||
+            utils.isValueNullOrUndefined(attachmentRefValidator.supportedContentTypes)) {
+          validationErrors.push('attachment "' + attachmentName + '" must conform to expected pattern ' + filenameRegexPattern);
+        }
       }
     }
 

--- a/test/attachment-constraints.spec.js
+++ b/test/attachment-constraints.spec.js
@@ -23,13 +23,13 @@ describe('File attachment constraints:', () => {
               length: 15,
               content_type: 'text/html'
             },
-            'baz.foo': {
+            'other.foo': {
               length: 5,
               content_type: 'text/bar'
             }
           },
           type: 'staticRegularAttachmentsDoc',
-          attachmentRefProp: 'baz.foo' // The attachmentReference overrides the document's supported extensions and content types
+          attachmentRefProp: 'other.foo' // The attachmentReference overrides supported extensions, content types and the regex pattern
         };
 
         testFixture.verifyDocumentCreated(doc);
@@ -111,7 +111,7 @@ describe('File attachment constraints:', () => {
       });
 
       describe('maximum attachment count constraint', () => {
-        it('should block creation of a document whose attachments exceed the limit', () => {
+        it('should block creation of a document whose number of attachments exceed the limit', () => {
           const doc = {
             _id: 'myDoc',
             _attachments: {

--- a/test/attachment-reference.spec.js
+++ b/test/attachment-reference.spec.js
@@ -14,7 +14,7 @@ describe('Attachment reference validation type', () => {
       it('allows an attachment reference with a valid file extension', () => {
         const doc = {
           _id: 'foo',
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           staticExtensionsValidationProp: 'bar.htm'
         };
 
@@ -24,13 +24,13 @@ describe('Attachment reference validation type', () => {
       it('rejects an attachment reference with an invalid file extension', () => {
         const doc = {
           _id: 'foo',
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           staticExtensionsValidationProp: 'bar.pdf'
         };
 
         testFixture.verifyDocumentNotCreated(
           doc,
-          'attachmentsDoc',
+          'attachmentReferencesDoc',
           errorFormatter.supportedExtensionsAttachmentReferenceViolation('staticExtensionsValidationProp', [ 'html', 'htm' ]));
       });
     });
@@ -39,7 +39,7 @@ describe('Attachment reference validation type', () => {
       it('allows an attachment reference with a valid file extension', () => {
         const doc = {
           _id: 'foo',
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           dynamicExtensionsValidationProp: 'bar.txt',
           dynamicSupportedExtensions: [ 'txt' ]
         };
@@ -51,14 +51,14 @@ describe('Attachment reference validation type', () => {
         const expectedSupportedExtensions = [ 'png', 'jpg', 'gif' ];
         const doc = {
           _id: 'foo',
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           dynamicExtensionsValidationProp: 'bar.ico',
           dynamicSupportedExtensions: expectedSupportedExtensions
         };
 
         testFixture.verifyDocumentNotCreated(
           doc,
-          'attachmentsDoc',
+          'attachmentReferencesDoc',
           errorFormatter.supportedExtensionsAttachmentReferenceViolation('dynamicExtensionsValidationProp', expectedSupportedExtensions));
       });
     });
@@ -72,7 +72,7 @@ describe('Attachment reference validation type', () => {
           _attachments: {
             'foo.bar': { content_type: 'text/plain' }
           },
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           staticContentTypesValidationProp: 'foo.bar'
         };
 
@@ -85,13 +85,13 @@ describe('Attachment reference validation type', () => {
           _attachments: {
             'foo.bar': { content_type: 'application/pdf' }
           },
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           staticContentTypesValidationProp: 'foo.bar'
         };
 
         testFixture.verifyDocumentNotCreated(
           doc,
-          'attachmentsDoc',
+          'attachmentReferencesDoc',
           errorFormatter.supportedContentTypesAttachmentReferenceViolation('staticContentTypesValidationProp', [ 'text/plain', 'text/html' ]));
       });
     });
@@ -103,7 +103,7 @@ describe('Attachment reference validation type', () => {
           _attachments: {
             'foo.bar': { content_type: 'text/plain' }
           },
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           dynamicContentTypesValidationProp: 'foo.bar',
           dynamicSupportedContentTypes: [ 'text/plain' ]
         };
@@ -118,14 +118,14 @@ describe('Attachment reference validation type', () => {
           _attachments: {
             'foo.bar': { content_type: 'application/pdf' }
           },
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           dynamicContentTypesValidationProp: 'foo.bar',
           dynamicSupportedContentTypes: expectedSupportedContentTypes
         };
 
         testFixture.verifyDocumentNotCreated(
           doc,
-          'attachmentsDoc',
+          'attachmentReferencesDoc',
           errorFormatter.supportedContentTypesAttachmentReferenceViolation('dynamicContentTypesValidationProp', expectedSupportedContentTypes));
       });
     });
@@ -139,7 +139,7 @@ describe('Attachment reference validation type', () => {
           _attachments: {
             'foo.bar': { length: 200 }
           },
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           staticMaxSizeValidationProp: 'foo.bar'
         };
 
@@ -152,13 +152,13 @@ describe('Attachment reference validation type', () => {
           _attachments: {
             'foo.bar': { length: 201 }
           },
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           staticMaxSizeValidationProp: 'foo.bar'
         };
 
         testFixture.verifyDocumentNotCreated(
           doc,
-          'attachmentsDoc',
+          'attachmentReferencesDoc',
           errorFormatter.maximumSizeAttachmentViolation('staticMaxSizeValidationProp', 200));
       });
     });
@@ -170,7 +170,7 @@ describe('Attachment reference validation type', () => {
           _attachments: {
             'foo.bar': { length: 150 }
           },
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           dynamicMaxSizeValidationProp: 'foo.bar',
           dynamicMaxSize: 150
         };
@@ -184,15 +184,71 @@ describe('Attachment reference validation type', () => {
           _attachments: {
             'foo.bar': { length: 151 }
           },
-          type: 'attachmentsDoc',
+          type: 'attachmentReferencesDoc',
           dynamicMaxSizeValidationProp: 'foo.bar',
           dynamicMaxSize: 150
         };
 
         testFixture.verifyDocumentNotCreated(
           doc,
-          'attachmentsDoc',
+          'attachmentReferencesDoc',
           errorFormatter.maximumSizeAttachmentViolation('dynamicMaxSizeValidationProp', 150));
+      });
+    });
+  });
+
+  describe('regular expression pattern constraint', () => {
+    describe('with static validation', () => {
+      it('allows an attachment whose name matches the pattern', () => {
+        const doc = {
+          _id: 'my-doc',
+          type: 'attachmentReferencesDoc',
+          staticRegexPatternValidationProp: 'a03.hc'
+        };
+
+        testFixture.verifyDocumentCreated(doc);
+      });
+
+      it('allows an attachment whose name violates the pattern', () => {
+        const doc = {
+          _id: 'my-doc',
+          type: 'attachmentReferencesDoc',
+          staticRegexPatternValidationProp: '123ABC'
+        };
+
+        testFixture.verifyDocumentNotCreated(
+          doc,
+          'attachmentReferencesDoc',
+          errorFormatter.attachmentReferenceRegexPatternViolation('staticRegexPatternValidationProp', /^[a-z][a-z0-9]*\.[a-z]+$/));
+      });
+    });
+
+    describe('with dynamic validation', () => {
+      const expectedRegexString = '^\\d+\\.[a-z]+$';
+
+      it('allows an attachment whose name matches the pattern', () => {
+        const doc = {
+          _id: 'my-doc',
+          type: 'attachmentReferencesDoc',
+          dynamicRegexPattern: expectedRegexString,
+          dynamicRegexPatternValidationProp: '66134.txt'
+        };
+
+        testFixture.verifyDocumentCreated(doc);
+      });
+
+      it('allows an attachment whose name violates the pattern', () => {
+        const doc = {
+          _id: 'my-doc',
+          type: 'attachmentReferencesDoc',
+          dynamicRegexPattern: expectedRegexString,
+          dynamicRegexPatternValidationProp: 'd.foo'
+        };
+
+        testFixture.verifyDocumentNotCreated(
+          doc,
+          'attachmentReferencesDoc',
+          errorFormatter.attachmentReferenceRegexPatternViolation('dynamicRegexPatternValidationProp', new RegExp(expectedRegexString)));
       });
     });
   });

--- a/test/attachment-reference.spec.js
+++ b/test/attachment-reference.spec.js
@@ -209,7 +209,7 @@ describe('Attachment reference validation type', () => {
         testFixture.verifyDocumentCreated(doc);
       });
 
-      it('allows an attachment whose name violates the pattern', () => {
+      it('rejects an attachment whose name violates the pattern', () => {
         const doc = {
           _id: 'my-doc',
           type: 'attachmentReferencesDoc',
@@ -237,7 +237,7 @@ describe('Attachment reference validation type', () => {
         testFixture.verifyDocumentCreated(doc);
       });
 
-      it('allows an attachment whose name violates the pattern', () => {
+      it('rejects an attachment whose name violates the pattern', () => {
         const doc = {
           _id: 'my-doc',
           type: 'attachmentReferencesDoc',

--- a/test/resources/attachment-constraints-doc-definitions.js
+++ b/test/resources/attachment-constraints-doc-definitions.js
@@ -8,14 +8,16 @@
       maximumTotalSize: 40,
       maximumAttachmentCount: 3,
       supportedExtensions: [ 'html', 'jpg', 'pdf', 'txt', 'xml' ],
-      supportedContentTypes: [ 'text/html', 'image/jpeg', 'application/pdf', 'text/plain', 'application/xml' ]
+      supportedContentTypes: [ 'text/html', 'image/jpeg', 'application/pdf', 'text/plain', 'application/xml' ],
+      filenameRegexPattern: /^(foo|ba[rz]|qux)\.[a-z]+$/
     },
     propertyValidators: {
       attachmentRefProp: {
         type: 'attachmentReference',
         maximumSize: 40,
         supportedExtensions: [ 'foo', 'html', 'jpg', 'pdf', 'txt', 'xml' ],
-        supportedContentTypes: [ 'text/bar', 'text/html', 'image/jpeg', 'application/pdf', 'text/plain', 'application/xml' ]
+        supportedContentTypes: [ 'text/bar', 'text/html', 'image/jpeg', 'application/pdf', 'text/plain', 'application/xml' ],
+        regexPattern: /^[a-z]+\.[a-z]+$/
       }
     }
   },

--- a/test/resources/attachment-reference-doc-definitions.js
+++ b/test/resources/attachment-reference-doc-definitions.js
@@ -1,5 +1,5 @@
 {
-  attachmentsDoc: {
+  attachmentReferencesDoc: {
     typeFilter: simpleTypeFilter,
     channels: { write: 'write' },
     allowAttachments: true,
@@ -41,6 +41,19 @@
         type: 'attachmentReference',
         maximumSize: function(doc, oldDoc, value, oldValue) {
           return doc.dynamicMaxSize;
+        }
+      },
+      staticRegexPatternValidationProp: {
+        type: 'attachmentReference',
+        regexPattern: /^[a-z][a-z0-9]*\.[a-z]+$/
+      },
+      dynamicRegexPattern: {
+        type: 'string'
+      },
+      dynamicRegexPatternValidationProp: {
+        type: 'attachmentReference',
+        regexPattern: function(doc, oldDoc, value, oldValue) {
+          return doc.dynamicRegexPattern ? new RegExp(doc.dynamicRegexPattern) : null;
         }
       }
     }


### PR DESCRIPTION
# Description

When included in a document definition, the `attachmentReference` validation type's `regexPattern` constraint verifies that the value conforms to the specified regular expression pattern. It overrides the value of the document-wide `attachmentConstraints.filenameRegexPattern` constraint for that attachment reference.

# Testing

First, verify that the constraint works on its own (i.e. without being forced to interact with `attachmentConstraints.filenameRegexPattern`):

1. Generate a sync function from `attachment-reference-doc-definitions.js`:

```bash
./make-sync-function -j test/resources/attachment-reference-doc-definitions.js build/test-sync-function.txt
```

2. Copy and paste the sync function into a Sync Gateway configuration file.
3. Attempt to create a test document with an attachment reference that violates the regex pattern (it should be rejected with 403 Forbidden):

```
PUT /test/attachment-ref-test-1 HTTP/1.1
Host: localhost:4985
Content-Type: application/json

{
    "type": "attachmentReferencesDoc",
    "staticRegexPatternValidationProp": "12345.pdf"
}
```

4. Create a test document with an attachment reference that satisfies the regex pattern (it should succeed with 201 Created):

```
PUT /test/attachment-ref-test-1 HTTP/1.1
Host: localhost:4985
Content-Type: application/json

{
    "type": "attachmentReferencesDoc",
    "staticRegexPatternValidationProp": "abc.txt"
}
```

Now, verify that the constraint correctly takes precedence over the document-wide `attachmentConstraints.filenameRegexPattern` constraint:

1. Generate a sync function from `attachment-constraints-doc-definitions.js`:

```bash
./make-sync-function -j test/resources/attachment-constraints-doc-definitions.js build/test-sync-function.txt
```

2. Copy and paste the sync function into a Sync Gateway configuration file.
3. Create a document:

```
PUT /test/attachment-test-1 HTTP/1.1
Host: localhost:4985
Content-Type: application/json

{
    "type": "staticRegularAttachmentsDoc",
    "attachmentRefProp": "abcdef.foo"
}
```

4. Attempt to add an attachment that violates the `attachmentConstraints.filenameRegexPattern` constraint and isn't referenced by the `attachmentReference` property (should be rejected with 403 Forbidden):

```
PUT /test/attachment-test-1/123.txt?rev=1-bd0bfae78d5526672643b053b76f55be HTTP/1.1
Host: localhost:4985
Content-Type: text/plain

The file name doesn't match attachmentConstraints.filenameRegexPattern: /^(foo|ba[rz]|qux)\.[a-z]+$/
```

5. Add an attachment that violates the `attachmentConstraints.filenameRegexPattern` constraint but is allowed anyway because it is referenced by the `attachmentReference` property which defines a more permissive `regexPattern` constraint (should be allowed with 201 Created):

```
PUT /test/attachment-test-1/abcdef.foo?rev=1-bd0bfae78d5526672643b053b76f55be HTTP/1.1
Host: localhost:4985
Content-Type: text/plain

Matches!
```

# Related Issue

* GitHub issue link: #316