### PR TITLE
Issue 315: Restore the Unreleased section to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased]
+Nothing yet.
+
 ## [2.5.0] - 2018-05-30
 ### Added
 - [#311](https://github.com/Kashoo/synctos/issues/311): Case insensitive equality constraint for strings


### PR DESCRIPTION
# Description

Now that v2.5.0 has been released, the changelog's "Unreleased" section has been restored.

# Related Issue

* GitHub issue link: #315